### PR TITLE
Remove obsolete rubygems requires

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,7 +13,6 @@ This project aims to produce ruby implementations of algorithms covering several
 
 2. Include require statements in your code:
 
-  require "rubygems"
   require "ai4r"
 
 = Documentation

--- a/ai4r.gemspec
+++ b/ai4r.gemspec
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'rake'
 
 SPEC = Gem::Specification.new do |s|

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,6 @@ gem install ai4r
 Include the library in your code:
 
 ```ruby
-require 'rubygems'
 require 'ai4r'
 ```
 

--- a/examples/clusterers/clusterer_example.rb
+++ b/examples/clusterers/clusterer_example.rb
@@ -12,7 +12,6 @@
 # the word "Diana" by "KMeans", "AverageLinkage", or any other cluster implementation.
 # The cluster API is the same, so you can play around and observe different results.
 
-require 'rubygems'
 require 'ai4r'
 include Ai4r::Data
 include Ai4r::Clusterers


### PR DESCRIPTION
## Summary
- remove `require 'rubygems'` from gemspec, docs and example

## Testing
- `bundle exec rake test`
- `ruby -I. examples/neural_network/backpropagation_example.rb`
- `ruby -Ilib examples/clusterers/clusterer_example.rb`


------
https://chatgpt.com/codex/tasks/task_e_68717cbdb0f48326a2c7b1d4e613ef3d