### PR TITLE
Support rectangular SOM grids

### DIFF
--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -189,7 +189,6 @@ module Ai4r
         domain = domain(data_examples)
         return CategoryNode.new(@data_set.category_label, domain.last[0]) if domain.last.length == 1
 
-<<<<<<< HEAD
         best_index = nil
         best_entropy = nil
         best_split = nil
@@ -473,19 +472,28 @@ module Ai4r
 
     class EvaluationNode #:nodoc: all
 
-      attr_reader :index, :values, :nodes, :numeric, :threshold
+      attr_reader :index, :values, :nodes, :numeric, :threshold, :majority
 
-      def initialize(data_labels, index, values_or_threshold, nodes, numeric=false)
+      # The last parameter can either be a boolean flag indicating a numeric
+      # split, or the majority class value for this node.
+      def initialize(data_labels, index, values_or_threshold, nodes, param=nil)
         @index = index
-        @numeric = numeric
-        if numeric
+        if param == true || param == false
+          @numeric = param
+          @majority = nil
+        else
+          @numeric = false
+          @majority = param
+        end
+
+        if @numeric
           @threshold = values_or_threshold
           @values = nil
         else
           @values = values_or_threshold
         end
+
         @nodes = nodes
-        @majority = majority
         @data_labels = data_labels
       end
 
@@ -498,6 +506,7 @@ module Ai4r
           return ErrorNode.new.value(data) unless @values.include?(value)
           @nodes[@values.index(value)].value(data)
         end
+      end
 
       def value(data, classifier)
         value = data[@index]
@@ -511,7 +520,7 @@ module Ai4r
             return ErrorNode.new.value(data, classifier)
           end
         end
-        return nodes[@values.index(value)].value(data, classifier)
+        @nodes[@values.index(value)].value(data, classifier)
       end
 
       def get_rules

--- a/lib/ai4r/som/node.rb
+++ b/lib/ai4r/som/node.rb
@@ -38,14 +38,17 @@ module Ai4r
                       :id => "id of the node"      
 
       # creates an instance of Node and instantiates the weights
-      # the parameters is a uniq and sequential ID as well as the number of total nodes
-      # dimensions signals the dimension of the input vector
-      def self.create(id, total, dimensions, options = {})
+      #
+      # +id+:: unique identifier for this node
+      # +rows+:: number of rows of the SOM grid
+      # +columns+:: number of columns of the SOM grid
+      # +dimensions+:: dimension of the input vector
+      def self.create(id, rows, columns, dimensions, options = {})
         n = Node.new
         n.id = id
         n.instantiate_weight dimensions, options
-        n.x = id % total
-        n.y = (id / total.to_f).to_i
+        n.x = id % columns
+        n.y = (id / columns.to_f).to_i
         n
       end
 

--- a/lib/ai4r/som/som.rb
+++ b/lib/ai4r/som/som.rb
@@ -42,7 +42,8 @@ module Ai4r
     #
     # = Parameters
     # * dim => dimension of the input vector
-    # * number_of_nodes => is the number of nodes per row/column (square som).
+    # * rows => number of rows for the map
+    # * columns => number of columns for the map
     # * layer => instante of a layer-algorithm class
     #
     # = About the project
@@ -54,17 +55,20 @@ module Ai4r
 
       include Ai4r::Data::Parameterizable
 
-      parameters_info :nodes  => "sets the architecture of the map (nodes x nodes)",
+      parameters_info :rows  => "number of rows for the map",
+                      :columns => "number of columns for the map",
+                      :nodes => "array holding all nodes of the map",
                       :dimension => "sets the dimension of the input",
                       :layer => "instance of a layer, defines how the training algorithm works",
                       :epoch => "number of finished epochs",
                       :init_weight_options => "Hash with :range and :seed to initialize node weights"
 
-      def initialize(dim, number_of_nodes, layer, init_weight_options = { range: 0..1, seed: nil })
+      def initialize(dim, rows, columns, layer, init_weight_options = { range: 0..1, seed: nil })
         @layer = layer
         @dimension = dim
-        @number_of_nodes = number_of_nodes
-        @nodes = Array.new(number_of_nodes * number_of_nodes)
+        @rows = rows
+        @columns = columns
+        @nodes = Array.new(rows * columns)
         @epoch = 0
         @cache = {}
         @init_weight_options = init_weight_options
@@ -130,19 +134,19 @@ module Ai4r
         false
       end
 
-      # returns the node at position (x,y) in the square map
+      # returns the node at position (x,y) in the map
       def get_node(x, y)
         if check_param_for_som(x, y)
           raise ArgumentError, "invalid node coordinates (#{x}, #{y})"
         end
-        @nodes[y + x * @number_of_nodes]
+        @nodes[y + x * @columns]
       end
 
-      # intitiates the map by creating (@number_of_nodes * @number_of_nodes) nodes
+      # intitiates the map by creating (@rows * @columns) nodes
       def initiate_map
         srand(@init_weight_options[:seed]) unless @init_weight_options[:seed].nil?
         @nodes.each_with_index do |node, i|
-          @nodes[i] = Node.create i, @number_of_nodes, @dimension, @init_weight_options
+          @nodes[i] = Node.create i, @rows, @columns, @dimension, @init_weight_options
         end
       end
 
@@ -151,7 +155,7 @@ module Ai4r
       # checks whether or not there is a node in the map at the coordinates (x,y).
       # x is the row, y the column indicator
       def check_param_for_som(x, y)
-        y > @number_of_nodes - 1 || x > @number_of_nodes - 1  || x < 0 || y < 0
+        y > @columns - 1 || x > @rows - 1  || x < 0 || y < 0
       end
 
     end

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -20,7 +20,7 @@ module Ai4r
     class SomTest < Test::Unit::TestCase
 
       def setup
-        @som = Som.new 2, 5, Layer.new(3, 3)
+        @som = Som.new 2, 5, 5, Layer.new(3, 3)
         @som.initiate_map
       end
 
@@ -83,7 +83,7 @@ module Ai4r
       end
 
       def test_weight_options
-        som = Som.new 2, 2, Layer.new(3, 3), { range: -1..0, seed: 1 }
+        som = Som.new 2, 2, 2, Layer.new(3, 3), { range: -1..0, seed: 1 }
         som.initiate_map
         som.nodes.each do |node|
           node.weights.each do |w|
@@ -92,10 +92,19 @@ module Ai4r
           end
         end
 
-        other = Som.new 2, 2, Layer.new(3, 3)
+        other = Som.new 2, 2, 2, Layer.new(3, 3)
         other.set_parameters({ :init_weight_options => { range: -1..0, seed: 1 } })
         other.initiate_map
         assert_equal som.nodes.map(&:weights), other.nodes.map(&:weights)
+      end
+
+      def test_rectangular_node_positions
+        som = Som.new 1, 2, 3, Layer.new(3, 3)
+        som.initiate_map
+        assert_equal 6, som.nodes.length
+        assert_equal [0, 0], [som.get_node(0, 0).x, som.get_node(0, 0).y]
+        assert_equal [2, 0], [som.get_node(0, 2).x, som.get_node(0, 2).y]
+        assert_equal [1, 1], [som.get_node(1, 1).x, som.get_node(1, 1).y]
       end
 
       private


### PR DESCRIPTION
## Summary
- generalize SOM grid to use separate row and column counts
- update node creation to position using rows and columns
- expose nodes through Parameterizable again
- fix broken ID3 file to run tests
- cover rectangular node positions in the SOM tests

## Testing
- `bundle exec rake test` *(fails: 1 failures, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68719a89d1d48326aecd7a448ecb3212