### PR TITLE
Add configurable distance metrics to SOM

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,6 +74,16 @@ RNG before choosing initial centroids.
   kmeans = Ai4r::Clusterers::KMeans.new
   kmeans.set_parameters(:random_seed => 1).build(data, 2)
 
+== SOM distance metric
+
+Layers and nodes accept an optional ``distance_metric'' parameter.  It controls
+how neighbourhood distances are computed.  Supported metrics are
+``:chebyshev'' (default), ``:euclidean'' and ``:manhattan''.
+
+  layer = Ai4r::Som::TwoPhaseLayer.new(10, distance_metric: :euclidean)
+  som = Ai4r::Som::Som.new(4, 8, 8, layer)
+  som.initiate_map
+
 = Documentation
 
 Tutorials for genetic algorithms, ID3 decision trees and neural networks are available in the +docs/+ directory.

--- a/lib/ai4r/som/distance_metrics.rb
+++ b/lib/ai4r/som/distance_metrics.rb
@@ -1,0 +1,18 @@
+module Ai4r
+  module Som
+    # Helper module with distance metrics for node coordinates
+    module DistanceMetrics
+      def self.chebyshev(dx, dy)
+        [dx.abs, dy.abs].max
+      end
+
+      def self.euclidean(dx, dy)
+        Math.sqrt(dx**2 + dy**2)
+      end
+
+      def self.manhattan(dx, dy)
+        dx.abs + dy.abs
+      end
+    end
+  end
+end

--- a/lib/ai4r/som/layer.rb
+++ b/lib/ai4r/som/layer.rb
@@ -30,9 +30,10 @@ module Ai4r
 
       parameters_info :nodes => "number of nodes, has to be equal to the som",
                       :epochs => "number of epochs the algorithm has to run",
-                      :radius => "sets the initial neighborhoud radius"
+                      :radius => "sets the initial neighborhoud radius",
+                      :distance_metric => "metric used to compute node distance"
 
-      def initialize(nodes, radius, epochs = 100, learning_rate = 0.7)
+      def initialize(nodes, radius, epochs = 100, learning_rate = 0.7, options = {})
         raise("Too few nodes") if nodes < 3
         
         @nodes = nodes
@@ -42,6 +43,7 @@ module Ai4r
         @time_for_epoch = @epochs + 1.0 if @time_for_epoch < @epochs
 
         @initial_learning_rate = learning_rate
+        @distance_metric = options[:distance_metric] || :chebyshev
       end
 
       # calculates the influnce decay for a certain distance and the current radius

--- a/lib/ai4r/som/node.rb
+++ b/lib/ai4r/som/node.rb
@@ -10,6 +10,7 @@
 
 require_relative '../data/parameterizable'
 require_relative 'layer'
+require_relative 'distance_metrics'
 
 module Ai4r
 
@@ -35,7 +36,8 @@ module Ai4r
                       :instantiated_weight => "holds the very first weight",
                       :x => "holds the row ID of the unit in the map",
                       :y => "holds the column ID of the unit in the map",
-                      :id => "id of the node"      
+                      :id => "id of the node",
+                      :distance_metric => "metric used to compute node distance"
 
       # creates an instance of Node and instantiates the weights
       #
@@ -46,6 +48,7 @@ module Ai4r
       def self.create(id, rows, columns, dimensions, options = {})
         n = Node.new
         n.id = id
+        n.distance_metric = options[:distance_metric] || :chebyshev
         n.instantiate_weight dimensions, options
         n.x = id % columns
         n.y = (id / columns.to_f).to_i
@@ -90,13 +93,10 @@ module Ai4r
       # 2 2 2 2 2
       # 0 being the current node
       def distance_to_node(node)
-        max((self.x - node.x).abs, (self.y - node.y).abs)
-      end
-
-      private
-
-      def max(a, b)
-        a > b ? a : b
+        dx = self.x - node.x
+        dy = self.y - node.y
+        metric = (@distance_metric || :chebyshev)
+        DistanceMetrics.send(metric, dx, dy)
       end
 
     end

--- a/lib/ai4r/som/som.rb
+++ b/lib/ai4r/som/som.rb
@@ -146,7 +146,8 @@ module Ai4r
       def initiate_map
         srand(@init_weight_options[:seed]) unless @init_weight_options[:seed].nil?
         @nodes.each_with_index do |node, i|
-          @nodes[i] = Node.create i, @rows, @columns, @dimension, @init_weight_options
+          options = @init_weight_options.merge(distance_metric: @layer.distance_metric)
+          @nodes[i] = Node.create i, @rows, @columns, @dimension, options
         end
       end
 

--- a/lib/ai4r/som/two_phase_layer.rb
+++ b/lib/ai4r/som/two_phase_layer.rb
@@ -35,8 +35,8 @@ module Ai4r
     class TwoPhaseLayer < Layer
 
       def initialize(nodes, learning_rate = 0.9, phase_one = 150, phase_two = 100,
-              phase_one_learning_rate = 0.1, phase_two_learning_rate = 0)
-        super nodes, nodes, phase_one + phase_two, learning_rate
+              phase_one_learning_rate = 0.1, phase_two_learning_rate = 0, options = {})
+        super nodes, nodes, phase_one + phase_two, learning_rate, options
         @phase_one = phase_one
         @phase_two = phase_two
         @lr = @initial_learning_rate

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -12,6 +12,7 @@
 
 require 'ai4r/som/som'
 require 'test/unit'
+require_relative '../test_helper'
 
 module Ai4r
 
@@ -105,6 +106,20 @@ module Ai4r
         assert_equal [0, 0], [som.get_node(0, 0).x, som.get_node(0, 0).y]
         assert_equal [2, 0], [som.get_node(0, 2).x, som.get_node(0, 2).y]
         assert_equal [1, 1], [som.get_node(1, 1).x, som.get_node(1, 1).y]
+      end
+
+      def test_euclidean_distance_metric
+        layer = Layer.new(3, 3, 100, 0.7, distance_metric: :euclidean)
+        som = Som.new 1, 2, 2, layer
+        som.initiate_map
+        assert_approximate_equality Math.sqrt(2), som.get_node(0,0).distance_to_node(som.get_node(1,1))
+      end
+
+      def test_manhattan_distance_metric
+        layer = Layer.new(3, 3, 100, 0.7, distance_metric: :manhattan)
+        som = Som.new 1, 2, 2, layer
+        som.initiate_map
+        assert_equal 2, som.get_node(0,0).distance_to_node(som.get_node(1,1))
       end
 
       private


### PR DESCRIPTION
## Summary
- add `distance_metric` option to `Layer` and `Node`
- implement `DistanceMetrics` helper for chebyshev, euclidean and manhattan distances
- allow SOM to pass the metric when creating nodes
- document SOM distance metric configuration
- test euclidean and manhattan distance metrics

## Testing
- `bundle exec rake test TEST=test/som/som_test.rb`
- `bundle exec rake test` *(fails: Command failed with status (1))*

------
https://chatgpt.com/codex/tasks/task_e_68719e4f3e28832692917ced35fa05aa