### PR TITLE
Fixes tests for hyperpipes and Multilayer Perceptron - Issue #7

### DIFF
--- a/lib/ai4r/classifiers/multilayer_perceptron.rb
+++ b/lib/ai4r/classifiers/multilayer_perceptron.rb
@@ -33,12 +33,14 @@ module Ai4r
     # * :hidden_layers => Hidden layer structure. E.g. [8, 6] will generate 
     #   2 hidden layers with 8 and 6 neurons each. By default []
     # * :training_iterations => How many times the training should be repeated. 
-    #   By default: 1000. 
+    #   By default: 500. 
     # :active_node_value => Default: 1        
     # :inactive_node_value => Default: 1
     class MultilayerPerceptron < Classifier
 
       attr_reader :data_set, :class_value, :network, :domains
+
+      TRAINING_ITERATIONS = 500
       
       parameters_info :network_class => "Neural network implementation class."+
           "By default: Ai4r::NeuralNetwork::Backpropagation.",
@@ -47,14 +49,14 @@ module Ai4r
         :hidden_layers => "Hidden layer structure. E.g. [8, 6] will generate " +
           "2 hidden layers with 8 and 6 neurons each. By default []",
         :training_iterations => "How many times the training should be " +
-          "repeated. By default: 500",
+          "repeated. By default: #{TRAINING_ITERATIONS}",
         :active_node_value => "Default: 1",
         :inactive_node_value => "Default: 0"
     
       def initialize
         @network_class = Ai4r::NeuralNetwork::Backpropagation
         @hidden_layers = []
-        @training_iterations = 500
+        @training_iterations = TRAINING_ITERATIONS
         @network_parameters = {}
         @active_node_value = 1
         @inactive_node_value = 0
@@ -106,7 +108,7 @@ module Ai4r
           att_value = data_item[att_index]
           domain_index = @domains[att_index].index(att_value)
           input_values[domain_index + accum_index] = @active_node_value
-          accum_index = @domains[att_index].length
+          accum_index += @domains[att_index].length
         end
         return input_values
       end

--- a/lib/ai4r/classifiers/votes.rb
+++ b/lib/ai4r/classifiers/votes.rb
@@ -1,0 +1,38 @@
+# Author::    Will Warner
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       http://ai4r.org/
+#
+# You can redistribute it and/or modify it under the terms of 
+# the Mozilla Public License version 1.1  as published by the 
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+module Ai4r
+  module Classifiers
+    class Votes
+
+      def initialize
+        self.tally_sheet = Hash.new(0)
+      end
+
+      def increment_category(category)
+        tally_sheet[category] += 1
+      end
+
+      def tally_for(category)
+        tally_sheet[category]
+      end
+
+      def get_winner
+        n = 0 # used to create a stable sort of the tallys
+        sorted_sheet = tally_sheet.sort_by { |_, score| n += 1; [score, n] }
+        sorted_sheet.last.first
+      end
+
+      private
+
+      attr_accessor :tally_sheet
+    end
+  end
+end
+

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -47,10 +47,6 @@ class HyperpipesTest < Test::Unit::TestCase
     assert_equal [{}, {:max=>-1.0/0, :min=>1.0/0}, {}], classifier.build_pipe(@data_set)
   end
   
-  def test_get_rules
-    
-  end
-  
   def test_build
     assert_raise(ArgumentError) { Hyperpipes.new.build(DataSet.new) }
     classifier = Hyperpipes.new.build(@data_set)

--- a/test/classifiers/multilayer_perceptron_test.rb
+++ b/test/classifiers/multilayer_perceptron_test.rb
@@ -14,13 +14,14 @@ class MultilayerPerceptronTest < Test::Unit::TestCase
   include Ai4r::Classifiers
   include Ai4r::Data
   
-  @@data_set = DataSet.new(:data_items =>[   ['New York',  '<30',      'M', 'Y'],
-                ['Chicago',     '<30',      'M', 'Y'],
-                ['New York',  '<30',      'M', 'Y'],
-                ['New York',  '[30-50)',  'F', 'N'],
-                ['Chicago',     '[30-50)',  'F', 'Y'],
-                ['New York',  '[30-50)',  'F', 'N'],
-                ['Chicago',     '[50-80]', 'M', 'N'],
+  @@data_set = DataSet.new(:data_items =>[   
+                ['New York',  '<30',     'M', 'Y'],
+                ['Chicago',   '<30',     'M', 'Y'],
+                ['New York',  '<30',     'M', 'Y'],
+                ['New York',  '[30-50)', 'F', 'N'],
+                ['Chicago',   '[30-50)', 'F', 'Y'],
+                ['New York',  '[30-50)', 'F', 'N'],
+                ['Chicago',   '[50-80]', 'M', 'N'],
               ])
 
   def test_initialize

--- a/test/classifiers/votes_test.rb
+++ b/test/classifiers/votes_test.rb
@@ -1,0 +1,42 @@
+# Author::    Will Warner
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       http://www.ai4r.org/
+#
+# You can redistribute it and/or modify it under the terms of 
+# the Mozilla Public License version 1.1  as published by the 
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+require 'ai4r/classifiers/votes'
+require 'test/unit'
+
+class VotesTest < Test::Unit::TestCase
+  def setup
+    @votes = Votes.new
+  end
+
+  def test_without_category
+    assert_equal(0, @votes.tally_for("Y"))
+  end
+
+  def test_increment
+    @votes.increment_category("Y")
+    assert_equal(1, @votes.tally_for("Y"))
+  end
+
+  def test_get_winner
+    @votes.increment_category("Y")
+    @votes.increment_category("Y")
+    @votes.increment_category("N")
+    assert_equal("Y", @votes.get_winner)
+  end
+
+  def test_get_winner_with_tie
+    @votes.increment_category("N")
+    @votes.increment_category("Y")
+    @votes.increment_category("X")
+    @votes.increment_category("Y")
+    @votes.increment_category("N")
+    assert_equal("Y", @votes.get_winner)
+  end
+end


### PR DESCRIPTION
Problem with Hyperpipes was that in case of a tie, the last value in the sequence should win.
See http://www.csee.wvu.edu/~timm/tmp/r7.pdf for a description. This involved creating a new
Votes class (and accompanying tests) to tally votes and return the winner.

The multilayer perceptron had a bug where the value of the index accumulator in
data_to_input was being reassigned rather than incremented with the length of the
current domain.
