### PR TITLE
Add loss_function option to Backpropagation

### DIFF
--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -50,6 +50,18 @@ net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3], :tanh)
 net.set_parameters(activation: :relu)
 ```
 
+## Loss Functions
+
+Backpropagation returns the training loss after each update. The default
+loss is mean squared error (`:mse`) which is suitable for regression or
+continuous outputs. For classification problems you can switch to
+cross entropy (`:cross_entropy`) which penalizes confident mistakes:
+
+```ruby
+net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3])
+net.set_parameters(loss_function: :cross_entropy)
+```
+
 ## Batch Training API
 
 Use `train_batch` to update the network with a list of examples and

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -95,6 +95,21 @@ module Ai4r
         net.weights.first.flatten.each { |w| assert w.abs <= limit }
       end
 
+      def test_loss_function_and_train_return
+        net = Backpropagation.new([1, 1])
+        assert_in_delta 0.125, net.calculate_loss([0], [0.5]), 0.0001
+        net.loss_function = :cross_entropy
+        assert_in_delta 0.6931, net.calculate_loss([1], [0.5]), 0.0001
+
+        net = Backpropagation.new([2, 1])
+        net.set_parameters(loss_function: :cross_entropy)
+        loss = net.train([0, 0], [0])
+        assert_in_delta net.calculate_loss([0], net.activation_nodes.last), loss, 0.0000001
+        net.set_parameters(loss_function: :mse)
+        loss = net.train([1, 1], [1])
+        assert_in_delta net.calculate_loss([1], net.activation_nodes.last), loss, 0.0000001
+      end
+
 
     end
 


### PR DESCRIPTION
## Summary
- extend Backpropagation with new `loss_function` parameter
- add `calculate_loss` supporting MSE and cross entropy
- update training code to return selected loss
- document how to select a loss function
- test both loss options and return value of `train`

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718ea72c0083268325e3ad75ebe55e