### PR TITLE
Use max_by and min_by in statistics

### DIFF
--- a/lib/ai4r/data/statistics.rb
+++ b/lib/ai4r/data/statistics.rb
@@ -59,14 +59,14 @@ module Ai4r
       # Get the maximum value of an attribute in the data set
       def self.max(data_set, attribute)
         index = data_set.get_index(attribute)
-        item = data_set.data_items.max {|x,y| x[index] <=> y[index]}
+        item = data_set.data_items.max_by { |item| item[index] }
         return (item) ? item[index] : (-1.0/0)
       end
 
       # Get the minimum value of an attribute in the data set
       def self.min(data_set, attribute)
         index = data_set.get_index(attribute)
-        item = data_set.data_items.min {|x,y| x[index] <=> y[index]}
+        item = data_set.data_items.min_by { |item| item[index] }
         return (item) ? item[index] : (1.0/0)
       end
 


### PR DESCRIPTION
## Summary
- use `max_by` for clarity when finding the maximum value
- use `min_by` for clarity when finding the minimum value

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717cc90a1483269c8e443c5679c493