### PR TITLE
Add epoch history and early stopping

### DIFF
--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -65,8 +65,26 @@ net.set_parameters(loss_function: :cross_entropy)
 ## Batch Training API
 
 Use `train_batch` to update the network with a list of examples and
-`train_epochs` to run multiple passes over the dataset. Both methods
-return the average loss for the processed data.
+`train_epochs` to run multiple passes over the dataset. `train_epochs`
+returns an array with the loss of each epoch so you can easily plot the
+learning curve. Training can also stop early by providing
+`early_stopping_patience` and `min_delta` parameters.
+
+```ruby
+history = net.train_epochs(
+  inputs, outputs,
+  epochs: 100,
+  batch_size: 1,
+  early_stopping_patience: 5,
+  min_delta: 0.001
+)
+
+require 'gruff'
+g = Gruff::Line.new
+g.title = 'Training Loss'
+g.data(:loss, history)
+g.write('loss.png')
+```
 
 For a recurrent associative network that can recall patterns from noisy inputs see the [Hopfield network](hopfield_network.md) document.
 

--- a/lib/ai4r/neural_network/backpropagation.rb
+++ b/lib/ai4r/neural_network/backpropagation.rb
@@ -196,9 +196,13 @@ module Ai4r
 
       # Train for a number of epochs over the dataset. Optionally define a batch size.
       # Returns an array with the average loss of each epoch.
-      def train_epochs(data_inputs, data_outputs, epochs:, batch_size: 1)
+      def train_epochs(data_inputs, data_outputs, epochs:, batch_size: 1,
+                       early_stopping_patience: nil, min_delta: 0.0)
         raise ArgumentError, "Inputs and outputs size mismatch" if data_inputs.length != data_outputs.length
         losses = []
+        best_loss = Float::INFINITY
+        patience = early_stopping_patience
+        patience_counter = 0
         epochs.times do
           epoch_error = 0.0
           index = 0
@@ -209,7 +213,17 @@ module Ai4r
             epoch_error += batch_error * batch_in.length
             index += batch_size
           end
-          losses << epoch_error / data_inputs.length.to_f
+          epoch_loss = epoch_error / data_inputs.length.to_f
+          losses << epoch_loss
+          if patience
+            if best_loss - epoch_loss > min_delta
+              best_loss = epoch_loss
+              patience_counter = 0
+            else
+              patience_counter += 1
+              break if patience_counter >= patience
+            end
+          end
         end
         losses
       end

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -110,6 +110,18 @@ module Ai4r
         assert_in_delta net.calculate_loss([1], net.activation_nodes.last), loss, 0.0000001
       end
 
+      def test_train_epochs_with_early_stopping
+        net = Backpropagation.new([1, 1])
+        # Mock train_batch to return predefined losses
+        losses = [0.5, 0.4, 0.41, 0.42]
+        net.define_singleton_method(:train_batch) do |_, _|
+          losses.shift
+        end
+        history = net.train_epochs([[0]], [[0]], epochs: 10, early_stopping_patience: 1)
+        assert_equal 3, history.length
+        assert history[0] > history[1]
+      end
+
 
     end
 


### PR DESCRIPTION
## Summary
- extend `train_epochs` to support early stopping
- return epoch loss history for charting
- document training curves example
- test early stopping logic

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68719000aaf08326bc2747c0cb5d40a8