### PR TITLE
Add validation helpers and tests

### DIFF
--- a/examples/classifiers/id3_validation_example.rb
+++ b/examples/classifiers/id3_validation_example.rb
@@ -1,0 +1,21 @@
+require File.dirname(__FILE__) + '/../../lib/ai4r/classifiers/id3'
+require File.dirname(__FILE__) + '/../../lib/ai4r/classifiers/validation'
+require File.dirname(__FILE__) + '/../../lib/ai4r/data/data_set'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+file = "#{File.dirname(__FILE__)}/id3_data.csv"
+data_set = DataSet.new.load_csv_with_labels(file)
+
+train_set, test_set = Validation.train_test_split(data_set, 0.3)
+classifier = ID3.new.set_parameters(on_unknown: :most_frequent).build(train_set)
+
+correct = test_set.data_items.count do |item|
+  classifier.eval(item[0..-2]) == item.last
+end
+puts "Accuracy on test set: #{correct.to_f / test_set.data_items.length}"
+
+accuracies = Validation.evaluate_k_fold(ID3, data_set, 5, on_unknown: :most_frequent)
+puts "5-fold accuracies: #{accuracies.inspect}"
+puts "Average accuracy: #{accuracies.inject(:+) / accuracies.length}"

--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -27,6 +27,7 @@ require_relative 'ai4r/classifiers/zero_r'
 require_relative 'ai4r/classifiers/hyperpipes'
 require_relative 'ai4r/classifiers/naive_bayes'
 require_relative 'ai4r/classifiers/ib1'
+require_relative 'ai4r/classifiers/validation'
 # Neural networks
 require_relative 'ai4r/neural_network/backpropagation'
 require_relative 'ai4r/neural_network/hopfield'

--- a/lib/ai4r/classifiers/validation.rb
+++ b/lib/ai4r/classifiers/validation.rb
@@ -1,0 +1,70 @@
+module Ai4r
+  module Classifiers
+    # Utility helpers for classifier evaluation.
+    module Validation
+      module_function
+
+      # Split a data set into a training and test set. `test_ratio` specifies the
+      # proportion of items to place in the test set.
+      def train_test_split(data_set, test_ratio = 0.3, shuffle: true)
+        items = data_set.data_items.dup
+        items.shuffle! if shuffle
+        test_size = (items.length * test_ratio).round
+        test_items = items.slice(0, test_size)
+        train_items = items.slice(test_size, items.length - test_size)
+        [
+          Ai4r::Data::DataSet.new(data_items: train_items, data_labels: data_set.data_labels),
+          Ai4r::Data::DataSet.new(data_items: test_items,  data_labels: data_set.data_labels)
+        ]
+      end
+
+      # Divide a data set into +k+ folds for cross validation.
+      def k_folds(data_set, k, shuffle: true)
+        items = data_set.data_items.dup
+        items.shuffle! if shuffle
+        base = items.length / k
+        rem = items.length % k
+        sizes = Array.new(k, base)
+        rem.times { |i| sizes[i] += 1 }
+        folds = []
+        idx = 0
+        sizes.each do |s|
+          folds << Ai4r::Data::DataSet.new(
+            data_items: items.slice(idx, s),
+            data_labels: data_set.data_labels
+          )
+          idx += s
+        end
+        folds
+      end
+
+      # Perform k-fold cross validation. The +classifier_klass+ should be a class
+      # implementing the Classifier API. Optional +params+ will be passed to
+      # +set_parameters+ when available.
+      # Returns an array with the accuracy for each fold.
+      def evaluate_k_fold(classifier_klass, data_set, k, params = {})
+        folds = k_folds(data_set, k)
+        folds.each_index.map do |i|
+          test_set = folds[i]
+          train_items = []
+          folds.each_index do |j|
+            train_items.concat(folds[j].data_items) unless j == i
+          end
+          train_set = Ai4r::Data::DataSet.new(
+            data_items: train_items,
+            data_labels: data_set.data_labels
+          )
+          classifier = classifier_klass.new
+          classifier.set_parameters(params) if params && classifier.respond_to?(:set_parameters)
+          classifier.build(train_set)
+          correct = test_set.data_items.count do |item|
+            classifier.eval(item[0..-2]) == item.last
+          rescue Ai4r::Classifiers::ModelFailureError
+            false
+          end
+          correct.to_f / test_set.data_items.length
+        end
+      end
+    end
+  end
+end

--- a/test/classifiers/validation_test.rb
+++ b/test/classifiers/validation_test.rb
@@ -1,0 +1,48 @@
+require 'test/unit'
+require 'ai4r/classifiers/validation'
+require 'ai4r/classifiers/id3'
+require 'ai4r/data/data_set'
+
+class ValidationTest < Test::Unit::TestCase
+  include Ai4r::Classifiers
+  include Ai4r::Data
+
+  DATA_LABELS = %w(city age_range gender marketing_target)
+  DATA_ITEMS = [
+    ['New York', '<30', 'M', 'Y'],
+    ['Chicago', '<30', 'M', 'Y'],
+    ['Chicago', '<30', 'F', 'Y'],
+    ['New York', '<30', 'M', 'Y'],
+    ['New York', '<30', 'M', 'Y'],
+    ['Chicago', '[30-50)', 'M', 'Y'],
+    ['New York', '[30-50)', 'F', 'N'],
+    ['Chicago', '[30-50)', 'F', 'Y'],
+    ['New York', '[30-50)', 'F', 'N'],
+    ['Chicago', '[50-80]', 'M', 'N'],
+    ['New York', '[50-80]', 'F', 'N'],
+    ['New York', '[50-80]', 'M', 'N'],
+    ['Chicago', '[50-80]', 'M', 'N'],
+    ['New York', '[50-80]', 'F', 'N'],
+    ['Chicago', '>80', 'F', 'Y']
+  ]
+
+  def setup
+    @data_set = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
+  end
+
+  def test_train_test_split
+    train, test = Validation.train_test_split(@data_set, 0.2)
+    assert_equal @data_set.data_labels, train.data_labels
+    assert_equal @data_set.data_labels, test.data_labels
+    assert_equal DATA_ITEMS.length, train.data_items.length + test.data_items.length
+  end
+
+  def test_evaluate_k_fold
+    accuracies = Validation.evaluate_k_fold(ID3, @data_set, 5, on_unknown: :most_frequent)
+    assert_equal 5, accuracies.length
+    accuracies.each { |acc| assert_operator acc, :>=, 0.0 }
+    accuracies.each { |acc| assert_operator acc, :<=, 1.0 }
+    mean = accuracies.inject(:+) / accuracies.length
+    assert_in_delta 0.8, mean, 0.2
+  end
+end

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -101,6 +101,7 @@ module Ai4r
       def test_eval_trace
         net = Hopfield.new
         net.eval_iterations = 10
+        net.update_strategy = :async_sequential
         net.train @data_set
         pattern = [1,1,-1,1,1,1,-1,-1,1,1,-1,-1,1,1,1,-1]
         trace = net.eval(pattern, trace: true)


### PR DESCRIPTION
## Summary
- add `Ai4r::Classifiers::Validation` helper module
- demonstrate ID3 evaluation using the new utilities
- test train/test splits and k-fold accuracy helpers
- make Hopfield trace test deterministic

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687192ccc0f4832686b8e51f7866404e