### PR TITLE
Add Hopfield energy and convergence checks

### DIFF
--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -65,7 +65,41 @@ module Ai4r
         p = [-1,-1,-1,-1,-1,-1,-1,-1,1,1,1,1,1,1,-1,-1]
         assert_equal @data_set.data_items[2], net.eval(p)
         p = [-1,-1,1,1,1,1,1,1,-1,-1,-1,-1,1,-1,-1,-1]
-        assert_equal @data_set.data_items[3], net.eval(p)        
+        assert_equal @data_set.data_items[3], net.eval(p)
+      end
+
+      def test_energy
+        net = Hopfield.new
+        data_set = Ai4r::Data::DataSet.new :data_items => [[1,-1]]
+        net.train data_set
+        net.set_input([1,-1])
+        assert_equal(-1.0, net.energy)
+      end
+
+      class CountingHopfield < Hopfield
+        attr_reader :propagate_count
+        def propagate
+          @propagate_count ||= 0
+          @propagate_count += 1
+          super
+        end
+      end
+
+      def test_eval_convergence_break
+        data_set = Ai4r::Data::DataSet.new :data_items => [[1,-1]]
+        net = CountingHopfield.new
+        net.eval_iterations = 5
+        net.stop_when_stable = true
+        net.train data_set
+        assert_equal [-1,1], net.eval([-1,1])
+        assert_operator net.propagate_count, :<, 5
+
+        net2 = CountingHopfield.new
+        net2.eval_iterations = 5
+        net2.stop_when_stable = false
+        net2.train data_set
+        assert_equal [-1,1], net2.eval([-1,1])
+        assert_equal 5, net2.propagate_count
       end
 
     end


### PR DESCRIPTION
## Summary
- implement Hopfield energy computation
- optionally stop evaluation on stable energy
- test energy and convergence behaviour

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871899cdf0c83268b1a651d9ee4aed3