### PR TITLE
Add genetic algorithm rate parameters

### DIFF
--- a/docs/genetic_algorithms.md
+++ b/docs/genetic_algorithms.md
@@ -34,8 +34,8 @@ class MyChromosome < Ai4r::GeneticAlgorithm::ChromosomeBase
   def fitness; ... end
 
   def self.seed; ... end
-  def self.reproduce(a, b); ... end
-  def self.mutate(chromosome); ... end
+  def self.reproduce(a, b, crossover_rate = 0.4); ... end
+  def self.mutate(chromosome, mutation_rate = 0.3); ... end
 end
 
 search = Ai4r::GeneticAlgorithm::GeneticSearch.new(50, 100, MyChromosome)
@@ -49,6 +49,24 @@ search = Ai4r::GeneticAlgorithm::GeneticSearch.new(50, 100, MyChromosome)
 search = Ai4r::GeneticAlgorithm::GeneticSearch.new(10, 20)
 result = search.run
 ```
+
+### Parameters
+
+`GeneticSearch` accepts optional `mutation_rate` and `crossover_rate` arguments which
+control how chromosomes change over generations. Defaults maintain the behaviour
+used by `TspChromosome`:
+
+```ruby
+search = Ai4r::GeneticAlgorithm::GeneticSearch.new(
+  10, 20, Ai4r::GeneticAlgorithm::TspChromosome,
+  0.3, # mutation_rate
+  0.4  # crossover_rate
+)
+```
+
+* `mutation_rate` – factor multiplied by `(1 - normalized_fitness)` when deciding
+  whether to mutate a chromosome (default `0.3`).
+* `crossover_rate` – probability that parents swap roles during reproduction (default `0.4`).
 
 Running the search with a larger population and more generations usually finds cheaper tours.
 

--- a/lib/ai4r/genetic_algorithm/chromosome_base.rb
+++ b/lib/ai4r/genetic_algorithm/chromosome_base.rb
@@ -19,11 +19,11 @@ module Ai4r
         raise NotImplementedError, 'Implement .seed in subclass'
       end
 
-      def self.reproduce(_a, _b)
+      def self.reproduce(_a, _b, _crossover_rate = 0.4)
         raise NotImplementedError, 'Implement .reproduce in subclass'
       end
 
-      def self.mutate(_chromosome)
+      def self.mutate(_chromosome, _mutation_rate = 0.3)
         raise NotImplementedError, 'Implement .mutate in subclass'
       end
     end

--- a/lib/ai4r/genetic_algorithm/genetic_algorithm.rb
+++ b/lib/ai4r/genetic_algorithm/genetic_algorithm.rb
@@ -36,13 +36,17 @@ module Ai4r
 
       attr_accessor :population
       attr_reader :chromosome_class
+      attr_accessor :mutation_rate, :crossover_rate
 
 
-      def initialize(initial_population_size, generations, chromosome_class = TspChromosome)
+      def initialize(initial_population_size, generations, chromosome_class = TspChromosome,
+                     mutation_rate = 0.3, crossover_rate = 0.4)
         @population_size = initial_population_size
         @max_generation = generations
         @generation = 0
         @chromosome_class = chromosome_class
+        @mutation_rate = mutation_rate
+        @crossover_rate = crossover_rate
       end
 
       #     1. Choose initial population
@@ -119,10 +123,14 @@ module Ai4r
       def reproduction(selected_to_breed)
         offsprings = []
         0.upto(selected_to_breed.length/2 - 1) do |i|
-          offsprings << @chromosome_class.reproduce(selected_to_breed[2 * i], selected_to_breed[2 * i + 1])
+          offsprings << @chromosome_class.reproduce(
+            selected_to_breed[2 * i],
+            selected_to_breed[2 * i + 1],
+            @crossover_rate
+          )
         end
         @population.each do |individual|
-          @chromosome_class.mutate(individual)
+          @chromosome_class.mutate(individual, @mutation_rate)
         end
         offsprings
       end

--- a/lib/ai4r/genetic_algorithm/tsp_chromosome.rb
+++ b/lib/ai4r/genetic_algorithm/tsp_chromosome.rb
@@ -16,8 +16,8 @@ module Ai4r
         @fitness
       end
 
-      def self.mutate(chromosome)
-        if chromosome.normalized_fitness && rand < ((1 - chromosome.normalized_fitness) * 0.3)
+      def self.mutate(chromosome, mutation_rate = 0.3)
+        if chromosome.normalized_fitness && rand < ((1 - chromosome.normalized_fitness) * mutation_rate)
           data = chromosome.data
           index = (0...data.length - 1).to_a.sample
           data[index], data[index + 1] = data[index + 1], data[index]
@@ -26,7 +26,7 @@ module Ai4r
         end
       end
 
-      def self.reproduce(a, b)
+      def self.reproduce(a, b, crossover_rate = 0.4)
         data_size = @@costs[0].length
         available = []
         0.upto(data_size - 1) { |n| available << n }
@@ -44,7 +44,7 @@ module Ai4r
           token = next_token
           available.delete(token)
           spawn << next_token
-          a, b = b, a if rand < 0.4
+          a, b = b, a if rand < crossover_rate
         end
         new(spawn)
       end


### PR DESCRIPTION
## Summary
- make `GeneticSearch` store `mutation_rate` and `crossover_rate`
- update `ChromosomeBase` interface with optional rate parameters
- update `TspChromosome` to use the provided rates
- describe the new arguments in the genetic algorithms docs

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_687189ec53888326a32713ac724f7cdd