### PR TITLE
Add weight scaling parameter to Hopfield

### DIFF
--- a/lib/ai4r/neural_network/hopfield.rb
+++ b/lib/ai4r/neural_network/hopfield.rb
@@ -41,13 +41,16 @@ require_relative '../data/parameterizable'
         "default.",
         :active_node_value => "Default: 1",
         :inactive_node_value => "Default: -1",
-        :threshold => "Default: 0"
+        :threshold => "Default: 0",
+        :weight_scaling => "Scale factor applied when computing weights. " +
+          "Default 1.0 / patterns_count"
             
       def initialize
         @eval_iterations = 500
         @active_node_value = 1
         @inactive_node_value = -1
         @threshold = 0
+        @weight_scaling = nil
       end
 
       # Prepares the network to memorize the given data set.
@@ -127,10 +130,13 @@ require_relative '../data/parameterizable'
       # 
       # Use read_weight(i,j) to find out weight between node i and j
       def initialize_weights(data_set)
+        patterns_count = data_set.data_items.length
+        scaling = @weight_scaling || (1.0 / patterns_count)
         @weights = Array.new(@nodes.length-1) {|l| Array.new(l+1)}
         @nodes.each_index do |i|
           i.times do |j|
-            @weights[i-1][j] = data_set.data_items.inject(0) { |sum, item| sum+= item[i]*item[j] }
+            sum = data_set.data_items.inject(0) { |s, item| s + item[i] * item[j] }
+            @weights[i-1][j] = sum * scaling
           end
         end
       end

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -42,6 +42,7 @@ module Ai4r
         net.initialize_weights(@data_set)
         assert_equal 15, net.weights.length
         net.weights.each_with_index {|w_row, i| assert_equal i+1, w_row.length}
+        assert_in_delta 1.0, net.read_weight(1,0), 0.00001
       end
       
       def test_run


### PR DESCRIPTION
## Summary
- allow Hopfield network weight scaling by introducing `weight_scaling` parameter
- compute weights scaled by `1.0 / patterns_count` by default
- check new weight computation in hopfield tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687187d0a308832689d17814cb4126d5