### PR TITLE
Missing module in Ai4r::Classifiers::NaiveBayes#build method

### DIFF
--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -102,7 +102,7 @@ module Ai4r
       # and the conditional probabilities
       # Parameter data has to be an instance of CsvDataSet
       def build(data)
-        raise "Error instance must be passed" unless data.is_a?(DataSet)
+        raise "Error instance must be passed" unless data.is_a?(Ai4r::Data::DataSet)
         raise "Data should not be empty" if data.data_items.length == 0
 
         initialize_domain_data(data)


### PR DESCRIPTION
```
NameError: uninitialized constant Ai4r::Classifiers::NaiveBayes::DataSet
    from /usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ai4r-1.12/lib/ai4r/classifiers/naive_bayes.rb:105:in `build'
```

There is little typo in `Ai4r::Classifiers::NaiveBayes#build` method causing NameError.
PR attached.
