### PR TITLE
Remove obsolete Hash#key alias

### DIFF
--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -262,7 +262,3 @@ module Ai4r
   end
 end
 
-# Monkeypatch to support both ruby 1.8 and 1.9 (key vs index method)
-class Hash
-  alias_method(:key, :index) unless method_defined?(:key)
-end


### PR DESCRIPTION
## Summary
- remove Hash#key monkeypatch from NaiveBayes

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717cb982c08326ba985c8f33782923