### PR TITLE
Fix open_csv_file to close handle

### DIFF
--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -59,11 +59,13 @@ module Ai4r
       # ruby1.8 and 1.9 safe
       def open_csv_file(filepath, &block)
         if CSV.const_defined? :Reader
-          CSV::Reader.parse(File.open(filepath, 'r')) do |row|
-            block.call row
+          File.open(filepath, 'r') do |f|
+            CSV::Reader.parse(f) do |row|
+              block.call row
+            end
           end
         else
-          CSV.parse(File.open(filepath, 'r')) do |row|
+          CSV.foreach(filepath) do |row|
             block.call row
           end
         end


### PR DESCRIPTION
## Summary
- ensure `open_csv_file` closes its IO handle

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717505705c8326b0c019522ff1187f