### PR TITLE
Add seedable SOM weight initialization

### DIFF
--- a/lib/ai4r/som/node.rb
+++ b/lib/ai4r/som/node.rb
@@ -39,10 +39,10 @@ module Ai4r
       # creates an instance of Node and instantiates the weights
       # the parameters is a uniq and sequential ID as well as the number of total nodes
       # dimensions signals the dimension of the input vector
-      def self.create(id, total, dimensions)
+      def self.create(id, total, dimensions, options = {})
         n = Node.new
         n.id = id
-        n.instantiate_weight dimensions
+        n.instantiate_weight dimensions, options
         n.x = id % total
         n.y = (id / total.to_f).to_i
         n
@@ -50,11 +50,17 @@ module Ai4r
 
       # instantiates the weights to the dimension (of the input vector)
       # for backup reasons, the instantiated weight is stored into @instantiated_weight  as well
-      def instantiate_weight(dimensions)
+      def instantiate_weight(dimensions, options = {})
+        opts = { range: 0..1, seed: nil }.merge(options)
+        srand(opts[:seed]) unless opts[:seed].nil?
+        range = opts[:range] || (0..1)
+        min = range.first.to_f
+        max = range.last.to_f
+        span = max - min
         @weights = Array.new dimensions
         @instantiated_weight = Array.new dimensions
         @weights.each_with_index do |weight, index|
-          @weights[index] = rand
+          @weights[index] = min + rand * span
           @instantiated_weight[index] = @weights[index]
         end
       end

--- a/lib/ai4r/som/som.rb
+++ b/lib/ai4r/som/som.rb
@@ -56,15 +56,17 @@ module Ai4r
       parameters_info :nodes  => "sets the architecture of the map (nodes x nodes)",
                       :dimension => "sets the dimension of the input",
                       :layer => "instance of a layer, defines how the training algorithm works",
-                      :epoch => "number of finished epochs"
+                      :epoch => "number of finished epochs",
+                      :init_weight_options => "Hash with :range and :seed to initialize node weights"
 
-      def initialize(dim, number_of_nodes, layer)
+      def initialize(dim, number_of_nodes, layer, init_weight_options = { range: 0..1, seed: nil })
         @layer = layer
         @dimension = dim
         @number_of_nodes = number_of_nodes
         @nodes = Array.new(number_of_nodes * number_of_nodes)
         @epoch = 0
         @cache = {}
+        @init_weight_options = init_weight_options
       end
 
       # finds the best matching unit (bmu) of a certain input in all the @nodes
@@ -135,8 +137,9 @@ module Ai4r
 
       # intitiates the map by creating (@number_of_nodes * @number_of_nodes) nodes
       def initiate_map
+        srand(@init_weight_options[:seed]) unless @init_weight_options[:seed].nil?
         @nodes.each_with_index do |node, i|
-          @nodes[i] = Node.create i, @number_of_nodes, @dimension
+          @nodes[i] = Node.create i, @number_of_nodes, @dimension, @init_weight_options
         end
       end
 

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -84,6 +84,22 @@ module Ai4r
         assert_equal 2, distancer(3, 2, 1, 3)
       end
 
+      def test_weight_options
+        som = Som.new 2, 2, Layer.new(3, 3), { range: -1..0, seed: 1 }
+        som.initiate_map
+        som.nodes.each do |node|
+          node.weights.each do |w|
+            assert w <= 0
+            assert w >= -1
+          end
+        end
+
+        other = Som.new 2, 2, Layer.new(3, 3)
+        other.set_parameters({ :init_weight_options => { range: -1..0, seed: 1 } })
+        other.initiate_map
+        assert_equal som.nodes.map(&:weights), other.nodes.map(&:weights)
+      end
+
       private
 
       def distancer(x1, y1, x2, y2)


### PR DESCRIPTION
## Summary
- allow custom random range and seed when initializing SOM weights
- plumb options through Som to Node
- expose options via `parameters_info`
- test deterministic weight setup

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_687192ef5e3c8326b075a32f2e8a2e4c