### PR TITLE
Add deterministic KMeans option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,6 +65,15 @@ z-score normalization, but you can also use `:minmax` to scale values to the
   Ai4r::Data::DataSet.normalized(data, method: :minmax)
   data.normalize!  # in place using z-score
 
+== KMeans random seed
+
+The ``random_seed'' parameter makes KMeans deterministic by seeding Ruby's
+RNG before choosing initial centroids.
+
+  data = Ai4r::Data::DataSet.new(:data_items => [[1, 2], [3, 4], [5, 6]])
+  kmeans = Ai4r::Clusterers::KMeans.new
+  kmeans.set_parameters(:random_seed => 1).build(data, 2)
+
 = Documentation
 
 Tutorials for genetic algorithms, ID3 decision trees and neural networks are available in the +docs/+ directory.

--- a/lib/ai4r/clusterers/k_means.rb
+++ b/lib/ai4r/clusterers/k_means.rb
@@ -25,15 +25,15 @@ module Ai4r
       attr_reader :data_set, :number_of_clusters
       attr_reader :clusters, :centroids, :iterations
       
-      parameters_info :max_iterations => "Maximum number of iterations to " + 
+      parameters_info :max_iterations => "Maximum number of iterations to " +
         "build the clusterer. By default it is uncapped.",
         :distance_function => "Custom implementation of distance function. " +
           "It must be a closure receiving two data items and return the " +
-          "distance between them. By default, this algorithm uses " + 
+          "distance between them. By default, this algorithm uses " +
           "euclidean distance of numeric attributes to the power of 2.",
         :centroid_function => "Custom implementation to calculate the " +
           "centroid of a cluster. It must be a closure receiving an array of " +
-          "data sets, and return an array of data items, representing the " + 
+          "data sets, and return an array of data items, representing the " +
           "centroids of for each data set. " +
           "By default, this algorithm returns a data items using the mode "+
           "or mean of each attribute on each data set.",
@@ -41,19 +41,22 @@ module Ai4r
           "the initial centroids.  Otherwise, the initial centroids will be " +
           "assigned randomly from the data set.",
         :on_empty => "Action to take if a cluster becomes empty, with values " +
-          "'eliminate' (the default action, eliminate the empty cluster), " + 
+          "'eliminate' (the default action, eliminate the empty cluster), " +
           "'terminate' (terminate with error), 'random' (relocate the " +
-          "empty cluster to a random point), 'outlier' (relocate the " + 
-          "empty cluster to the point furthest from its centroid)."
+          "empty cluster to a random point), 'outlier' (relocate the " +
+          "empty cluster to the point furthest from its centroid).",
+        :random_seed => "Seed value used to initialize Ruby's random number " +
+          "generator when selecting random centroids."
       
       def initialize
         @distance_function = nil
         @max_iterations = nil
-        @centroid_function = lambda do |data_sets| 
+        @centroid_function = lambda do |data_sets|
           data_sets.collect{ |data_set| data_set.get_mean_or_mode}
         end
         @centroid_indices = []
         @on_empty = 'eliminate' # default if none specified
+        @random_seed = nil
       end
       
       
@@ -138,6 +141,7 @@ module Ai4r
         tried_indexes = []
         case populate_method
         when 'random' # for initial assignment (without the :centroid_indices option) and for reassignment of empty cluster centroids (with :on_empty option 'random')
+          srand(@random_seed) if @random_seed
           while @centroids.length < number_of_clusters &&
               tried_indexes.length < @data_set.data_items.length
             random_index = (0...@data_set.data_items.length).to_a.sample

--- a/test/clusterers/k_means_test.rb
+++ b/test/clusterers/k_means_test.rb
@@ -131,6 +131,13 @@ class KMeansTest < Test::Unit::TestCase
     assert_equal("Invalid centroid index #{@@data.size+10}", exception.message)
   end
 
+  def test_random_seed
+    data_set = DataSet.new(:data_items => @@data, :data_labels => ["X", "Y"])
+    clusterer1 = KMeans.new.set_parameters(:random_seed => 1).build(data_set, 4)
+    clusterer2 = KMeans.new.set_parameters(:random_seed => 1).build(data_set, 4)
+    assert_equal clusterer1.centroids, clusterer2.centroids
+  end
+
   def test_on_empty
     data_set = DataSet.new(:data_items => @@empty_cluster_data, :data_labels => ["X", "Y"])
     clusterer = KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices}).build(data_set, @@empty_centroid_indices.size)


### PR DESCRIPTION
## Summary
- allow seeding of RNG via `:random_seed`
- document deterministic mode in README
- add test ensuring clusters repeat with a seed

## Testing
- `rake test` *(fails: ID3Test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68719c4e3efc8326a04148aaf943592a