### PR TITLE
Add configurability to ID3 classifier

### DIFF
--- a/test/classifiers/id3_test.rb
+++ b/test/classifiers/id3_test.rb
@@ -236,6 +236,28 @@ class ID3Test < Test::Unit::TestCase
     end
     assert_equal true, true
   end
+
+  def test_on_unknown_nil
+    bad_data_items = [ ['a', 'Y'], ['b', 'N'] ]
+    bad_data_labels = ['bogus', 'target']
+    id3 = ID3.new.set_parameters(:on_unknown => :nil).build(DataSet.new(:data_items => bad_data_items, :data_labels => bad_data_labels))
+    assert_nil id3.eval(['c'])
+  end
+
+  def test_on_unknown_most_frequent
+    bad_data_items = [ ['a', 'Y'], ['b', 'N'], ['b', 'Y'] ]
+    bad_data_labels = ['bogus', 'target']
+    id3 = ID3.new.set_parameters(:on_unknown => :most_frequent).build(DataSet.new(:data_items => bad_data_items, :data_labels => bad_data_labels))
+    assert_equal 'Y', id3.eval(['c'])
+  end
+
+  def test_max_depth_and_min_gain
+    ds = DataSet.new(:data_items => DATA_ITEMS, :data_labels => DATA_LABELS)
+    id3 = ID3.new.set_parameters(:max_depth => 0).build(ds)
+    assert_equal 'Y', id3.eval(['New York', '<30', 'M'])
+    id3 = ID3.new.set_parameters(:min_gain => 1.0).build(ds)
+    assert_equal 'Y', id3.eval(['New York', '<30', 'F'])
+  end
 end
 
   


### PR DESCRIPTION
## Summary
- let ID3 expose `:max_depth`, `:min_gain` and `:on_unknown` parameters
- stop splits when depth or information gain thresholds are hit
- handle unseen feature values using the configured strategy
- test `on_unknown`, `max_depth`, and `min_gain`

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68717e7156b083268ec168415805db06