### PR TITLE
Add graphviz rendering helpers and example

### DIFF
--- a/examples/classifiers/id3_graphviz_example.rb
+++ b/examples/classifiers/id3_graphviz_example.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../lib/ai4r/classifiers/id3'
+require_relative '../../lib/ai4r/classifiers/id3'
 
 # Load the training data
 file = "#{File.dirname(__FILE__)}/id3_data.csv"

--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -189,7 +189,6 @@ module Ai4r
         domain = domain(data_examples)
         return CategoryNode.new(@data_set.category_label, domain.last[0]) if domain.last.length == 1
 
-<<<<<<< HEAD
         best_index = nil
         best_entropy = nil
         best_split = nil
@@ -475,7 +474,7 @@ module Ai4r
 
       attr_reader :index, :values, :nodes, :numeric, :threshold
 
-      def initialize(data_labels, index, values_or_threshold, nodes, numeric=false)
+      def initialize(data_labels, index, values_or_threshold, nodes, numeric=false, majority=nil)
         @index = index
         @numeric = numeric
         if numeric
@@ -498,6 +497,7 @@ module Ai4r
           return ErrorNode.new.value(data) unless @values.include?(value)
           @nodes[@values.index(value)].value(data)
         end
+      end
 
       def value(data, classifier)
         value = data[@index]


### PR DESCRIPTION
## Summary
- fix merge leftover and syntax errors in ID3 classifier
- include majority parameter in EvaluationNode
- update GraphViz example to use require_relative

## Testing
- `ruby -c lib/ai4r/classifiers/id3.rb`
- `bundle exec rake test` *(fails: Could not find rake-13.3.0 ...)*

------
https://chatgpt.com/codex/tasks/task_e_68719cf0e6c08326b4b2a966aba89d69