### PR TITLE
Add cluster tree mixin for hierarchical clusterers

### DIFF
--- a/docs/hierarchical_clustering.md
+++ b/docs/hierarchical_clustering.md
@@ -1,0 +1,27 @@
+# Hierarchical Clustering
+
+AI4R includes several agglomerative algorithms such as SingleLinkage,
+CompleteLinkage and WardLinkage.  All hierarchical clusterers expose a
+`cluster_tree` array storing the clusters at each merge step when the
+clusterer is built.
+
+```ruby
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [[0,0],[0,1],[1,0],[1,1]]
+set = DataSet.new(data_items: points)
+clusterer = SingleLinkage.new.build(set, 1)
+puts clusterer.cluster_tree.size       # => 4
+puts clusterer.cluster_tree.last.size  # => 4
+```
+
+The first element of the array contains the final cluster and the last
+captures the initial individual points. You can limit the depth by
+passing a value to the constructor.
+
+## Plotting a dendrogram
+
+The example `examples/clusterers/dendrogram_example.rb` shows how to
+plot the recorded tree using the `dendrogram` gem.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ require 'ai4r'
 * **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
 * **Neural Networks** – simple OCR recognition of visual patterns.
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
+* [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * **Automatic Classifiers** – identify relevant marketing targets using decision trees.
 
 ## Contact

--- a/examples/clusterers/dendrogram_example.rb
+++ b/examples/clusterers/dendrogram_example.rb
@@ -1,0 +1,18 @@
+require 'ai4r'
+require 'dendrograms'
+
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [[0,0],[0,1],[1,0],[1,1]]
+data = DataSet.new(data_items: points)
+
+clusterer = WardLinkage.new.build(data, 1)
+
+# Convert stored tree to a simple array of point sets
+steps = clusterer.cluster_tree.map do |clusters|
+  clusters.map(&:data_items)
+end
+
+Dendrograms::Dendrogram.new(steps).draw('dendrogram.png')
+puts 'Dendrogram saved to dendrogram.png'

--- a/lib/ai4r/clusterers/average_linkage.rb
+++ b/lib/ai4r/clusterers/average_linkage.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/data_set'
 require_relative '../clusterers/single_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -26,6 +27,8 @@ module Ai4r
     #
     #   D(cx, (ci U cj) = (D(cx, ci) + D(cx, cj)) / 2
     class AverageLinkage < SingleLinkage
+
+      include ClusterTree
 
       parameters_info :distance_function =>
           "Custom implementation of distance function. " +

--- a/lib/ai4r/clusterers/centroid_linkage.rb
+++ b/lib/ai4r/clusterers/centroid_linkage.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/data_set'
 require_relative '../clusterers/single_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -29,6 +30,8 @@ module Ai4r
     #                       (nj/(ni+nj))*D(cx, cj) -
     #                       (ni*nj/(ni+nj)^2)*D(ci, cj)
     class CentroidLinkage < SingleLinkage
+
+      include ClusterTree
 
     parameters_info :distance_function =>
           "Custom implementation of distance function. " +

--- a/lib/ai4r/clusterers/cluster_tree.rb
+++ b/lib/ai4r/clusterers/cluster_tree.rb
@@ -1,0 +1,37 @@
+module Ai4r
+  module Clusterers
+    # Mixin to capture merge steps during agglomerative clustering.
+    # Stores intermediate clusters in +cluster_tree+. Optional +depth+
+    # limits how many last merges are recorded.
+    module ClusterTree
+      attr_reader :cluster_tree
+
+      def initialize(depth = nil, *args)
+        @cluster_tree = []
+        @depth = depth
+        @merges_so_far = 0
+        super(*args)
+      end
+
+      def build(data_set, number_of_clusters = 1, **options)
+        @total_merges = data_set.data_items.length - number_of_clusters
+        super
+        @cluster_tree << self.clusters
+        @cluster_tree.reverse!
+        self
+      end
+
+      protected
+
+      def merge_clusters(index_a, index_b, index_clusters)
+        if @depth.nil? || @merges_so_far > @total_merges - @depth
+          stored_distance_matrix = @distance_matrix.dup
+          @cluster_tree << build_clusters_from_index_clusters(index_clusters)
+          @distance_matrix = stored_distance_matrix
+        end
+        @merges_so_far += 1
+        super
+      end
+    end
+  end
+end

--- a/lib/ai4r/clusterers/complete_linkage.rb
+++ b/lib/ai4r/clusterers/complete_linkage.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/data_set'
 require_relative '../clusterers/single_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -24,6 +25,8 @@ module Ai4r
     #
     #   D(cx, (ci U cj) = max(D(cx, ci), D(cx, cj))
     class CompleteLinkage < SingleLinkage
+
+      include ClusterTree
 
       parameters_info :distance_function =>
           "Custom implementation of distance function. " +

--- a/lib/ai4r/clusterers/median_linkage.rb
+++ b/lib/ai4r/clusterers/median_linkage.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/data_set'
 require_relative '../clusterers/single_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -26,6 +27,8 @@ module Ai4r
     #                       (1/2)*D(cx, cj) -
     #                       (1/4)*D(ci, cj)
     class MedianLinkage < SingleLinkage
+
+      include ClusterTree
 
     parameters_info :distance_function =>
           "Custom implementation of distance function. " +

--- a/lib/ai4r/clusterers/single_linkage.rb
+++ b/lib/ai4r/clusterers/single_linkage.rb
@@ -11,6 +11,7 @@
 require_relative '../data/data_set'
 require_relative '../data/proximity'
 require_relative '../clusterers/clusterer'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -25,6 +26,8 @@ module Ai4r
     #
     #   D(cx, (ci U cj) = min(D(cx, ci), D(cx, cj))
     class SingleLinkage < Clusterer
+
+      include ClusterTree
 
       attr_reader :data_set, :number_of_clusters, :clusters
 

--- a/lib/ai4r/clusterers/ward_linkage.rb
+++ b/lib/ai4r/clusterers/ward_linkage.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/data_set'
 require_relative '../clusterers/single_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -26,6 +27,8 @@ module Ai4r
     #                       (nj/(ni+nj+nx))*D(cx, cj) -
     #                       (nx/(ni+nj)^2)*D(ci, cj)
     class WardLinkage < SingleLinkage
+
+      include ClusterTree
 
     parameters_info :distance_function =>
           "Custom implementation of distance function. " +

--- a/lib/ai4r/clusterers/ward_linkage_hierarchical.rb
+++ b/lib/ai4r/clusterers/ward_linkage_hierarchical.rb
@@ -5,6 +5,7 @@
 # Url::       http://peet.ldee.org
 
 require_relative '../clusterers/ward_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -12,37 +13,8 @@ module Ai4r
     # Hierarchical version to store classes as merges occur.
     class WardLinkageHierarchical < WardLinkage
 
-      attr_reader :cluster_tree
+      include ClusterTree
 
-      def initialize(depth = nil)
-        @cluster_tree = []
-        @depth = depth
-        @merges_so_far = 0
-        super()
-      end
-
-      def build(data_set, number_of_clusters = 1, **options)
-        data_len = data_set.data_items.length
-        @total_merges = data_len - number_of_clusters
-        super
-        @cluster_tree << self.clusters
-        @cluster_tree.reverse!
-        return self
-      end
-
-      protected
-
-      def merge_clusters(index_a, index_b, index_clusters)
-        # only store if no or above depth
-        if @depth.nil? or @merges_so_far > @total_merges - @depth
-          # store current clusters
-          stored_distance_matrix = @distance_matrix.dup
-          @cluster_tree << build_clusters_from_index_clusters(index_clusters)
-          @distance_matrix = stored_distance_matrix
-        end
-        @merges_so_far += 1
-        super
-      end
     end
   end
 end

--- a/lib/ai4r/clusterers/weighted_average_linkage.rb
+++ b/lib/ai4r/clusterers/weighted_average_linkage.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/data_set'
 require_relative '../clusterers/single_linkage'
+require_relative '../clusterers/cluster_tree'
 
 module Ai4r
   module Clusterers
@@ -25,6 +26,8 @@ module Ai4r
     #
     #   D(cx, (ci U cj)) =  ( ni * D(cx, ci) + nj * D(cx, cj)) / (ni + nj)
     class WeightedAverageLinkage < SingleLinkage
+
+      include ClusterTree
 
     parameters_info :distance_function =>
           "Custom implementation of distance function. " +


### PR DESCRIPTION
## Summary
- track merge operations with a new `ClusterTree` mixin
- apply mixin to all agglomerative clusterers
- simplify `WardLinkageHierarchical` implementation
- document accessing the merge tree and plotting a dendrogram
- add dendrogram example script

## Testing
- `bundle exec rake test` *(fails: ID3 tests error)*

------
https://chatgpt.com/codex/tasks/task_e_68719c5b765c8326a1a1d05704bf1985