### PR TITLE
Refine numeric detection for CSV parsing

### DIFF
--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -82,7 +82,9 @@ module Ai4r
       def parse_csv(filepath)
         items = []
         open_csv_file(filepath) do |row|
-          items << row.collect{|x| is_number?(x) ? Float(x) : x }
+          items << row.collect do |x|
+            is_number?(x) ? Float(x, exception: false) : x
+          end
         end
         set_data_items(items)
       end
@@ -237,7 +239,7 @@ module Ai4r
       protected
 
       def is_number?(x)
-        true if Float(x) rescue false
+        !Float(x, exception: false).nil?
       end
 
       def check_data_items(data_items)


### PR DESCRIPTION
## Summary
- use exception-free float conversion in `is_number?`
- update `parse_csv` to use `Float(x, exception: false)` when converting

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717cae53808326af0f6912d3815cf2