### PR TITLE
Add activation function parameter to Backpropagation

### DIFF
--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -22,7 +22,8 @@ After training, the network can evaluate noisy patterns with good accuracy.
 
 ## Customizing Parameters
 
-You can tweak the learning rate, momentum and propagation function:
+You can tweak the learning rate, momentum and propagation function. You can also
+pick one of the built-in activation functions with the `activation` parameter:
 
 ```ruby
 net.set_parameters(
@@ -31,6 +32,13 @@ net.set_parameters(
   propagation_function: ->(x) { Math.tanh(x) },
   derivative_propagation_function: ->(y) { 1.0 - y**2 }
 )
+```
+
+Alternatively you can simply specify the activation name:
+
+```ruby
+net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3], :tanh)
+net.set_parameters(activation: :relu)
 ```
 
 See the [Artificial Neural Network](http://en.wikipedia.org/wiki/Artificial_neural_network) and [Backpropagation](http://en.wikipedia.org/wiki/Backpropagation) articles for more information.

--- a/lib/ai4r/neural_network/activation_functions.rb
+++ b/lib/ai4r/neural_network/activation_functions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# Author::    Sergio Fierens
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       https://github.com/SergioFierens/ai4r
+#
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+module Ai4r
+  module NeuralNetwork
+    # Collection of common activation functions and their derivatives.
+    module ActivationFunctions
+      FUNCTIONS = {
+        sigmoid: ->(x) { 1.0 / (1.0 + Math.exp(-x)) },
+        tanh: ->(x) { Math.tanh(x) },
+        relu: ->(x) { x > 0 ? x : 0 }
+      }
+
+      DERIVATIVES = {
+        sigmoid: ->(y) { y * (1 - y) },
+        tanh: ->(y) { 1.0 - y**2 },
+        relu: ->(y) { y > 0 ? 1.0 : 0.0 }
+      }
+    end
+  end
+end
+

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -75,6 +75,15 @@ module Ai4r
         assert_approximate_equality_of_nested_list net.last_changes, x.last_changes
         assert_approximate_equality_of_nested_list net.activation_nodes, x.activation_nodes
       end
+      def test_activation_parameter
+        net = Backpropagation.new([2, 1], :tanh)
+        assert_equal :tanh, net.activation
+        assert_in_delta Math.tanh(0.5), net.instance_variable_get(:@propagation_function).call(0.5), 0.0001
+        net.set_parameters(activation: :relu)
+        assert_equal :relu, net.activation
+        assert_equal 0.0, net.instance_variable_get(:@derivative_propagation_function).call(-1.0)
+      end
+
 
     end
 


### PR DESCRIPTION
## Summary
- create activation functions module with sigmoid, tanh and relu
- update Backpropagation to accept `activation` parameter and map to functions
- store activation setting during marshal dump/load
- document activation usage
- test new activation parameter

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687186e84aa08326abca782d3607736d