### PR TITLE
Add configurable ZeroR parameters

### DIFF
--- a/lib/ai4r/classifiers/zero_r.rb
+++ b/lib/ai4r/classifiers/zero_r.rb
@@ -23,25 +23,55 @@ module Ai4r
     class ZeroR < Classifier
 
       attr_reader :data_set, :class_value
+
+      parameters_info :default_class => "Return this value when the provided " +
+        "dataset is empty.",
+        :tie_strategy => "Strategy used when more than one class has the " +
+          "same maximal frequency. Valid values are :first (default) " +
+          "and :random."
+
+      def initialize
+        @default_class = nil
+        @tie_strategy = :first
+      end
     
       # Build a new ZeroR classifier. You must provide a DataSet instance
       # as parameter. The last attribute of each item is considered as 
       # the item class.
       def build(data_set)
-        data_set.check_not_empty
         @data_set = data_set
-        frequencies = {}
+        if @data_set.data_items.empty?
+          @class_value = @default_class
+          return self
+        end
+
+        frequencies = Hash.new(0)
         max_freq = 0
-        @class_value = nil
+        tied_classes = []
+
         @data_set.data_items.each do |example|
           class_value = example.last
-          frequencies[class_value] = frequencies[class_value].nil? ? 1 : frequencies[class_value] + 1
+          frequencies[class_value] += 1
           class_frequency = frequencies[class_value]
-          if max_freq < class_frequency
+          if class_frequency > max_freq
             max_freq = class_frequency
-            @class_value = class_value
+            tied_classes = [class_value]
+          elsif class_frequency == max_freq && !tied_classes.include?(class_value)
+            tied_classes << class_value
           end
         end
+
+        if tied_classes.length == 1
+          @class_value = tied_classes.first
+        else
+          @class_value = case @tie_strategy
+                         when :random
+                           tied_classes.sample
+                         else
+                           tied_classes.first
+                         end
+        end
+
         return self
       end
       

--- a/test/classifiers/zero_r_test.rb
+++ b/test/classifiers/zero_r_test.rb
@@ -20,7 +20,8 @@ class ZeroRTest < Test::Unit::TestCase
   @@data_labels = [ 'city', 'age_range', 'gender', 'marketing_target'  ]
   
   def test_build
-    assert_raise(ArgumentError) { ZeroR.new.build(DataSet.new) } 
+    classifier = ZeroR.new.build(DataSet.new)
+    assert_nil(classifier.class_value)
     classifier = ZeroR.new.build(DataSet.new(:data_items => @@data_examples))
     assert_equal("Y", classifier.class_value)
     assert_equal("attribute_1", classifier.data_set.data_labels.first)
@@ -42,8 +43,23 @@ class ZeroRTest < Test::Unit::TestCase
     classifier = ZeroR.new.build(DataSet.new(:data_items => @@data_examples,
       :data_labels => @@data_labels))
     marketing_target = nil
-    eval(classifier.get_rules) 
+    eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
+  end
+
+  def test_default_class
+    classifier = ZeroR.new.set_parameters({:default_class => 'N'}).build(DataSet.new)
+    assert_equal('N', classifier.class_value)
+  end
+
+  def test_tie_strategy
+    data = [['a','Y'],['b','N'],['c','Y'],['d','N']]
+    data_set = DataSet.new(:data_items => data)
+    classifier = ZeroR.new.set_parameters({:tie_strategy => :first}).build(data_set)
+    assert_equal('Y', classifier.class_value)
+    srand(1)
+    classifier = ZeroR.new.set_parameters({:tie_strategy => :random}).build(data_set)
+    assert_equal('N', classifier.class_value)
   end
   
 end


### PR DESCRIPTION
## Summary
- allow :default_class and :tie_strategy options for ZeroR
- honour the options in the ZeroR build method
- test default class and tie strategy behaviour

## Testing
- `bundle exec rake test` *(fails: NameError: uninitialized constant Ai4r::Data::DataSet::Fixnum)*

------
https://chatgpt.com/codex/tasks/task_e_6871905b132483268c883567b19c3b6b