### PR TITLE
Fix BisectingKMeans initialization

### DIFF
--- a/lib/ai4r/clusterers/bisecting_k_means.rb
+++ b/lib/ai4r/clusterers/bisecting_k_means.rb
@@ -41,7 +41,8 @@ module Ai4r
             "result of the bisecting approach."
       
       
-      def intialize
+      def initialize
+        super
         @refine = true
       end
       

--- a/test/clusterers/bisecting_k_means_test.rb
+++ b/test/clusterers/bisecting_k_means_test.rb
@@ -21,9 +21,13 @@ class BisectingKMeansTest < Test::Unit::TestCase
   def test_build_without_refine
     build(false)
   end
-  
+
   def test_build_with_refine
     build(true)
+  end
+
+  def test_refine_defaults_to_true
+    assert_equal true, BisectingKMeans.new.refine
   end
   
   protected


### PR DESCRIPTION
## Summary
- fix typo in BisectingKMeans initializer
- set `@refine` default to true
- test that refine defaults to true

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687174e0dfac8326bc3e45336ee6755e