### PR TITLE
Add Hopfield network docs and example

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -1,0 +1,45 @@
+# Hopfield Networks
+
+A Hopfield network is a recurrent neural network that stores patterns as stable states. It can remove noise from an input pattern by iteratively updating the neurons until it converges to the closest memorized pattern.
+
+## Input Format
+
+Training requires an `Ai4r::Data::DataSet` where each `data_item` is an array of values. Values should match the `active_node_value` and `inactive_node_value` parameters (by default `1` and `-1`). All patterns must have the same length.
+
+```ruby
+require 'ai4r/neural_network/hopfield'
+require 'ai4r/data/data_set'
+
+patterns = [
+  [1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1],
+  [-1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1]
+]
+
+data = Ai4r::Data::DataSet.new(data_items: patterns)
+net = Ai4r::NeuralNetwork::Hopfield.new.train(data)
+```
+
+Evaluation uses the same vector format:
+
+```ruby
+result = net.eval(noisy_pattern)
+```
+
+## Parameters
+
+`Ai4r::NeuralNetwork::Hopfield` supports several parameters which can be set with `set_parameters`:
+
+* `eval_iterations` – maximum number of iterations when calling `eval` (default `500`).
+* `active_node_value` – value representing an active neuron (default `1`).
+* `inactive_node_value` – value representing an inactive neuron (default `-1`).
+* `threshold` – activation threshold used during propagation (default `0`).
+
+```ruby
+net.set_parameters(eval_iterations: 1000, threshold: 0.2)
+```
+
+## Theory
+
+Each pattern is stored as a minimum of an energy function defined by the weight matrix. During evaluation the network repeatedly updates random neurons based on the weighted sum of their neighbours until the pattern stabilizes. If the input resembles one of the stored patterns the network will typically converge to it and thus clean the noise.
+
+For further reading see the [Hopfield network](https://en.wikipedia.org/wiki/Hopfield_network) article.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ require 'ai4r'
 
 * **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
 * **Neural Networks** – simple OCR recognition of visual patterns.
+* [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
 * **Automatic Classifiers** – identify relevant marketing targets using decision trees.
 
 ## Contact

--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -33,4 +33,6 @@ net.set_parameters(
 )
 ```
 
+For a recurrent associative network that can recall patterns from noisy inputs see the [Hopfield network](hopfield_network.md) document.
+
 See the [Artificial Neural Network](http://en.wikipedia.org/wiki/Artificial_neural_network) and [Backpropagation](http://en.wikipedia.org/wiki/Backpropagation) articles for more information.

--- a/examples/neural_network/hopfield_example.rb
+++ b/examples/neural_network/hopfield_example.rb
@@ -1,0 +1,33 @@
+# Author::    Sergio Fierens
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       http://www.ai4r.org/
+#
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+require File.dirname(__FILE__) + '/../../lib/ai4r/neural_network/hopfield'
+require File.dirname(__FILE__) + '/../../lib/ai4r/data/data_set'
+
+patterns = [
+  [1,1,-1,-1,1,1,-1,-1,1,1,-1,-1,1,1,-1,-1],
+  [-1,-1,1,1,-1,-1,1,1,-1,-1,1,1,-1,-1,1,1],
+  [-1,-1,-1,-1,-1,-1,-1,-1,1,1,1,1,1,1,1,1],
+  [1,1,1,1,1,1,1,1,-1,-1,-1,-1,-1,-1,-1,-1]
+]
+
+noisy_patterns = [
+  [1,1,-1,1,1,1,-1,-1,1,1,-1,-1,1,1,1,-1],
+  [-1,-1,1,1,1,-1,1,1,-1,-1,1,-1,-1,-1,1,1],
+  [-1,-1,-1,-1,-1,-1,-1,-1,1,1,1,1,1,1,-1,-1],
+  [-1,-1,1,1,1,1,1,1,-1,-1,-1,-1,1,-1,-1,-1]
+]
+
+data = Ai4r::Data::DataSet.new(data_items: patterns)
+net = Ai4r::NeuralNetwork::Hopfield.new.train(data)
+
+puts 'Evaluation of noisy patterns:'
+noisy_patterns.each do |p|
+  puts "#{p.inspect} => #{net.eval(p).inspect}"
+end


### PR DESCRIPTION
## Summary
- document Hopfield networks
- reference Hopfield info from index and neural network docs
- add a Hopfield training example

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687186a850fc83269ed6f849288cca61