### PR TITLE
Handle numeric splits in ID3 decision tree

### DIFF
--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -59,4 +59,17 @@ eval id3.get_rules
 puts marketing_target  # => 'Y'
 ```
 
+## Numeric Attributes
+
+ID3 can evaluate numeric features by automatically searching for the best
+threshold. Each numeric split generates rules using comparison operators:
+
+```ruby
+labels = ['size', 'label']
+items  = [[20, 'S'], [30, 'S'], [40, 'S'], [50, 'L'], [60, 'L'], [70, 'L']]
+id3 = ID3.new.build(DataSet.new(:data_items => items, :data_labels => labels))
+puts id3.get_rules
+# => "size <= 45.0 ? ..."
+```
+
 Further reading: [ID3 Algorithm](http://en.wikipedia.org/wiki/ID3_algorithm) and [Decision Trees](http://en.wikipedia.org/wiki/Decision_tree).

--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -59,10 +59,12 @@ eval id3.get_rules
 puts marketing_target  # => 'Y'
 ```
 
+Further reading: [ID3 Algorithm](http://en.wikipedia.org/wiki/ID3_algorithm) and [Decision Trees](http://en.wikipedia.org/wiki/Decision_tree).
+
 ## Numeric Attributes
 
-ID3 can evaluate numeric features by automatically searching for the best
-threshold. Each numeric split generates rules using comparison operators:
+ID3 also works with numeric features by automatically searching for the best
+threshold. Each numeric split produces rules with comparison operators:
 
 ```ruby
 labels = ['size', 'label']
@@ -71,5 +73,3 @@ id3 = ID3.new.build(DataSet.new(:data_items => items, :data_labels => labels))
 puts id3.get_rules
 # => "size <= 45.0 ? ..."
 ```
-
-Further reading: [ID3 Algorithm](http://en.wikipedia.org/wiki/ID3_algorithm) and [Decision Trees](http://en.wikipedia.org/wiki/Decision_tree).

--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -145,15 +145,49 @@ module Ai4r
       private
       def build_node(data_examples, flag_att = [])
         return ErrorNode.new if data_examples.length == 0
-        domain = domain(data_examples)   
+        domain = domain(data_examples)
         return CategoryNode.new(@data_set.category_label, domain.last[0]) if domain.last.length == 1
-        min_entropy_index = min_entropy_index(data_examples, domain, flag_att)
-        split_data_examples = split_data_examples(data_examples, domain, min_entropy_index)
-        return CategoryNode.new(@data_set.category_label, most_freq(data_examples, domain)) if split_data_examples.length == 1
-        nodes = split_data_examples.collect do |partial_data_examples|  
-          build_node(partial_data_examples, [*flag_att, min_entropy_index])
+
+        best_index = nil
+        best_entropy = nil
+        best_split = nil
+        best_threshold = nil
+
+        domain[0..-2].each_index do |index|
+          next if flag_att.include?(index)
+          if data_examples.first[index].is_a?(Numeric)
+            values = data_examples.collect { |ex| ex[index] }.uniq.sort
+            thresholds = candidate_thresholds(values)
+            thresholds.each do |thr|
+              grid = freq_grid_numeric(index, data_examples, domain, thr)
+              entropy = entropy(grid, data_examples.length)
+              if !best_entropy || entropy < best_entropy
+                best_entropy = entropy
+                best_index = index
+                best_threshold = thr
+                best_split = split_numeric_data_examples(data_examples, index, thr)
+              end
+            end
+          else
+            grid = freq_grid(index, data_examples, domain)
+            entropy_val = entropy(grid, data_examples.length)
+            if !best_entropy || entropy_val < best_entropy
+              best_entropy = entropy_val
+              best_index = index
+              best_threshold = nil
+              best_split = split_data_examples(data_examples, domain, index)
+            end
+          end
         end
-        return EvaluationNode.new(@data_set.data_labels, min_entropy_index, domain[min_entropy_index], nodes)
+
+        return CategoryNode.new(@data_set.category_label, most_freq(data_examples, domain)) if best_split.length == 1
+
+        nodes = best_split.collect do |partial_data_examples|
+          build_node(partial_data_examples, [*flag_att, best_index])
+        end
+
+        split_value = best_threshold.nil? ? domain[best_index] : best_threshold
+        EvaluationNode.new(@data_set.data_labels, best_index, split_value, nodes)
       end
 
       private
@@ -201,6 +235,41 @@ module Ai4r
            data_examples_array[att_value_index] = example_set
         end
         return data_examples_array
+      end
+
+      private
+      def split_numeric_data_examples(data_examples, att_index, threshold)
+        lower = []
+        higher = []
+        data_examples.each do |example|
+          if example[att_index] <= threshold
+            lower << example
+          else
+            higher << example
+          end
+        end
+        [lower, higher]
+      end
+
+      private
+      def candidate_thresholds(sorted_values)
+        thresholds = []
+        sorted_values.each_cons(2) do |a, b|
+          thresholds << (a + b) / 2.0
+        end
+        thresholds.empty? ? sorted_values : thresholds
+      end
+
+      private
+      def freq_grid_numeric(att_index, data_examples, domain, threshold)
+        category_domain = domain.last
+        grid = Array.new(2) { Array.new(category_domain.length, 0) }
+        data_examples.each do |example|
+          category_index = category_domain.index(example.last)
+          pos = example[att_index] <= threshold ? 0 : 1
+          grid[pos][category_index] += 1
+        end
+        grid
       end
 
       private 
@@ -272,33 +341,54 @@ module Ai4r
     end
 
     class EvaluationNode #:nodoc: all
-      
+
       attr_reader :index, :values, :nodes
-      
+
       def initialize(data_labels, index, values, nodes)
         @index = index
-        @values = values
         @nodes = nodes
         @data_labels = data_labels
+        if values.is_a?(Array)
+          @values = values
+          @threshold = nil
+        else
+          @threshold = values
+          @values = nil
+        end
       end
-      
+
       def value(data)
         value = data[@index]
-        return ErrorNode.new.value(data) unless @values.include?(value)
-        return nodes[@values.index(value)].value(data)
+        if @threshold
+          node = value <= @threshold ? @nodes[0] : @nodes[1]
+          node.value(data)
+        else
+          return ErrorNode.new.value(data) unless @values.include?(value)
+          nodes[@values.index(value)].value(data)
+        end
       end
-      
+
       def get_rules
         rule_set = []
-        @nodes.each_with_index do |child_node, child_node_index|
-          my_rule = "#{@data_labels[@index]}=='#{@values[child_node_index]}'"
-          child_node_rules = child_node.get_rules
-          child_node_rules.each do |child_rule|
-            child_rule.unshift(my_rule)
+        if @threshold
+          @nodes.each_with_index do |child_node, idx|
+            op = idx.zero? ? '<=' : '>'
+            my_rule = "#{@data_labels[@index]} #{op} #{@threshold}"
+            child_node_rules = child_node.get_rules
+            child_node_rules.each { |r| r.unshift(my_rule) }
+            rule_set += child_node_rules
           end
-          rule_set += child_node_rules
+        else
+          @nodes.each_with_index do |child_node, child_node_index|
+            my_rule = "#{@data_labels[@index]}=='#{@values[child_node_index]}'"
+            child_node_rules = child_node.get_rules
+            child_node_rules.each do |child_rule|
+              child_rule.unshift(my_rule)
+            end
+            rule_set += child_node_rules
+          end
         end
-        return rule_set
+        rule_set
       end
       
     end

--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -155,14 +155,14 @@ module Ai4r
 
         domain[0..-2].each_index do |index|
           next if flag_att.include?(index)
+
           if data_examples.first[index].is_a?(Numeric)
             values = data_examples.collect { |ex| ex[index] }.uniq.sort
-            thresholds = candidate_thresholds(values)
-            thresholds.each do |thr|
+            candidate_thresholds(values).each do |thr|
               grid = freq_grid_numeric(index, data_examples, domain, thr)
-              entropy = entropy(grid, data_examples.length)
-              if !best_entropy || entropy < best_entropy
-                best_entropy = entropy
+              ent = entropy(grid, data_examples.length)
+              if !best_entropy || ent < best_entropy
+                best_entropy = ent
                 best_index = index
                 best_threshold = thr
                 best_split = split_numeric_data_examples(data_examples, index, thr)
@@ -170,9 +170,9 @@ module Ai4r
             end
           else
             grid = freq_grid(index, data_examples, domain)
-            entropy_val = entropy(grid, data_examples.length)
-            if !best_entropy || entropy_val < best_entropy
-              best_entropy = entropy_val
+            ent = entropy(grid, data_examples.length)
+            if !best_entropy || ent < best_entropy
+              best_entropy = ent
               best_index = index
               best_threshold = nil
               best_split = split_data_examples(data_examples, domain, index)
@@ -182,8 +182,8 @@ module Ai4r
 
         return CategoryNode.new(@data_set.category_label, most_freq(data_examples, domain)) if best_split.length == 1
 
-        nodes = best_split.collect do |partial_data_examples|
-          build_node(partial_data_examples, [*flag_att, best_index])
+        nodes = best_split.collect do |partial|
+          build_node(partial, [*flag_att, best_index])
         end
 
         split_value = best_threshold.nil? ? domain[best_index] : best_threshold

--- a/test/classifiers/id3_test.rb
+++ b/test/classifiers/id3_test.rb
@@ -236,6 +236,17 @@ class ID3Test < Test::Unit::TestCase
     end
     assert_equal true, true
   end
+
+  def test_numeric_attribute
+    labels = ['size', 'label']
+    items = [[20, 'S'], [30, 'S'], [40, 'S'], [50, 'L'], [60, 'L'], [70, 'L']]
+    id3 = ID3.new.build(DataSet.new(:data_items => items, :data_labels => labels))
+    assert_equal 'S', id3.eval([25])
+    assert_equal 'L', id3.eval([65])
+    rules = id3.get_rules
+    assert_match(/size <= 45.0/, rules)
+    assert_match(/size > 45.0/, rules)
+  end
 end
 
   


### PR DESCRIPTION
## Summary
- extend `build_node` to support numeric attributes
- compute candidate thresholds and select the best entropy split
- represent numeric decision nodes using comparison operators
- add unit test exercising numeric data
- document numeric attribute support for ID3

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68717e721efc83268a3a621d0e8aa968