### PR TITLE
Add configurable update strategy for Hopfield network

### DIFF
--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -54,6 +54,28 @@ module Ai4r
         end
         assert_equal [1,1,-1,-1,1,1,-1,-1,1,1,-1,-1,1,1,-1,-1], pattern
       end
+
+      def test_run_async_sequential
+        net = Hopfield.new
+        net.update_strategy = :async_sequential
+        net.train @data_set
+        pattern = [1,1,-1,1,1,1,-1,-1,1,1,-1,-1,1,1,1,-1]
+        100.times do
+          pattern = net.run(pattern)
+        end
+        assert_equal [1,1,-1,-1,1,1,-1,-1,1,1,-1,-1,1,1,-1,-1], pattern
+      end
+
+      def test_run_synchronous
+        net = Hopfield.new
+        net.update_strategy = :synchronous
+        net.train @data_set
+        pattern = [1,1,-1,1,1,1,-1,-1,1,1,-1,-1,1,1,1,-1]
+        100.times do
+          pattern = net.run(pattern)
+        end
+        assert_equal [1,1,-1,-1,1,1,-1,-1,1,1,-1,-1,1,1,-1,-1], pattern
+      end
       
       def test_eval
         net = Hopfield.new


### PR DESCRIPTION
## Summary
- add `update_strategy` parameter to Hopfield network
- implement three propagation modes (`:async_random`, `:async_sequential`, `:synchronous`)
- extend Hopfield tests to cover the new strategies

## Testing
- `ruby -Ilib -Itest test/neural_network/hopfield_test.rb`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68718cea1c9483268b163cb75c27f3a2