### PR TITLE
Simplify CSV loading

### DIFF
--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -54,20 +54,10 @@ module Ai4r
         set_data_items(items)
       end
 
-      # opens a csv-file and reads it line by line
-      # for each line, a block is called and the row is passed to the block
-      # ruby1.8 and 1.9 safe
+      # Open a CSV file and yield each row to the provided block.
       def open_csv_file(filepath, &block)
-        if CSV.const_defined? :Reader
-          File.open(filepath, 'r') do |f|
-            CSV::Reader.parse(f) do |row|
-              block.call row
-            end
-          end
-        else
-          CSV.foreach(filepath) do |row|
-            block.call row
-          end
+        CSV.foreach(filepath) do |row|
+          block.call row
         end
       end
 

--- a/test/data/data_set_test.rb
+++ b/test/data/data_set_test.rb
@@ -27,6 +27,15 @@ module Ai4r
         assert_equal ["zone", "rooms", "size", "price"], set.data_labels
         assert_equal ["Moron Sur (GBA)",2.0,"[28 m2 - 39 m2]","[29K-35K]"], set.data_items.first
       end
+
+      def test_open_csv_file
+        rows = []
+        DataSet.new.open_csv_file("#{File.dirname(__FILE__)}/data_set.csv") do |row|
+          rows << row
+        end
+        assert_equal 121, rows.length
+        assert_equal ["zone", "rooms", "size", "price"], rows.first
+      end
       
       def test_build_domains
         domains =  [  Set.new(["New York", "Chicago"]), 


### PR DESCRIPTION
## Summary
- drop legacy CSV::Reader handling
- rely on CSV.foreach for row iteration
- test open_csv_file behavior

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717ca6c7e48326990a08bfd3f0cf6f