### PR TITLE
Add supports_eval? to clusterers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,6 +74,14 @@ RNG before choosing initial centroids.
   kmeans = Ai4r::Clusterers::KMeans.new
   kmeans.set_parameters(:random_seed => 1).build(data, 2)
 
+== Checking eval availability
+
+Some hierarchical algorithms cannot classify new items once built.  Use
+`supports_eval?` to verify before calling `eval`:
+
+  clusterer = Ai4r::Clusterers::AverageLinkage.new.build(data, 2)
+  clusterer.supports_eval? # => false
+
 = Documentation
 
 Tutorials for genetic algorithms, ID3 decision trees and neural networks are available in the +docs/+ directory.

--- a/examples/clusterers/clusterer_example.rb
+++ b/examples/clusterers/clusterer_example.rb
@@ -48,8 +48,15 @@ data_set = DataSet.new(:data_items => answers, :data_labels => questions)
 # Let's group answers in 4 groups
 clusterer = Diana.new.build(data_set, 4)
 
-clusterer.clusters.each_with_index do |cluster, index| 
-	puts "Group #{index+1}"
-	p cluster.data_items
+clusterer.clusters.each_with_index do |cluster, index|
+        puts "Group #{index+1}"
+        p cluster.data_items
+end
+
+# Check if this algorithm supports evaluating new data items
+if clusterer.supports_eval?
+  puts "First survey belongs to group #{clusterer.eval(answers.first)}"
+else
+  puts 'This algorithm does not support eval on unseen data.'
 end
 

--- a/lib/ai4r/clusterers/average_linkage.rb
+++ b/lib/ai4r/clusterers/average_linkage.rb
@@ -46,6 +46,12 @@ module Ai4r
         raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
+      # Average linkage builds a dendrogram and cannot classify new data
+      # once built.
+      def supports_eval?
+        false
+      end
+
       protected
 
       # return distance between cluster cx and cluster (ci U cj),

--- a/lib/ai4r/clusterers/centroid_linkage.rb
+++ b/lib/ai4r/clusterers/centroid_linkage.rb
@@ -49,6 +49,10 @@ module Ai4r
         raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
+      def supports_eval?
+        false
+      end
+
       protected
 
       # return distance between cluster cx and cluster (ci U cj),

--- a/lib/ai4r/clusterers/clusterer.rb
+++ b/lib/ai4r/clusterers/clusterer.rb
@@ -31,6 +31,13 @@ module Ai4r
       def eval(data_item)
         raise NotImplementedError
       end
+
+      # Returns +true+ if this clusterer supports evaluating new data items
+      # with {#eval}. Hierarchical algorithms that only build a dendrogram
+      # will override this method to return +false+.
+      def supports_eval?
+        true
+      end
       
       protected    
       def get_min_index(array)

--- a/lib/ai4r/clusterers/median_linkage.rb
+++ b/lib/ai4r/clusterers/median_linkage.rb
@@ -46,6 +46,10 @@ module Ai4r
         raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
+      def supports_eval?
+        false
+      end
+
       protected
 
       # return distance between cluster cx and cluster (ci U cj),

--- a/lib/ai4r/clusterers/ward_linkage.rb
+++ b/lib/ai4r/clusterers/ward_linkage.rb
@@ -46,6 +46,10 @@ module Ai4r
         raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
+      def supports_eval?
+        false
+      end
+
       protected
 
       # return distance between cluster cx and cluster (ci U cj),

--- a/lib/ai4r/clusterers/ward_linkage_hierarchical.rb
+++ b/lib/ai4r/clusterers/ward_linkage_hierarchical.rb
@@ -30,6 +30,10 @@ module Ai4r
         return self
       end
 
+      def supports_eval?
+        false
+      end
+
       protected
 
       def merge_clusters(index_a, index_b, index_clusters)

--- a/lib/ai4r/clusterers/weighted_average_linkage.rb
+++ b/lib/ai4r/clusterers/weighted_average_linkage.rb
@@ -45,6 +45,10 @@ module Ai4r
         raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
       end
 
+      def supports_eval?
+        false
+      end
+
       protected
 
       # return distance between cluster cx and cluster (ci U cj),

--- a/test/clusterers/average_linkage_test.rb
+++ b/test/clusterers/average_linkage_test.rb
@@ -52,4 +52,8 @@ class AverageLinkageTest < Test::Unit::TestCase
     assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
+  def test_supports_eval
+    assert_equal false, Ai4r::Clusterers::AverageLinkage.new.supports_eval?
+  end
+
 end

--- a/test/clusterers/centroid_linkage_test.rb
+++ b/test/clusterers/centroid_linkage_test.rb
@@ -54,4 +54,8 @@ class Ai4r::Clusterers::CentroidLinkageTest < Test::Unit::TestCase
     assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
+  def test_supports_eval
+    assert_equal false, Ai4r::Clusterers::CentroidLinkage.new.supports_eval?
+  end
+
 end

--- a/test/clusterers/median_linkage_test.rb
+++ b/test/clusterers/median_linkage_test.rb
@@ -54,4 +54,8 @@ class Ai4r::Clusterers::MedianLinkageTest < Test::Unit::TestCase
     assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
+  def test_supports_eval
+    assert_equal false, Ai4r::Clusterers::MedianLinkage.new.supports_eval?
+  end
+
 end

--- a/test/clusterers/ward_linkage_hierarchical_test.rb
+++ b/test/clusterers/ward_linkage_hierarchical_test.rb
@@ -76,5 +76,9 @@ class Ai4r::Clusterers::WardLinkageHierarchicalTest < Test::Unit::TestCase
     assert_equal 5, clusterer.cluster_tree.last.length
   end
 
+  def test_supports_eval
+    assert_equal false, Ai4r::Clusterers::WardLinkageHierarchical.new.supports_eval?
+  end
+
 
 end

--- a/test/clusterers/ward_linkage_test.rb
+++ b/test/clusterers/ward_linkage_test.rb
@@ -54,4 +54,8 @@ class Ai4r::Clusterers::WardLinkageTest < Test::Unit::TestCase
     assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
+  def test_supports_eval
+    assert_equal false, Ai4r::Clusterers::WardLinkage.new.supports_eval?
+  end
+
 end

--- a/test/clusterers/weighted_average_linkage_test.rb
+++ b/test/clusterers/weighted_average_linkage_test.rb
@@ -53,4 +53,8 @@ class Ai4r::Clusterers::WeightedAverageLinkageTest < Test::Unit::TestCase
     clusterer = Ai4r::Clusterers::WeightedAverageLinkage.new
     assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
   end
+
+  def test_supports_eval
+    assert_equal false, Ai4r::Clusterers::WeightedAverageLinkage.new.supports_eval?
+  end
 end


### PR DESCRIPTION
## Summary
- add `supports_eval?` method to base Clusterer
- return `false` in hierarchical algorithms
- show `supports_eval?` usage in example and README
- test the new behaviour

## Testing
- `bundle exec rake test` *(fails: ArgumentError during ID3 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68719e2ef6c083268d692f6f91789aaf