### PR TITLE
Validate Hopfield training data values

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -4,7 +4,7 @@ A Hopfield network is a recurrent neural network that stores patterns as stable 
 
 ## Input Format
 
-Training requires an `Ai4r::Data::DataSet` where each `data_item` is an array of values. Values should match the `active_node_value` and `inactive_node_value` parameters (by default `1` and `-1`). All patterns must have the same length.
+Training requires an `Ai4r::Data::DataSet` where each `data_item` is an array of values. Values must match the `active_node_value` and `inactive_node_value` parameters (by default `1` and `-1`). Any other value will cause `train` to raise `ArgumentError`. All patterns must have the same length.
 
 ```ruby
 require 'ai4r/neural_network/hopfield'

--- a/lib/ai4r/neural_network/hopfield.rb
+++ b/lib/ai4r/neural_network/hopfield.rb
@@ -65,6 +65,7 @@ require_relative '../data/parameterizable'
       # of the "memorized" patterns is not guaranteed.
       def train(data_set)
         @data_set = data_set
+        validate_training_data
         initialize_nodes(@data_set)
         initialize_weights(@data_set)
         return self
@@ -160,16 +161,28 @@ require_relative '../data/parameterizable'
         end
         @nodes = new_nodes
       end
-      
+
       # Initialize all nodes with "inactive" state.
       def initialize_nodes(data_set)
-        @nodes = Array.new(data_set.data_items.first.length, 
+        @nodes = Array.new(data_set.data_items.first.length,
           @inactive_node_value)
       end
-      
+
+      # Ensure training data only contains active or inactive values.
+      def validate_training_data
+        allowed = [@active_node_value, @inactive_node_value]
+        @data_set.data_items.each_with_index do |item, row|
+          item.each_with_index do |v, col|
+            unless allowed.include?(v)
+              raise ArgumentError, "Invalid value #{v} in item #{row}, position #{col}"
+            end
+          end
+        end
+      end
+
       # Create a partial weigth matrix:
-      #   [ 
-      #     [w(1,0)], 
+      #   [
+      #     [w(1,0)],
       #     [w(2,0)], [w(2,1)],
       #     [w(3,0)], [w(3,1)], [w(3,2)],
       #     ... 

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -124,6 +124,19 @@ module Ai4r
         assert_equal 5, net2.propagate_count
       end
 
+      def test_train_validates_values
+        net = Hopfield.new
+        invalid = Ai4r::Data::DataSet.new :data_items => [[1, 0, -1]]
+        assert_raise(ArgumentError) { net.train(invalid) }
+
+        net.active_node_value = 1
+        net.inactive_node_value = 0
+        valid = Ai4r::Data::DataSet.new :data_items => [[1,0,1,0]]
+        net.train(valid)
+        invalid2 = Ai4r::Data::DataSet.new :data_items => [[1,2,0]]
+        assert_raise(ArgumentError) { net.train(invalid2) }
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Summary
- validate Hopfield training data values
- document requirement in Hopfield docs
- test that invalid patterns raise ArgumentError

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718e9db948832699500800453848cd