### PR TITLE
Fix GA mutation fitness clearing

### DIFF
--- a/lib/ai4r/genetic_algorithm/tsp_chromosome.rb
+++ b/lib/ai4r/genetic_algorithm/tsp_chromosome.rb
@@ -22,7 +22,7 @@ module Ai4r
           index = (0...data.length - 1).to_a.sample
           data[index], data[index + 1] = data[index + 1], data[index]
           chromosome.data = data
-          @fitness = nil
+          chromosome.instance_variable_set(:@fitness, nil)
         end
       end
 

--- a/test/genetic_algorithm/chromosome_test.rb
+++ b/test/genetic_algorithm/chromosome_test.rb
@@ -51,6 +51,18 @@ module Ai4r
         assert_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], c3.data.sort)
       end
 
+      def test_mutate_recalculates_fitness
+        TspChromosome.set_cost_matrix(COST)
+        chromosome = TspChromosome.new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        original_fitness = chromosome.fitness
+        chromosome.normalized_fitness = 0.0
+        TspChromosome.mutate(chromosome, 1.0)
+        mutated_data = chromosome.data.dup
+        expected_fitness = TspChromosome.new(mutated_data).fitness
+        assert_equal expected_fitness, chromosome.fitness
+        assert_not_equal original_fitness, chromosome.fitness
+      end
+
     end
 
   end


### PR DESCRIPTION
## Summary
- clear chromosome fitness state in `mutate`
- test that mutation recalculates fitness

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718cfcf11c83269934b7022146c919