### PR TITLE
Add clustering examples

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,6 +74,15 @@ RNG before choosing initial centroids.
   kmeans = Ai4r::Clusterers::KMeans.new
   kmeans.set_parameters(:random_seed => 1).build(data, 2)
 
+== Clusterer examples
+
+Scripts under `examples/clusterers` showcase additional features:
+
+* `kmeans_custom_example.rb` runs KMeans with a custom distance function and a
+  fixed seed.  It prints the final SSE and how many iterations were needed.
+* `hierarchical_dendrogram_example.rb` builds a hierarchical clusterer and
+  outputs a simple dendrogram using the recorded tree.
+
 = Documentation
 
 Tutorials for genetic algorithms, ID3 decision trees and neural networks are available in the +docs/+ directory.

--- a/examples/clusterers/hierarchical_dendrogram_example.rb
+++ b/examples/clusterers/hierarchical_dendrogram_example.rb
@@ -1,0 +1,20 @@
+# Demonstrates recording the merge tree using WardLinkageHierarchical
+# and printing a simple dendrogram.
+
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [[1,1],[1,2],[2,1],[2,2],[8,8],[8,9],[9,8],[9,9]]
+data_set = DataSet.new(:data_items => points)
+
+clusterer = WardLinkageHierarchical.new
+clusterer.build(data_set, 1)
+
+puts "Dendrogram:"
+clusterer.cluster_tree.each_with_index do |clusters, level|
+  puts "Level #{level}:"
+  clusters.each_with_index do |cluster, idx|
+    puts "  Cluster #{idx}: #{cluster.data_items.inspect}"
+  end
+end

--- a/examples/clusterers/kmeans_custom_example.rb
+++ b/examples/clusterers/kmeans_custom_example.rb
@@ -1,0 +1,26 @@
+# This example shows KMeans with a custom distance function and deterministic initialization.
+# It also prints the number of iterations and the sum of squared errors (SSE).
+
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+# Simple two-cluster data set
+points = [[1,1],[1,2],[2,1],[2,2],[8,8],[8,9],[9,8],[9,9]]
+data_set = DataSet.new(:data_items => points)
+
+# Manhattan distance instead of the default squared Euclidean distance
+manhattan = lambda do |a, b|
+  a.zip(b).map { |x, y| (x - y).abs }.reduce(:+)
+end
+
+kmeans = KMeans.new
+kmeans.set_parameters(:distance_function => manhattan, :random_seed => 1)
+       .build(data_set, 2)
+
+kmeans.clusters.each_with_index do |cluster, idx|
+  puts "Cluster #{idx}: #{cluster.data_items.inspect}"
+end
+
+puts "Iterations: #{kmeans.iterations}"
+puts "SSE: #{kmeans.sse}"


### PR DESCRIPTION
## Summary
- provide example of KMeans using a custom distance and seed
- demonstrate hierarchical clustering with dendrogram output
- reference new clustering examples in README

## Testing
- `bundle install`
- `bundle exec rake test` *(fails: Command failed with status (1))*

------
https://chatgpt.com/codex/tasks/task_e_68719e404d888326b492ef09cb3f4e8b