### PR TITLE
Update eval for hierarchical clusterers

### DIFF
--- a/lib/ai4r/clusterers/average_linkage.rb
+++ b/lib/ai4r/clusterers/average_linkage.rb
@@ -42,8 +42,8 @@ module Ai4r
 
       # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
-      def eval(data_item)
-        raise "Eval of new data is not supported by this algorithm."
+      def eval(_data_item)
+        raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
       protected

--- a/lib/ai4r/clusterers/centroid_linkage.rb
+++ b/lib/ai4r/clusterers/centroid_linkage.rb
@@ -45,8 +45,8 @@ module Ai4r
 
       # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
-      def eval(data_item)
-        raise "Eval of new data is not supported by this algorithm."
+      def eval(_data_item)
+        raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
       protected

--- a/lib/ai4r/clusterers/median_linkage.rb
+++ b/lib/ai4r/clusterers/median_linkage.rb
@@ -42,8 +42,8 @@ module Ai4r
 
       # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
-      def eval(data_item)
-        raise "Eval of new data is not supported by this algorithm."
+      def eval(_data_item)
+        raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
       protected

--- a/lib/ai4r/clusterers/ward_linkage.rb
+++ b/lib/ai4r/clusterers/ward_linkage.rb
@@ -42,8 +42,8 @@ module Ai4r
 
       # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
-      def eval(data_item)
-        raise "Eval of new data is not supported by this algorithm."
+      def eval(_data_item)
+        raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
       protected

--- a/lib/ai4r/clusterers/weighted_average_linkage.rb
+++ b/lib/ai4r/clusterers/weighted_average_linkage.rb
@@ -41,8 +41,8 @@ module Ai4r
 
       # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
-      def eval(data_item)
-        raise "Eval of new data is not supported by this algorithm."
+      def eval(_data_item)
+        raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
       protected

--- a/test/clusterers/average_linkage_test.rb
+++ b/test/clusterers/average_linkage_test.rb
@@ -47,4 +47,9 @@ class AverageLinkageTest < Test::Unit::TestCase
     assert_equal 37.5, clusterer.linkage_distance(4,2,5)
   end
 
+  def test_eval_unsupported
+    clusterer = Ai4r::Clusterers::AverageLinkage.new
+    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
+
 end

--- a/test/clusterers/centroid_linkage_test.rb
+++ b/test/clusterers/centroid_linkage_test.rb
@@ -49,4 +49,9 @@ class Ai4r::Clusterers::CentroidLinkageTest < Test::Unit::TestCase
     assert_equal 15.25, clusterer.linkage_distance(4,2,5)
   end
 
+  def test_eval_unsupported
+    clusterer = Ai4r::Clusterers::CentroidLinkage.new
+    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
+
 end

--- a/test/clusterers/median_linkage_test.rb
+++ b/test/clusterers/median_linkage_test.rb
@@ -49,4 +49,9 @@ class Ai4r::Clusterers::MedianLinkageTest < Test::Unit::TestCase
     assert_equal 15.25, clusterer.linkage_distance(4,2,5)
   end
 
+  def test_eval_unsupported
+    clusterer = Ai4r::Clusterers::MedianLinkage.new
+    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
+
 end

--- a/test/clusterers/ward_linkage_test.rb
+++ b/test/clusterers/ward_linkage_test.rb
@@ -49,4 +49,9 @@ class Ai4r::Clusterers::WardLinkageTest < Test::Unit::TestCase
     assert_equal 27.75, clusterer.linkage_distance(4,2,5)
   end
 
+  def test_eval_unsupported
+    clusterer = Ai4r::Clusterers::WardLinkage.new
+    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
+
 end

--- a/test/clusterers/weighted_average_linkage_test.rb
+++ b/test/clusterers/weighted_average_linkage_test.rb
@@ -48,4 +48,9 @@ class Ai4r::Clusterers::WeightedAverageLinkageTest < Test::Unit::TestCase
     assert_equal 93.5, clusterer.linkage_distance(0,1,2)
     assert_equal 37.5, clusterer.linkage_distance(4,2,5)
   end
+
+  def test_eval_unsupported
+    clusterer = Ai4r::Clusterers::WeightedAverageLinkage.new
+    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
 end


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` in hierarchical clusterers' `eval`
- test that the five linkage algorithms raise

## Testing
- `bundle exec rake test` *(fails: 1 failure, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68719c29a1088326800204b304676ba7