### PR TITLE
Hierarchical Agglomerative Clustering based on distance

### DIFF
--- a/lib/ai4r/clusterers/average_linkage.rb
+++ b/lib/ai4r/clusterers/average_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -12,48 +12,48 @@ require File.dirname(__FILE__) + '/../clusterers/single_linkage'
 
 module Ai4r
   module Clusterers
-     
+
     # Implementation of a Hierarchical clusterer with group average
-    # linkage, AKA unweighted pair group method average or UPGMA (Everitt 
+    # linkage, AKA unweighted pair group method average or UPGMA (Everitt
     # et al., 2001 ; Jain and Dubes, 1988 ; Sokal and Michener, 1958).
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # With average linkage, the distance between a clusters cx and 
+    # With average linkage, the distance between a clusters cx and
     # cluster (ci U cj) the the average distance between cx and ci, and
     # cx and cj.
     #
     #   D(cx, (ci U cj) = (D(cx, ci) + D(cx, cj)) / 2
     class AverageLinkage < SingleLinkage
-      
-      parameters_info :distance_function => 
+
+      parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         super
       end
-      
-      # This algorithms does not allow classification of new data items 
+
+      # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
       def eval(data_item)
         Raise "Eval of new data is not supported by this algorithm."
       end
-      
+
       protected
-      
+
       # return distance between cluster cx and cluster (ci U cj),
       # using average linkage
       def linkage_distance(cx, ci, cj)
         (read_distance_matrix(cx, ci)+
           read_distance_matrix(cx, cj))/2
       end
-      
+
     end
   end
 end

--- a/lib/ai4r/clusterers/centroid_linkage.rb
+++ b/lib/ai4r/clusterers/centroid_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -12,44 +12,44 @@ require File.dirname(__FILE__) + '/../clusterers/single_linkage'
 
 module Ai4r
   module Clusterers
-     
-    # Implementation of an Agglomerative Hierarchical clusterer with 
-    # centroid linkage algorithm, aka unweighted pair group method 
+
+    # Implementation of an Agglomerative Hierarchical clusterer with
+    # centroid linkage algorithm, aka unweighted pair group method
     # centroid (UPGMC) (Everitt et al., 2001 ; Jain and Dubes, 1988 ;
     # Sokal and Michener, 1958 )
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # The distance between clusters is the squared euclidean distance 
-    # between their centroids. 
-    # 
+    # The distance between clusters is the squared euclidean distance
+    # between their centroids.
+    #
     #   D(cx, (ci U cj)) = | mx - mij |^2
-    #   D(cx, (ci U cj)) =  (ni/(ni+nj))*D(cx, ci) + 
-    #                       (nj/(ni+nj))*D(cx, cj) - 
+    #   D(cx, (ci U cj)) =  (ni/(ni+nj))*D(cx, ci) +
+    #                       (nj/(ni+nj))*D(cx, cj) -
     #                       (ni*nj/(ni+nj)^2)*D(ci, cj)
     class CentroidLinkage < SingleLinkage
-      
-    parameters_info :distance_function => 
+
+    parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         super
       end
-      
-      # This algorithms does not allow classification of new data items 
+
+      # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
       def eval(data_item)
         Raise "Eval of new data is not supported by this algorithm."
       end
-      
+
       protected
-       
+
       # return distance between cluster cx and cluster (ci U cj),
       # using centroid linkage
       def linkage_distance(cx, ci, cj)
@@ -59,8 +59,7 @@ module Ai4r
           nj * read_distance_matrix(cx, cj) -
          1.0 * ni * nj * read_distance_matrix(ci, cj) / (ni+nj)) / (ni+nj)
       end
-      
+
     end
   end
 end
-

--- a/lib/ai4r/clusterers/complete_linkage.rb
+++ b/lib/ai4r/clusterers/complete_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -12,47 +12,47 @@ require File.dirname(__FILE__) + '/../clusterers/single_linkage'
 
 module Ai4r
   module Clusterers
-     
-    # Implementation of a Hierarchical clusterer with complete linkage (Everitt 
+
+    # Implementation of a Hierarchical clusterer with complete linkage (Everitt
     # et al., 2001 ; Jain and Dubes, 1988 ; Sorensen, 1948 ).
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # With complete linkage, the distance between two clusters is computed as 
+    # With complete linkage, the distance between two clusters is computed as
     # the maximum distance between elements of each cluster.
     #
     #   D(cx, (ci U cj) = max(D(cx, ci), D(cx, cj))
     class CompleteLinkage < SingleLinkage
-      
-      parameters_info :distance_function => 
+
+      parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
-      
+
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         super
       end
-      
-      # Classifies the given data item, returning the cluster index it belongs 
+
+      # Classifies the given data item, returning the cluster index it belongs
       # to (0-based).
       def eval(data_item)
         super
       end
-      
+
       protected
-      
+
       # return distance between cluster cx and new cluster (ci U cj),
       # using complete linkage
       def linkage_distance(cx, ci, cj)
         [read_distance_matrix(cx, ci),
           read_distance_matrix(cx, cj)].max
       end
-      
+
       def distance_between_item_and_cluster(data_item, cluster)
         max_dist = 0
         cluster.data_items.each do |another_item|
@@ -61,7 +61,7 @@ module Ai4r
         end
         return max_dist
       end
-      
+
     end
   end
 end

--- a/lib/ai4r/clusterers/median_linkage.rb
+++ b/lib/ai4r/clusterers/median_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://www.ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -12,41 +12,41 @@ require File.dirname(__FILE__) + '/../clusterers/single_linkage'
 
 module Ai4r
   module Clusterers
-     
-    # Implementation of an Agglomerative Hierarchical clusterer with 
-    # median linkage algorithm, aka weighted pair group method centroid 
+
+    # Implementation of an Agglomerative Hierarchical clusterer with
+    # median linkage algorithm, aka weighted pair group method centroid
     # or WPGMC (Everitt et al., 2001 ; Gower, 1967 ; Jain and Dubes, 1988 ).
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # Similar to centroid linkages, but using fix weight: 
-    # 
-    #   D(cx, (ci U cj)) =  (1/2)*D(cx, ci) + 
-    #                       (1/2)*D(cx, cj) - 
+    # Similar to centroid linkages, but using fix weight:
+    #
+    #   D(cx, (ci U cj)) =  (1/2)*D(cx, ci) +
+    #                       (1/2)*D(cx, cj) -
     #                       (1/4)*D(ci, cj)
     class MedianLinkage < SingleLinkage
-      
-    parameters_info :distance_function => 
+
+    parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         super
       end
-      
-      # This algorithms does not allow classification of new data items 
+
+      # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
       def eval(data_item)
         Raise "Eval of new data is not supported by this algorithm."
       end
-      
+
       protected
-       
+
       # return distance between cluster cx and cluster (ci U cj),
       # using median linkage
       def linkage_distance(cx, ci, cj)
@@ -54,8 +54,7 @@ module Ai4r
           0.5  * read_distance_matrix(cx, cj) -
           0.25 * read_distance_matrix(ci, cj))
       end
-      
+
     end
   end
 end
-

--- a/lib/ai4r/clusterers/single_linkage.rb
+++ b/lib/ai4r/clusterers/single_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -13,62 +13,78 @@ require File.dirname(__FILE__) + '/../clusterers/clusterer'
 
 module Ai4r
   module Clusterers
-     
-    # Implementation of a Hierarchical clusterer with single linkage (Everitt et 
+
+    # Implementation of a Hierarchical clusterer with single linkage (Everitt et
     # al., 2001 ; Johnson, 1967 ; Jain and Dubes, 1988 ; Sneath, 1957 )
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # With single linkage, the distance between two clusters is computed as the 
+    # With single linkage, the distance between two clusters is computed as the
     # distance between the two closest elements in the two clusters.
     #
     #   D(cx, (ci U cj) = min(D(cx, ci), D(cx, cj))
     class SingleLinkage < Clusterer
-      
+
       attr_reader :data_set, :number_of_clusters, :clusters
-      
-      parameters_info :distance_function => 
+
+      parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
+
       def initialize
-        @distance_function = lambda do |a,b| 
+        @distance_function = lambda do |a,b|
             Ai4r::Data::Proximity.squared_euclidean_distance(
-              a.select {|att_a| att_a.is_a? Numeric} , 
+              a.select {|att_a| att_a.is_a? Numeric},
               b.select {|att_b| att_b.is_a? Numeric})
           end
       end
-      
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      #
+      # If you specify :distance options, it will stop whether
+      # number_of_clusters are reached or no distance among clusters are below :distance
+      def build(data_set, number_of_clusters = 1, **options)
         @data_set = data_set
-        @number_of_clusters = number_of_clusters
-        
+        distance = options[:distance] || (1.0/0)
+
         @index_clusters = create_initial_index_clusters
         create_distance_matrix(data_set)
-        while @index_clusters.length > @number_of_clusters
+        while @index_clusters.length > number_of_clusters
           ci, cj = get_closest_clusters(@index_clusters)
+          break if read_distance_matrix(ci, cj) > distance
           update_distance_matrix(ci, cj)
           merge_clusters(ci, cj, @index_clusters)
         end
+
+        @number_of_clusters = @index_clusters.length
+        @distance_matrix = nil
         @clusters = build_clusters_from_index_clusters @index_clusters
-        
         return self
       end
-      
-      # Classifies the given data item, returning the cluster index it belongs 
+
+      def draw_map(clusters)
+        map = Array.new(11) {Array.new(11, 0)}
+        clusters.each_index do |i|
+          clusters[i].data_items.each do |point|
+            map[point.first][point.last]=(i+1)
+          end
+        end
+        map.each { |row| puts row.inspect}
+      end
+
+      # Classifies the given data item, returning the cluster index it belongs
       # to (0-based).
       def eval(data_item)
-        get_min_index(@clusters.collect {|cluster| 
+        get_min_index(@clusters.collect {|cluster|
             distance_between_item_and_cluster(data_item, cluster)})
       end
-      
+
       protected
-      
+
       # returns [ [0], [1], [2], ... , [n-1] ]
       # where n is the number of data items in the data set
       def create_initial_index_clusters
@@ -76,18 +92,18 @@ module Ai4r
         @data_set.data_items.length.times {|i| index_clusters << [i]}
         return index_clusters
       end
-      
+
       # Create a partial distance matrix:
-      #   [ 
-      #     [d(1,0)], 
-      #     [d(2,0)], [d(2,1)],
-      #     [d(3,0)], [d(3,1)], [d(3,2)],
-      #     ... 
-      #     [d(n-1,0)], [d(n-1,1)], [d(n-1,2)], ... , [d(n-1,n-2)]
+      #   [
+      #     [d(1,0)],
+      #     [d(2,0), d(2,1)],
+      #     [d(3,0), d(3,1), d(3,2)],
+      #     ...
+      #     [d(n-1,0), d(n-1,1), d(n-1,2), ... , d(n-1,n-2)]
       #   ]
       # where n is the number of data items in the data set
       def create_distance_matrix(data_set)
-        @distance_matrix = Array.new(data_set.data_items.length-1) {|index| Array.new(index+1)}      
+        @distance_matrix = Array.new(data_set.data_items.length-1) {|index| Array.new(index+1)}
         data_set.data_items.each_with_index do |a, i|
           i.times do |j|
             b = data_set.data_items[j]
@@ -95,7 +111,7 @@ module Ai4r
           end
         end
       end
-      
+
       # Returns the distance between element data_item[index_a] and
       # data_item[index_b] using the distance matrix
       def read_distance_matrix(index_a, index_b)
@@ -105,43 +121,43 @@ module Ai4r
       end
 
       # ci and cj are the indexes of the clusters that are going to
-      # be merged. We need to remove distances from/to ci and cj, 
+      # be merged. We need to remove distances from/to ci and cj,
       # and add distances from/to new cluster (ci U cj)
       def update_distance_matrix(ci, cj)
         ci, cj = cj, ci if cj > ci
         distances_to_new_cluster = Array.new
         (@distance_matrix.length+1).times do |cx|
           if cx!= ci && cx!=cj
-            distances_to_new_cluster << linkage_distance(cx, ci, cj) 
+            distances_to_new_cluster << linkage_distance(cx, ci, cj)
           end
         end
         if cj==0 && ci==1
-          @distance_matrix.delete_at(1) 
-          @distance_matrix.delete_at(0)         
+          @distance_matrix.delete_at(1)
+          @distance_matrix.delete_at(0)
         elsif cj==0
-          @distance_matrix.delete_at(ci-1) 
-          @distance_matrix.delete_at(0) 
+          @distance_matrix.delete_at(ci-1)
+          @distance_matrix.delete_at(0)
         else
-          @distance_matrix.delete_at(ci-1) 
+          @distance_matrix.delete_at(ci-1)
           @distance_matrix.delete_at(cj-1)
         end
-        @distance_matrix.each do |d| 
+        @distance_matrix.each do |d|
           d.delete_at(ci)
           d.delete_at(cj)
         end
         @distance_matrix << distances_to_new_cluster
       end
-      
+
       # return distance between cluster cx and new cluster (ci U cj),
       # using single linkage
       def linkage_distance(cx, ci, cj)
         [read_distance_matrix(cx, ci),
           read_distance_matrix(cx, cj)].min
       end
-      
-      # cluster_a and cluster_b are removed from index_cluster, 
+
+      # cluster_a and cluster_b are removed from index_cluster,
       # and a new cluster with all members of cluster_a and cluster_b
-      # is added. 
+      # is added.
       # It modifies index clusters array.
       def merge_clusters(index_a, index_b, index_clusters)
         index_a, index_b = index_b, index_a if index_b > index_a
@@ -152,17 +168,16 @@ module Ai4r
         index_clusters << new_index_cluster
         return index_clusters
       end
-   
-      # Given an array with clusters of data_items indexes, 
-      # it returns an array of data_items clusters 
+
+      # Given an array with clusters of data_items indexes,
+      # it returns an array of data_items clusters
       def build_clusters_from_index_clusters(index_clusters)
-        @distance_matrix = nil
         return index_clusters.collect do |index_cluster|
           Ai4r::Data::DataSet.new(:data_labels => @data_set.data_labels,
             :data_items => index_cluster.collect {|i| @data_set.data_items[i]})
         end
       end
-      
+
       # Returns ans array with the indexes of the two closest
       # clusters => [index_cluster_a, index_cluster_b]
       def get_closest_clusters(index_clusters)
@@ -179,7 +194,7 @@ module Ai4r
         end
         return closest_clusters
       end
-      
+
       def distance_between_item_and_cluster(data_item, cluster)
         min_dist = 1.0/0
         cluster.data_items.each do |another_item|
@@ -188,7 +203,7 @@ module Ai4r
         end
         return min_dist
       end
-      
+
     end
   end
 end

--- a/lib/ai4r/clusterers/ward_linkage.rb
+++ b/lib/ai4r/clusterers/ward_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://www.ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -12,41 +12,41 @@ require File.dirname(__FILE__) + '/../clusterers/single_linkage'
 
 module Ai4r
   module Clusterers
-     
-    # Implementation of an Agglomerative Hierarchical clusterer with 
+
+    # Implementation of an Agglomerative Hierarchical clusterer with
     # Ward's method linkage algorithm, aka the minimum variance method (Everitt
     # et al., 2001 ; Jain and Dubes, 1988 ; Ward, 1963 ).
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # The objective of this method is to minimize the variance. 
-    # 
-    #   D(cx, (ci U cj)) =  (ni/(ni+nj+nx))*D(cx, ci) + 
-    #                       (nj/(ni+nj+nx))*D(cx, cj) - 
+    # The objective of this method is to minimize the variance.
+    #
+    #   D(cx, (ci U cj)) =  (ni/(ni+nj+nx))*D(cx, ci) +
+    #                       (nj/(ni+nj+nx))*D(cx, cj) -
     #                       (nx/(ni+nj)^2)*D(ci, cj)
     class WardLinkage < SingleLinkage
-      
-    parameters_info :distance_function => 
+
+    parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         super
       end
-      
-      # This algorithms does not allow classification of new data items 
+
+      # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
       def eval(data_item)
         Raise "Eval of new data is not supported by this algorithm."
       end
-      
+
       protected
-       
+
       # return distance between cluster cx and cluster (ci U cj),
       # using ward's method linkage
       def linkage_distance(cx, ci, cj)
@@ -55,10 +55,9 @@ module Ai4r
         nx = @index_clusters[cx].length
         ( ( ( 1.0* (ni+nx) * read_distance_matrix(cx, ci) ) +
             ( 1.0* (nj+nx) * read_distance_matrix(cx, cj) ) ) / (ni + nj + nx)  -
-            ( 1.0 * nx * read_distance_matrix(ci, cj) / (ni+nj)**2 ) ) 
+            ( 1.0 * nx * read_distance_matrix(ci, cj) / (ni+nj)**2 ) )
       end
-      
+
     end
   end
 end
-

--- a/lib/ai4r/clusterers/ward_linkage_hierarchical.rb
+++ b/lib/ai4r/clusterers/ward_linkage_hierarchical.rb
@@ -12,7 +12,7 @@ module Ai4r
     class WardLinkageHierarchical < WardLinkage
 
       attr_reader :cluster_tree
-     
+
       def initialize(depth = nil)
         @cluster_tree = []
         @depth = depth
@@ -20,7 +20,7 @@ module Ai4r
         super()
       end
 
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         data_len = data_set.data_items.length
         @total_merges = data_len - number_of_clusters
         super
@@ -45,4 +45,3 @@ module Ai4r
     end
   end
 end
-

--- a/lib/ai4r/clusterers/weighted_average_linkage.rb
+++ b/lib/ai4r/clusterers/weighted_average_linkage.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://www.ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require File.dirname(__FILE__) + '/../data/data_set'
@@ -12,40 +12,40 @@ require File.dirname(__FILE__) + '/../clusterers/single_linkage'
 
 module Ai4r
   module Clusterers
-     
-    # Implementation of an Agglomerative Hierarchical clusterer with 
-    # weighted average linkage algorithm, aka weighted pair group method 
+
+    # Implementation of an Agglomerative Hierarchical clusterer with
+    # weighted average linkage algorithm, aka weighted pair group method
     # average or WPGMA (Jain and Dubes, 1988 ; McQuitty, 1966 )
-    # Hierarchical clusterer create one cluster per element, and then 
+    # Hierarchical clusterer create one cluster per element, and then
     # progressively merge clusters, until the required number of clusters
     # is reached.
-    # Similar to AverageLinkage, but the distances between clusters are 
+    # Similar to AverageLinkage, but the distances between clusters are
     # weighted based on the number of data items in each of them.
-    #   
+    #
     #   D(cx, (ci U cj)) =  ( ni * D(cx, ci) + nj * D(cx, cj)) / (ni + nj)
     class WeightedAverageLinkage < SingleLinkage
-      
-    parameters_info :distance_function => 
+
+    parameters_info :distance_function =>
           "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2."
-      
+
       # Build a new clusterer, using data examples found in data_set.
       # Items will be clustered in "number_of_clusters" different
       # clusters.
-      def build(data_set, number_of_clusters)
+      def build(data_set, number_of_clusters = 1, **options)
         super
       end
-      
-      # This algorithms does not allow classification of new data items 
+
+      # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
       def eval(data_item)
         Raise "Eval of new data is not supported by this algorithm."
       end
-      
+
       protected
-      
+
       # return distance between cluster cx and cluster (ci U cj),
       # using weighted average linkage
       def linkage_distance(cx, ci, cj)
@@ -54,8 +54,7 @@ module Ai4r
         (1.0 * ni * read_distance_matrix(cx, ci)+
           nj * read_distance_matrix(cx, cj))/(ni+nj)
       end
-      
+
     end
   end
 end
-

--- a/lib/ai4r/data/statistics.rb
+++ b/lib/ai4r/data/statistics.rb
@@ -3,19 +3,17 @@
 # Project::   ai4r
 # Url::       http://www.ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
-
-require File.dirname(__FILE__) + '/data_set'
 
 module Ai4r
   module Data
-  
+
     # This module provides some basic statistics functions to operate on
     # data set attributes.
     module Statistics
-      
+
       # Get the sample mean
       def self.mean(data_set, attribute)
         index = data_set.get_index(attribute)
@@ -23,7 +21,7 @@ module Ai4r
         data_set.data_items.each { |item| sum += item[index] }
         return sum / data_set.data_items.length
       end
-  
+
       # Get the variance.
       # You can provide the mean if you have it already, to speed up things.
       def self.variance(data_set, attribute, mean = nil)
@@ -33,21 +31,21 @@ module Ai4r
         data_set.data_items.each { |item| sum += (item[index]-mean)**2 }
         return sum / (data_set.data_items.length-1)
       end
-      
+
       # Get the standard deviation.
-      # You can provide the variance if you have it already, to speed up things.      
+      # You can provide the variance if you have it already, to speed up things.
       def self.standard_deviation(data_set, attribute, variance = nil)
         variance ||= variance(data_set, attribute)
         Math.sqrt(variance)
       end
-      
-      # Get the sample mode. 
+
+      # Get the sample mode.
       def self.mode(data_set, attribute)
         index = data_set.get_index(attribute)
         count = Hash.new {0}
         max_count = 0
         mode = nil
-        data_set.data_items.each do |data_item| 
+        data_set.data_items.each do |data_item|
           attr_value = data_item[index]
           attr_count = (count[attr_value] += 1)
           if attr_count > max_count
@@ -57,21 +55,21 @@ module Ai4r
         end
         return mode
       end
-      
+
       # Get the maximum value of an attribute in the data set
       def self.max(data_set, attribute)
         index = data_set.get_index(attribute)
         item = data_set.data_items.max {|x,y| x[index] <=> y[index]}
         return (item) ? item[index] : (-1.0/0)
       end
-      
+
       # Get the minimum value of an attribute in the data set
       def self.min(data_set, attribute)
         index = data_set.get_index(attribute)
         item = data_set.data_items.min {|x,y| x[index] <=> y[index]}
         return (item) ? item[index] : (1.0/0)
       end
-      
+
     end
   end
 end

--- a/test/clusterers/average_linkage_test.rb
+++ b/test/clusterers/average_linkage_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,32 +15,32 @@ class Ai4r::Clusterers::AverageLinkage < Ai4r::Clusterers::SingleLinkage
 end
 
 class AverageLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-      
-   def setup
-     Ai4r::Clusterers::AverageLinkage.send(:public, 
-       *Ai4r::Clusterers::AverageLinkage.protected_instance_methods)  
-   end
-  
-   def test_linkage_distance
+
+  def setup
+    Ai4r::Clusterers::AverageLinkage.send(:public,
+      *Ai4r::Clusterers::AverageLinkage.protected_instance_methods)
+  end
+
+  def test_linkage_distance
     clusterer = Ai4r::Clusterers::AverageLinkage.new
     clusterer.distance_matrix = @@expected_distance_matrix
     assert_equal 93.5, clusterer.linkage_distance(0,1,2)
@@ -48,4 +48,3 @@ class AverageLinkageTest < Test::Unit::TestCase
   end
 
 end
-

--- a/test/clusterers/centroid_linkage_test.rb
+++ b/test/clusterers/centroid_linkage_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,32 +15,32 @@ class Ai4r::Clusterers::CentroidLinkage
 end
 
 class Ai4r::Clusterers::CentroidLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-  
-   def setup
-     Ai4r::Clusterers::CentroidLinkage.send(:public, 
-       *Ai4r::Clusterers::CentroidLinkage.protected_instance_methods)  
-   end
-  
-   def test_linkage_distance
+
+  def setup
+    Ai4r::Clusterers::CentroidLinkage.send(:public,
+     *Ai4r::Clusterers::CentroidLinkage.protected_instance_methods)
+  end
+
+  def test_linkage_distance
     clusterer = Ai4r::Clusterers::CentroidLinkage.new
     clusterer.data_set = DataSet.new :data_items => @@data
     clusterer.index_clusters = clusterer.create_initial_index_clusters
@@ -50,4 +50,3 @@ class Ai4r::Clusterers::CentroidLinkageTest < Test::Unit::TestCase
   end
 
 end
-

--- a/test/clusterers/complete_linkage_test.rb
+++ b/test/clusterers/complete_linkage_test.rb
@@ -40,6 +40,13 @@ class CompleteLinkageTest < Test::Unit::TestCase
      *Ai4r::Clusterers::CompleteLinkage.protected_instance_methods)
   end
 
+  def test_build_with_distance
+    clusterer = Ai4r::Clusterers::CompleteLinkage.new
+    clusterer.build(DataSet.new(:data_items => @@data), distance: 4.0)
+    # draw_map(clusterer)
+    assert_equal 6, clusterer.clusters.length
+  end
+
   def test_linkage_distance
     clusterer = Ai4r::Clusterers::CompleteLinkage.new
     clusterer.distance_matrix = @@expected_distance_matrix
@@ -53,4 +60,14 @@ class CompleteLinkageTest < Test::Unit::TestCase
       DataSet.new(:data_items => [[3,4],[5,6]]))
   end
 
+  private
+  def draw_map(clusterer)
+    map = Array.new(11) {Array.new(11, 0)}
+    clusterer.clusters.each_index do |i|
+      clusterer.clusters[i].data_items.each do |point|
+        map[point.first][point.last]=(i+1)
+      end
+    end
+    map.each { |row| puts row.inspect}
+  end
 end

--- a/test/clusterers/complete_linkage_test.rb
+++ b/test/clusterers/complete_linkage_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,32 +15,32 @@ class Ai4r::Clusterers::CompleteLinkage
 end
 
 class CompleteLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-      
-   def setup
-     Ai4r::Clusterers::CompleteLinkage.send(:public, 
-       *Ai4r::Clusterers::CompleteLinkage.protected_instance_methods)  
-   end
-  
-   def test_linkage_distance
+
+  def setup
+    Ai4r::Clusterers::CompleteLinkage.send(:public,
+     *Ai4r::Clusterers::CompleteLinkage.protected_instance_methods)
+  end
+
+  def test_linkage_distance
     clusterer = Ai4r::Clusterers::CompleteLinkage.new
     clusterer.distance_matrix = @@expected_distance_matrix
     assert_equal 98, clusterer.linkage_distance(0,1,2)
@@ -49,9 +49,8 @@ class CompleteLinkageTest < Test::Unit::TestCase
 
   def test_distance_between_item_and_cluster
     clusterer = CompleteLinkage.new
-    assert_equal 32.0, clusterer.distance_between_item_and_cluster([1,2], 
+    assert_equal 32.0, clusterer.distance_between_item_and_cluster([1,2],
       DataSet.new(:data_items => [[3,4],[5,6]]))
   end
-  
-end
 
+end

--- a/test/clusterers/median_linkage_test.rb
+++ b/test/clusterers/median_linkage_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,32 +15,32 @@ class Ai4r::Clusterers::MedianLinkage
 end
 
 class Ai4r::Clusterers::MedianLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-      
-   def setup
-     Ai4r::Clusterers::MedianLinkage.send(:public, 
-       *Ai4r::Clusterers::MedianLinkage.protected_instance_methods)  
-   end
-  
-   def test_linkage_distance
+
+  def setup
+    Ai4r::Clusterers::MedianLinkage.send(:public,
+     *Ai4r::Clusterers::MedianLinkage.protected_instance_methods)
+  end
+
+  def test_linkage_distance
     clusterer = Ai4r::Clusterers::MedianLinkage.new
     clusterer.data_set = DataSet.new :data_items => @@data
     clusterer.index_clusters = clusterer.create_initial_index_clusters
@@ -50,4 +50,3 @@ class Ai4r::Clusterers::MedianLinkageTest < Test::Unit::TestCase
   end
 
 end
-

--- a/test/clusterers/single_linkage_test.rb
+++ b/test/clusterers/single_linkage_test.rb
@@ -42,8 +42,15 @@ class SingleLinkageTest < Test::Unit::TestCase
   def test_build
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.build(DataSet.new(:data_items => @@data), 4)
-    #draw_map(clusterer)
+    # draw_map(clusterer)
     assert_equal 4, clusterer.clusters.length
+  end
+
+  def test_build_with_distance
+    clusterer = Ai4r::Clusterers::SingleLinkage.new
+    clusterer.build(DataSet.new(:data_items => @@data), distance: 8.0)
+    # draw_map(clusterer)
+    assert_equal 3, clusterer.clusters.length
   end
 
   def test_eval

--- a/test/clusterers/single_linkage_test.rb
+++ b/test/clusterers/single_linkage_test.rb
@@ -3,25 +3,25 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
 require 'ai4r/clusterers/single_linkage'
- 
+
 class Ai4r::Clusterers::SingleLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix
 end
- 
+
 class SingleLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
- 
+
   @@data = [ [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
+
   @@expected_distance_matrix = [
         [98.0],
         [89.0, 5.0],
@@ -34,25 +34,25 @@ class SingleLinkageTest < Test::Unit::TestCase
         [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
         [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-  
+
   def setup
     SingleLinkage.send(:public, *SingleLinkage.protected_instance_methods)
   end
-  
+
   def test_build
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.build(DataSet.new(:data_items => @@data), 4)
     #draw_map(clusterer)
     assert_equal 4, clusterer.clusters.length
   end
-  
+
   def test_eval
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.build(DataSet.new(:data_items => @@data), 4)
     assert_equal 2, clusterer.eval([0,8])
     assert_equal 0, clusterer.eval([8,0])
   end
- 
+
   def test_create_distance_matrix
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.create_distance_matrix(DataSet.new(:data_items => @@data))
@@ -62,7 +62,7 @@ class SingleLinkageTest < Test::Unit::TestCase
     end
     assert_equal @@expected_distance_matrix, clusterer.distance_matrix
   end
-  
+
   def test_read_distance_matrix
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.distance_matrix = @@expected_distance_matrix
@@ -70,21 +70,21 @@ class SingleLinkageTest < Test::Unit::TestCase
     assert_equal 9.0, clusterer.read_distance_matrix(2, 3)
     assert_equal 0, clusterer.read_distance_matrix(5, 5)
   end
-  
+
   def test_linkage_distance
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.distance_matrix = @@expected_distance_matrix
     assert_equal 89, clusterer.linkage_distance(0,1,2)
     assert_equal 1, clusterer.linkage_distance(4,2,5)
   end
-  
+
   def test_get_closest_clusters
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.distance_matrix = @@expected_distance_matrix
     assert_equal [1,0], clusterer.get_closest_clusters([[0,1], [3,4]])
     assert_equal [2,1], clusterer.get_closest_clusters([[3,4], [0,1], [5,6]])
-   end
-   
+  end
+
   def test_create_initial_index_clusters
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusterer.data_set = DataSet.new :data_items => @@data
@@ -93,7 +93,7 @@ class SingleLinkageTest < Test::Unit::TestCase
     assert_equal 0, index_clusters.first.first
     assert_equal @@data.length-1, index_clusters.last.first
   end
-  
+
   def test_merge_clusters
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     clusters = clusterer.merge_clusters(1,2, [[1,2],[3,4],[5,6]])
@@ -101,13 +101,13 @@ class SingleLinkageTest < Test::Unit::TestCase
     clusters = clusterer.merge_clusters(2,1, [[1,2],[3,4],[5,6]])
     assert_equal [[1,2], [3,4,5,6]], clusters.collect {|x| x.sort}
   end
-  
+
   def test_distance_between_item_and_cluster
     clusterer = Ai4r::Clusterers::SingleLinkage.new
     assert_equal 8.0, clusterer.distance_between_item_and_cluster([1,2],
       DataSet.new(:data_items => [[3,4],[5,6]]))
   end
-  
+
   private
   def draw_map(clusterer)
     map = Array.new(11) {Array.new(11, 0)}
@@ -118,5 +118,5 @@ class SingleLinkageTest < Test::Unit::TestCase
     end
     map.each { |row| puts row.inspect}
   end
-  
+
 end

--- a/test/clusterers/ward_linkage_hierarchical_test.rb
+++ b/test/clusterers/ward_linkage_hierarchical_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.rubyforge.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,31 +15,31 @@ class Ai4r::Clusterers::WardLinkageHierarchical
 end
 
 class Ai4r::Clusterers::WardLinkageHierarchicalTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-      
-   def setup
-     Ai4r::Clusterers::WardLinkageHierarchical.send(:public, 
-       *Ai4r::Clusterers::WardLinkageHierarchical.protected_instance_methods)  
-   end
-   
+
+  def setup
+    Ai4r::Clusterers::WardLinkageHierarchical.send(:public,
+     *Ai4r::Clusterers::WardLinkageHierarchical.protected_instance_methods)
+  end
+
   def test_linkage_distance
     clusterer = Ai4r::Clusterers::WardLinkageHierarchical.new
     clusterer.data_set = DataSet.new :data_items => @@data
@@ -54,28 +54,27 @@ class Ai4r::Clusterers::WardLinkageHierarchicalTest < Test::Unit::TestCase
     clusterer.build(DataSet.new(:data_items => @@data), 1)
     assert_equal @@data.length, clusterer.cluster_tree.length
   end
-    
+
   def test_cluster_tree_limit
     depth = 5
     clusterer = Ai4r::Clusterers::WardLinkageHierarchical.new(5)
     clusterer.build(DataSet.new(:data_items => @@data), 1)
     assert_equal 5, clusterer.cluster_tree.length
   end
-    
+
   def test_cluster_tree_first_length
     depth = 5
     clusterer = Ai4r::Clusterers::WardLinkageHierarchical.new(5)
     clusterer.build(DataSet.new(:data_items => @@data), 1)
     assert_equal 1, clusterer.cluster_tree.first.length
   end
-    
+
   def test_cluster_tree_last_length
     depth = 5
     clusterer = Ai4r::Clusterers::WardLinkageHierarchical.new(5)
     clusterer.build(DataSet.new(:data_items => @@data), 1)
     assert_equal 5, clusterer.cluster_tree.last.length
   end
-    
+
 
 end
-

--- a/test/clusterers/ward_linkage_test.rb
+++ b/test/clusterers/ward_linkage_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,32 +15,32 @@ class Ai4r::Clusterers::WardLinkage
 end
 
 class Ai4r::Clusterers::WardLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-      
-   def setup
-     Ai4r::Clusterers::WardLinkage.send(:public, 
-       *Ai4r::Clusterers::WardLinkage.protected_instance_methods)  
-   end
-   
-   def test_linkage_distance
+
+  def setup
+    Ai4r::Clusterers::WardLinkage.send(:public,
+     *Ai4r::Clusterers::WardLinkage.protected_instance_methods)
+  end
+
+  def test_linkage_distance
     clusterer = Ai4r::Clusterers::WardLinkage.new
     clusterer.data_set = DataSet.new :data_items => @@data
     clusterer.index_clusters = clusterer.create_initial_index_clusters
@@ -50,4 +50,3 @@ class Ai4r::Clusterers::WardLinkageTest < Test::Unit::TestCase
   end
 
 end
-

--- a/test/clusterers/weighted_average_linkage_test.rb
+++ b/test/clusterers/weighted_average_linkage_test.rb
@@ -3,8 +3,8 @@
 # Project::   ai4r
 # Url::       http://ai4r.org/
 #
-# You can redistribute it and/or modify it under the terms of 
-# the Mozilla Public License version 1.1  as published by the 
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'test/unit'
@@ -15,32 +15,32 @@ class Ai4r::Clusterers::WeightedAverageLinkage
 end
 
 class Ai4r::Clusterers::WeightedAverageLinkageTest < Test::Unit::TestCase
-  
+
   include Ai4r::Clusterers
   include Ai4r::Data
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
-            
-  @@expected_distance_matrix = [ 
-        [98.0], 
-        [89.0, 5.0], 
-        [68.0, 26.0, 9.0], 
-        [74.0, 4.0, 1.0, 10.0], 
-        [0.0, 98.0, 89.0, 68.0, 74.0], 
-        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0], 
-        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0], 
-        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0], 
-        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0], 
-        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0], 
+
+  @@expected_distance_matrix = [
+        [98.0],
+        [89.0, 5.0],
+        [68.0, 26.0, 9.0],
+        [74.0, 4.0, 1.0, 10.0],
+        [0.0, 98.0, 89.0, 68.0, 74.0],
+        [81.0, 53.0, 26.0, 5.0, 29.0, 81.0],
+        [8.0, 106.0, 85.0, 52.0, 74.0, 8.0, 53.0],
+        [100.0, 2.0, 1.0, 16.0, 2.0, 100.0, 37.0, 100.0],
+        [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
+        [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]]
-      
-   def setup
-     Ai4r::Clusterers::WeightedAverageLinkage.send(:public, 
-       *Ai4r::Clusterers::WeightedAverageLinkage.protected_instance_methods)  
-   end
-  
-   def test_linkage_distance
+
+  def setup
+    Ai4r::Clusterers::WeightedAverageLinkage.send(:public,
+     *Ai4r::Clusterers::WeightedAverageLinkage.protected_instance_methods)
+  end
+
+  def test_linkage_distance
     clusterer = Ai4r::Clusterers::WeightedAverageLinkage.new
     clusterer.data_set = DataSet.new :data_items => @@data
     clusterer.index_clusters = clusterer.create_initial_index_clusters
@@ -48,6 +48,4 @@ class Ai4r::Clusterers::WeightedAverageLinkageTest < Test::Unit::TestCase
     assert_equal 93.5, clusterer.linkage_distance(0,1,2)
     assert_equal 37.5, clusterer.linkage_distance(4,2,5)
   end
-
 end
-


### PR DESCRIPTION
Currently for hierarchical agglomerative clustering, we can only retrieve the clusters based on the total number of clusters. One of the features of this bottom-to-top clustering is we can stop the clustering process (or cut the clustering tree) at any distance among clusters.

If we compare to Scipy implementation for [creating flat clusters](http://docs.scipy.org/doc/scipy-0.17.1/reference/generated/scipy.cluster.hierarchy.fcluster.html#scipy.cluster.hierarchy.fcluster), the current implementation supports `criterion='maxclust'` only. This pull request make `criterion='distance'` can be done.
