### PR TITLE
Fix hash default for mode calculation

### DIFF
--- a/lib/ai4r/data/statistics.rb
+++ b/lib/ai4r/data/statistics.rb
@@ -42,7 +42,7 @@ module Ai4r
       # Get the sample mode.
       def self.mode(data_set, attribute)
         index = data_set.get_index(attribute)
-        count = Hash.new {0}
+        count = Hash.new(0)
         max_count = 0
         mode = nil
         data_set.data_items.each do |data_item|


### PR DESCRIPTION
## Summary
- use explicit default for mode counts

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717cc23f308326b5398da5c2a2b7f6