### PR TITLE
Add configurable weight initialization

### DIFF
--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -34,6 +34,17 @@ net.set_parameters(
 )
 ```
 
+Weight initialization can be selected with the `weight_init` parameter. Options
+are `:uniform`, `:xavier` and `:he`:
+
+```ruby
+net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3], :tanh, :xavier)
+net.set_parameters(weight_init: :he)
+```
+`uniform` replicates the classic random weights in `[-1, 1)`. `xavier` works
+well with sigmoid or tanh activations while `he` is better suited for ReLU
+networks.
+
 Alternatively you can simply specify the activation name:
 
 ```ruby

--- a/lib/ai4r/neural_network/weight_initializations.rb
+++ b/lib/ai4r/neural_network/weight_initializations.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# Author::    Sergio Fierens
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       https://github.com/SergioFierens/ai4r
+#
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+module Ai4r
+  module NeuralNetwork
+    # Collection of common weight initialization strategies.
+    module WeightInitializations
+      # Uniform distribution in [-1, 1)
+      def self.uniform
+        ->(_n, _i, _j) { rand * 2 - 1 }
+      end
+
+      # Xavier/Glorot initialization based on layer dimensions
+      def self.xavier(structure)
+        lambda do |layer, _i, _j|
+          limit = Math.sqrt(6.0 / (structure[layer] + structure[layer + 1]))
+          rand * 2 * limit - limit
+        end
+      end
+
+      # He initialization suitable for ReLU activations
+      def self.he(structure)
+        lambda do |layer, _i, _j|
+          limit = Math.sqrt(6.0 / structure[layer])
+          rand * 2 * limit - limit
+        end
+      end
+    end
+  end
+end

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -84,6 +84,17 @@ module Ai4r
         assert_equal 0.0, net.instance_variable_get(:@derivative_propagation_function).call(-1.0)
       end
 
+      def test_weight_init_parameter
+        net = Backpropagation.new([2, 2, 1], :sigmoid, :xavier).init_network
+        limit = Math.sqrt(6.0 / (2 + 2))
+        net.weights.first.flatten.each { |w| assert w.abs <= limit }
+
+        net.set_parameters(weight_init: :he)
+        net.init_network
+        limit = Math.sqrt(6.0 / 2)
+        net.weights.first.flatten.each { |w| assert w.abs <= limit }
+      end
+
 
     end
 


### PR DESCRIPTION
## Summary
- add `WeightInitializations` module with uniform, xavier and he
- allow specifying `weight_init` when building Backpropagation networks
- document weight initialization strategies
- test `weight_init` option

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718a58a4b88326acafe3f4525b7148