### PR TITLE
Add ID3 tree export helpers and visualization example

### DIFF
--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -75,3 +75,17 @@ id3.prune!
 ```
 
 Further reading: [ID3 Algorithm](http://en.wikipedia.org/wiki/ID3_algorithm) and [Decision Trees](http://en.wikipedia.org/wiki/Decision_tree).
+
+## Tree Visualization
+
+The induced tree can be exported to a nested Ruby hash using `id3.to_h` or to
+GraphViz DOT format using `id3.to_graphviz`.
+
+```ruby
+id3 = ID3.new(DATA_SET, DATA_LABELS)
+dot = id3.to_graphviz
+File.write('tree.dot', dot)
+```
+
+Running `dot -Tpng tree.dot -o tree.png` will generate an image of the decision
+tree.

--- a/examples/classifiers/id3_graphviz_example.rb
+++ b/examples/classifiers/id3_graphviz_example.rb
@@ -1,0 +1,16 @@
+require File.dirname(__FILE__) + '/../../lib/ai4r/classifiers/id3'
+
+# Load the training data
+file = "#{File.dirname(__FILE__)}/id3_data.csv"
+data_set = Ai4r::Data::DataSet.new.load_csv_with_labels(file)
+
+# Build the tree
+id3 = Ai4r::Classifiers::ID3.new.build(data_set)
+
+# Export DOT representation
+File.open('id3_tree.dot', 'w') { |f| f.puts id3.to_graphviz }
+puts 'Decision tree saved to id3_tree.dot'
+
+# You can also inspect the tree as nested hashes
+p id3.to_h
+


### PR DESCRIPTION
## Summary
- add `to_h` and `to_graphviz` methods for ID3 trees
- expose same functionality from tree nodes
- document how to export ID3 trees to hashes and GraphViz DOT
- add example script producing a DOT file

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68718ff20c788326b1ba6a6b568d3868