### PR TITLE
Add deterministic seed support

### DIFF
--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -50,6 +50,16 @@ net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3], :tanh)
 net.set_parameters(activation: :relu)
 ```
 
+You can provide a `random_seed` to reproduce the same initial weights and
+inspect them through the `weights` and `activation_nodes` accessors:
+
+```ruby
+net = Ai4r::NeuralNetwork::Backpropagation.new([256, 3], random_seed: 123)
+net.init_network
+net.weights          # deterministic weights
+net.activation_nodes # initial activations
+```
+
 ## Loss Functions
 
 Backpropagation returns the training loss after each update. The default

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -95,6 +95,15 @@ module Ai4r
         net.weights.first.flatten.each { |w| assert w.abs <= limit }
       end
 
+      def test_random_seed_determinism
+        net1 = Backpropagation.new([2, 1], :sigmoid, :uniform, random_seed: 42).init_network
+        net2 = Backpropagation.new([2, 1], :sigmoid, :uniform, random_seed: 42).init_network
+        assert_equality_of_nested_list net1.weights, net2.weights
+
+        net3 = Backpropagation.new([2, 1], :sigmoid, :uniform, random_seed: 43).init_network
+        refute_equal net1.weights, net3.weights
+      end
+
       def test_loss_function_and_train_return
         net = Backpropagation.new([1, 1])
         assert_in_delta 0.125, net.calculate_loss([0], [0.5]), 0.0001


### PR DESCRIPTION
## Summary
- support deterministic weight seeding through new `random_seed` parameter
- expose read-only accessors for network state
- document reproducible initialization
- test deterministic initialization

## Testing
- `bundle exec rake test` *(fails: test_eval_trace in HopfieldTest)*

------
https://chatgpt.com/codex/tasks/task_e_687192d158c88326932cf3551de09532