### PR TITLE
Enhance OneR parameters with selection and tie-break

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rdoc'
+gem 'csv'
+gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rake (10.1.0)
+    csv (3.3.5)
+    json (1.8.6)
+    power_assert (2.0.5)
+    rake (13.3.0)
     rdoc (4.1.0)
+      json (~> 1.4)
+    test-unit (3.7.0)
+      power_assert
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  csv
   rake
   rdoc
+  test-unit
+
+BUNDLED WITH
+   2.6.7

--- a/lib/ai4r/classifiers/one_r.rb
+++ b/lib/ai4r/classifiers/one_r.rb
@@ -24,6 +24,14 @@ module Ai4r
       
       attr_reader :data_set, :rule
 
+      parameters_info :selected_attribute => 'Index of the attribute to force.',
+        :tie_break => 'Strategy when two attributes yield the same accuracy.'
+
+      def initialize
+        @selected_attribute = nil
+        @tie_break = :first
+      end
+
       # Build a new OneR classifier. You must provide a DataSet instance
       # as parameter. The last attribute of each item is considered as 
       # the item class.
@@ -38,9 +46,16 @@ module Ai4r
         end
         domains = @data_set.build_domains
         @rule = nil
-        domains[1...-1].each_index do |attr_index|
-          rule = build_rule(@data_set.data_items, attr_index, domains)
-          @rule = rule if !@rule || rule[:correct] > @rule[:correct]
+        if @selected_attribute
+          @rule = build_rule(@data_set.data_items, @selected_attribute, domains)
+        else
+          domains[1...-1].each_index do |attr_index|
+            rule = build_rule(@data_set.data_items, attr_index, domains)
+            if !@rule || rule[:correct] > @rule[:correct] ||
+              (rule[:correct] == @rule[:correct] && @tie_break == :last)
+              @rule = rule
+            end
+          end
         end
         return self
       end

--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -39,7 +39,7 @@ module Ai4r
       # Retrieve a new DataSet, with the item(s) selected by the provided 
       # index. You can specify an index range, too.
       def [](index)
-        selected_items = (index.is_a?(Fixnum)) ?
+        selected_items = (index.is_a?(Integer)) ?
                 [@data_items[index]] : @data_items[index]
         return DataSet.new(:data_items => selected_items,
                            :data_labels =>@data_labels)
@@ -187,7 +187,7 @@ module Ai4r
       #   get_index("gender") 
       #   => 2
       def get_index(attr)
-        return (attr.is_a?(Fixnum) || attr.is_a?(Range)) ? attr : @data_labels.index(attr)
+        return (attr.is_a?(Integer) || attr.is_a?(Range)) ? attr : @data_labels.index(attr)
       end
 
       # Raise an exception if there is no data item.

--- a/test/classifiers/one_r_test.rb
+++ b/test/classifiers/one_r_test.rb
@@ -57,6 +57,27 @@ class OneRTest < Test::Unit::TestCase
     eval(classifier.get_rules) 
     assert_equal("N", marketing_target)    
   end
+
+  def test_selected_attribute
+    classifier = OneR.new.set_parameters({:selected_attribute => 0}).build(
+      DataSet.new(:data_items => @@data_examples, :data_labels => @@data_labels))
+    assert_equal(0, classifier.rule[:attr_index])
+  end
+
+  def test_tie_break
+    tie_examples = [
+      ['A', 'X', 'foo', 'Y'],
+      ['B', 'X', 'foo', 'Y'],
+      ['A', 'Y', 'foo', 'Y'],
+      ['B', 'Y', 'foo', 'N']
+    ]
+    labels = ['att0', 'att1', 'att2', 'class']
+    ds = DataSet.new(:data_items => tie_examples, :data_labels => labels)
+    c_first = OneR.new.build(ds)
+    assert_equal(0, c_first.rule[:attr_index])
+    c_last = OneR.new.set_parameters({:tie_break => :last}).build(ds)
+    assert_equal(1, c_last.rule[:attr_index])
+  end
   
 end
 


### PR DESCRIPTION
## Summary
- add `parameters_info` to OneR to expose `selected_attribute` and `tie_break`
- respect a forced attribute in OneR#build and add tie-break behavior
- update DataSet for Ruby >=3 by using `Integer`
- extend OneR tests to cover parameter options
- update Gem dependencies for tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871905847e0832680cbd84d5127a461