### PR TITLE
Improve SOM node error

### DIFF
--- a/lib/ai4r/som/som.rb
+++ b/lib/ai4r/som/som.rb
@@ -129,7 +129,9 @@ module Ai4r
 
       # returns the node at position (x,y) in the square map
       def get_node(x, y)
-        raise(Exception.new) if check_param_for_som(x,y)
+        if check_param_for_som(x, y)
+          raise ArgumentError, "invalid node coordinates (#{x}, #{y})"
+        end
         @nodes[y + x * @number_of_nodes]
       end
 

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -50,13 +50,11 @@ module Ai4r
       end
 
       def test_access_to_nodes
-        assert_raise Exception do
-          @som.get_node(5, 5)
-        end
+        ex = assert_raise(ArgumentError) { @som.get_node(5, 5) }
+        assert_equal 'invalid node coordinates (5, 5)', ex.message
 
-        assert_raise Exception do
-          @som.get_node(5, -3)
-        end
+        ex = assert_raise(ArgumentError) { @som.get_node(5, -3) }
+        assert_equal 'invalid node coordinates (5, -3)', ex.message
 
         assert_equal Node, @som.get_node(0, 0).class
       end


### PR DESCRIPTION
## Summary
- raise a descriptive ArgumentError in SOM#get_node
- assert error type and message when node coordinates are invalid

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871750a97508326acc377f75d800950