### PR TITLE
Fix simple linear regression y_diff index

### DIFF
--- a/lib/ai4r/classifiers/simple_linear_regression.rb
+++ b/lib/ai4r/classifiers/simple_linear_regression.rb
@@ -75,7 +75,7 @@ module Ai4r
             slope = 0
             data.data_items.map do |instance|
               x_diff = instance[attr_index] - x_mean
-              y_diff = instance[attr_index] - y_mean
+              y_diff = instance[data.num_attributes - 1] - y_mean
               slope += x_diff * y_diff
               sum_x_diff_squared += x_diff * x_diff
               sum_y_diff_squared += y_diff * y_diff

--- a/test/classifiers/simple_linear_regression_test.rb
+++ b/test/classifiers/simple_linear_regression_test.rb
@@ -31,7 +31,7 @@ class SimpleLinearRegressionTest < Test::Unit::TestCase
 
   def test_eval
     result = @c.eval([-1,95,109.1,188.8,68.9,55.5,3062,141,3.78,3.15,9.5,114,5400,19,25])
-    assert_equal 17218.444444444445, result
+    assert_equal 18607.025513298104, result
   end
 
 end


### PR DESCRIPTION
## Summary
- fix slope calculation by referencing final attribute when computing y_diff
- update regression test expectation

## Testing
- `bundle exec ruby -Ilib -Itest test/classifiers/simple_linear_regression_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_687174fbc5d083269ebc488631bdc777