### PR TITLE
Add batch training helpers for neural nets

### DIFF
--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -6,16 +6,14 @@ AI4R includes a backpropagation neural network implementation. Neural networks i
 
 The library demonstrates a simple optical character recognition system. Patterns such as triangles, squares and crosses are represented by 16x16 matrices where pixels range from 0 (white) to 10 (black). The network has 256 input neurons and three outputs corresponding to the shapes.
 
-Training data looks like this:
+Training data looks like this using the `train_epochs` helper:
 
 ```ruby
 net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3])
 # TRIANGLE, SQUARE and CROSS are 16x16 matrices
-100.times do
-  net.train(TRIANGLE.flatten.map { |v| v.to_f / 10 }, [1,0,0])
-  net.train(SQUARE.flatten.map { |v| v.to_f / 10 }, [0,1,0])
-  net.train(CROSS.flatten.map { |v| v.to_f / 10 }, [0,0,1])
-end
+inputs  = [TRIANGLE, SQUARE, CROSS].map { |m| m.flatten.map { |v| v.to_f / 10 } }
+outputs = [[1,0,0], [0,1,0], [0,0,1]]
+net.train_epochs(inputs, outputs, epochs: 100, batch_size: 1)
 ```
 
 After training, the network can evaluate noisy patterns with good accuracy.
@@ -51,6 +49,12 @@ Alternatively you can simply specify the activation name:
 net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3], :tanh)
 net.set_parameters(activation: :relu)
 ```
+
+## Batch Training API
+
+Use `train_batch` to update the network with a list of examples and
+`train_epochs` to run multiple passes over the dataset. Both methods
+return the average loss for the processed data.
 
 For a recurrent associative network that can recall patterns from noisy inputs see the [Hopfield network](hopfield_network.md) document.
 

--- a/lib/ai4r/classifiers/multilayer_perceptron.rb
+++ b/lib/ai4r/classifiers/multilayer_perceptron.rb
@@ -75,13 +75,14 @@ module Ai4r
         @domains[0...-1].each {|domain| @inputs += domain.length}
         @structure = [@inputs] + @hidden_layers + [@outputs]
         @network = @network_class.new @structure
-        @training_iterations.times do
-          data_set.data_items.each do |data_item|
-            input_values = data_to_input(data_item[0...-1])
-            output_values = data_to_output(data_item.last)
-            @network.train(input_values, output_values)
-          end
+        inputs = []
+        outputs = []
+        data_set.data_items.each do |data_item|
+          inputs << data_to_input(data_item[0...-1])
+          outputs << data_to_output(data_item.last)
         end
+        @network.train_epochs(inputs, outputs,
+                              epochs: @training_iterations, batch_size: 1)
         return self
       end
       

--- a/lib/ai4r/neural_network/backpropagation.rb
+++ b/lib/ai4r/neural_network/backpropagation.rb
@@ -181,6 +181,36 @@ module Ai4r
         backpropagate(outputs)
         calculate_error(outputs)
       end
+
+      # Train a list of input/output pairs and return average loss.
+      def train_batch(batch_inputs, batch_outputs)
+        raise ArgumentError, "Inputs and outputs size mismatch" if batch_inputs.length != batch_outputs.length
+        sum_error = 0.0
+        batch_inputs.each_index do |i|
+          sum_error += train(batch_inputs[i], batch_outputs[i])
+        end
+        sum_error / batch_inputs.length.to_f
+      end
+
+      # Train for a number of epochs over the dataset. Optionally define a batch size.
+      # Returns an array with the average loss of each epoch.
+      def train_epochs(data_inputs, data_outputs, epochs:, batch_size: 1)
+        raise ArgumentError, "Inputs and outputs size mismatch" if data_inputs.length != data_outputs.length
+        losses = []
+        epochs.times do
+          epoch_error = 0.0
+          index = 0
+          while index < data_inputs.length
+            batch_in = data_inputs[index, batch_size]
+            batch_out = data_outputs[index, batch_size]
+            batch_error = train_batch(batch_in, batch_out)
+            epoch_error += batch_error * batch_in.length
+            index += batch_size
+          end
+          losses << epoch_error / data_inputs.length.to_f
+        end
+        losses
+      end
       
       # Initialize (or reset) activation nodes and weights, with the 
       # provided net structure and parameters.


### PR DESCRIPTION
## Summary
- add `train_batch` and `train_epochs` helpers in `Backpropagation`
- expose batch based training from `MultilayerPerceptron.build`
- show new API usage in docs

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718d406da88326a672325cf4fe2625