### PR TITLE
Add trace support for Hopfield eval

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -25,6 +25,25 @@ Evaluation uses the same vector format:
 result = net.eval(noisy_pattern)
 ```
 
+## Tracing Convergence
+
+Pass `trace: true` to `eval` to record the network state and energy after each
+iteration. The method returns a hash with `:states` and `:energies` arrays.
+
+```ruby
+trace = net.eval(noisy_pattern, trace: true)
+
+require 'gnuplot'
+Gnuplot.open do |gp|
+  Gnuplot::Plot.new(gp) do |plot|
+    plot.title = 'Hopfield Energy'
+    plot.data << Gnuplot::DataSet.new(trace[:energies]) { |ds| ds.with = 'lines' }
+  end
+end
+```
+
+The resulting plot shows how the energy decreases as the network converges.
+
 ## Parameters
 
 `Ai4r::NeuralNetwork::Hopfield` supports several parameters which can be set with `set_parameters`:

--- a/lib/ai4r/neural_network/hopfield.rb
+++ b/lib/ai4r/neural_network/hopfield.rb
@@ -89,17 +89,29 @@ require_relative '../data/parameterizable'
 
       # Propagates the input until the network returns one of the memorized
       # patterns, or a maximum of "eval_iterations" times.
-      def eval(input)
+      #
+      # If +trace: true+ is passed the method returns a hash with the
+      # :states and :energies recorded at every iteration (including the
+      # initial state). This can be used to visualize convergence.
+      def eval(input, trace: false)
         set_input(input)
         prev_energy = energy
+        if trace
+          states = [@nodes.clone]
+          energies = [prev_energy]
+        end
         @eval_iterations.times do
           propagate
-          return @nodes if @data_set.data_items.include?(@nodes)
           new_energy = energy
+          if trace
+            states << @nodes.clone
+            energies << new_energy
+          end
+          return(trace ? { states: states, energies: energies } : @nodes) if @data_set.data_items.include?(@nodes)
           break if @stop_when_stable && new_energy == prev_energy
           prev_energy = new_energy
         end
-        return @nodes
+        trace ? { states: states, energies: energies } : @nodes
       end
 
       # Calculate network energy using current node states and weights.

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -98,6 +98,19 @@ module Ai4r
         assert_equal(-1.0, net.energy)
       end
 
+      def test_eval_trace
+        net = Hopfield.new
+        net.eval_iterations = 10
+        net.train @data_set
+        pattern = [1,1,-1,1,1,1,-1,-1,1,1,-1,-1,1,1,1,-1]
+        trace = net.eval(pattern, trace: true)
+        assert_kind_of Hash, trace
+        assert_kind_of Array, trace[:states]
+        assert_kind_of Array, trace[:energies]
+        assert_equal trace[:states].length, trace[:energies].length
+        assert_equal @data_set.data_items[0], trace[:states].last
+      end
+
       class CountingHopfield < Hopfield
         attr_reader :propagate_count
         def propagate


### PR DESCRIPTION
## Summary
- allow Hopfield#eval to optionally return states and energies
- document convergence tracing
- test new trace behaviour

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718feb2dc483269ccf985fb67c9c82