### PR TITLE
Add SSE metric and silhouette support

### DIFF
--- a/lib/ai4r/clusterers/k_means.rb
+++ b/lib/ai4r/clusterers/k_means.rb
@@ -79,8 +79,21 @@ module Ai4r
       # Classifies the given data item, returning the cluster index it belongs 
       # to (0-based).
       def eval(data_item)
-        get_min_index(@centroids.collect {|centroid| 
+        get_min_index(@centroids.collect {|centroid|
             distance(data_item, centroid)})
+      end
+
+      # Sum of squared distances of all points to their respective centroids.
+      # It can be used as a measure of cluster compactness (SSE).
+      def sse
+        sum = 0.0
+        @clusters.each_with_index do |cluster, i|
+          centroid = @centroids[i]
+          cluster.data_items.each do |item|
+            sum += distance(item, centroid)
+          end
+        end
+        sum
       end
       
       # This function calculates the distance between 2 different

--- a/lib/ai4r/clusterers/single_linkage.rb
+++ b/lib/ai4r/clusterers/single_linkage.rb
@@ -86,6 +86,49 @@ module Ai4r
 
       protected
 
+      def distance_between_indexes(i, j)
+        @distance_function.call(@data_set.data_items[i], @data_set.data_items[j])
+      end
+
+      public
+
+      # Compute mean silhouette coefficient of the clustering result.
+      # Returns a float between -1 and 1. Only valid after build.
+      def silhouette
+        return nil unless @index_clusters && @data_set
+        total = 0.0
+        count = @data_set.data_items.length
+
+        @index_clusters.each_with_index do |cluster, ci|
+          cluster.each do |index|
+            a = 0.0
+            if cluster.length > 1
+              cluster.each do |j|
+                next if j == index
+                a += distance_between_indexes(index, j)
+              end
+              a /= (cluster.length - 1)
+            end
+
+            b = nil
+            @index_clusters.each_with_index do |other_cluster, cj|
+              next if ci == cj
+              dist = 0.0
+              other_cluster.each do |j|
+                dist += distance_between_indexes(index, j)
+              end
+              dist /= other_cluster.length
+              b = dist if b.nil? || dist < b
+            end
+            s = b && b > 0 ? (b - a) / [a, b].max : 0.0
+            total += s
+          end
+        end
+
+        total / count
+      end
+      protected
+
       # returns [ [0], [1], [2], ... , [n-1] ]
       # where n is the number of data items in the data set
       def create_initial_index_clusters

--- a/test/clusterers/hierarchical_silhouette_test.rb
+++ b/test/clusterers/hierarchical_silhouette_test.rb
@@ -1,0 +1,14 @@
+require 'test/unit'
+require 'ai4r/clusterers/ward_linkage'
+
+class HierarchicalSilhouetteTest < Test::Unit::TestCase
+  include Ai4r::Clusterers
+  include Ai4r::Data
+
+  DATA = [[1,1],[1,2],[2,1],[2,2],[8,8],[8,9],[9,8],[9,9]]
+
+  def test_silhouette
+    clusterer = WardLinkage.new.build(DataSet.new(:data_items => DATA), 2)
+    assert_in_delta 0.98639, clusterer.silhouette, 0.0001
+  end
+end

--- a/test/clusterers/k_means_test.rb
+++ b/test/clusterers/k_means_test.rb
@@ -18,6 +18,8 @@ class KMeansTest < Test::Unit::TestCase
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
 
+  @@sse_data = [[1,1],[1,2],[2,1],[2,2],[8,8],[8,9],[9,8],[9,9]]
+
   # k-means will generate an empty cluster with this data and initial centroid assignment
   @@empty_cluster_data = [[-0.1, 0], [0, 0], [0.1, 0], [-0.1, 10], [0.1, 10], [0.2, 10]]
   @@empty_centroid_indices = [0,1,2]
@@ -149,6 +151,12 @@ class KMeansTest < Test::Unit::TestCase
     clusterer = KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices, :on_empty=>'outlier'}).build(data_set, @@empty_centroid_indices.size)
     # Verify that cluster was not eliminated
     assert_equal @@empty_centroid_indices.size, clusterer.clusters.length
+  end
+
+  def test_sse
+    data_set = DataSet.new(:data_items => @@sse_data)
+    clusterer = KMeans.new.set_parameters(:centroid_indices => [0,4]).build(data_set, 2)
+    assert_in_delta 4.0, clusterer.sse, 0.0001
   end
 
   private


### PR DESCRIPTION
## Summary
- implement `sse` method for k-means clustering
- support silhouette score for hierarchical clusterers
- test SSE with simple clusters
- test silhouette for ward linkage

## Testing
- `bundle exec rake test` *(fails: 1 failure, 2 errors)*
- `bundle exec ruby -Ilib:test test/clusterers/k_means_test.rb -n test_sse`
- `bundle exec ruby -Ilib:test test/clusterers/hierarchical_silhouette_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_68719c545d48832693545b2f28b857ee