### PR TITLE
Fix population replacement boundary

### DIFF
--- a/lib/ai4r/genetic_algorithm/genetic_algorithm.rb
+++ b/lib/ai4r/genetic_algorithm/genetic_algorithm.rb
@@ -129,7 +129,7 @@ module Ai4r
       # Replace worst ranked part of population with offspring
       def replace_worst_ranked(offsprings)
         size = offsprings.length
-        @population = @population [0..((-1*size)-1)] + offsprings
+        @population = @population[0..(-size-1)] + offsprings
       end
 
       # Select the best chromosome in the population


### PR DESCRIPTION
## Summary
- correct the array boundary when replacing the worst ranked population

## Testing
- `bundle exec rake test TEST=test/genetic_algorithm/genetic_algorithm_test.rb`
- `bundle exec rake test TEST=test/genetic_algorithm/chromosome_test.rb`
- `bundle exec rake test TEST="test/genetic_algorithm/*_test.rb"`

------
https://chatgpt.com/codex/tasks/task_e_687174f214bc8326ba6dd9ec6cf79d46