### PR TITLE
Add error-based early stopping to SOM

### DIFF
--- a/examples/som/som_multi_node_example.rb
+++ b/examples/som/som_multi_node_example.rb
@@ -1,22 +1,19 @@
-# this example shows the impact of the size of a som on the global error distance
+# Demonstrates how map size impacts error and uses early stopping.
 require File.dirname(__FILE__) + '/../../lib/ai4r/som/som'
 require File.dirname(__FILE__) + '/som_data'
 require 'benchmark'
 
 10.times do |t|
-  t += 3 # minimum number of nodes
+  nodes = t + 3 # minimum number of nodes
 
-  puts "Nodes: #{t}"
-  som = Ai4r::Som::Som.new 4, 8, Ai4r::Som::TwoPhaseLayer.new(t)
+  puts "Nodes: #{nodes}"
+  som = Ai4r::Som::Som.new 4, 8, 8, Ai4r::Som::TwoPhaseLayer.new(nodes)
   som.initiate_map
 
-  puts "global error distance: #{som.global_error(SOM_DATA)}"
-  puts "\ntraining the som\n"
-
+  puts "Initial error: #{som.global_error(SOM_DATA)}"
   times = Benchmark.measure do
-    som.train SOM_DATA
+    som.train(SOM_DATA, error_threshold: 1000)
   end
-
   puts "Elapsed time for training: #{times}"
-  puts "global error distance: #{som.global_error(SOM_DATA)}\n\n"
+  puts "Final error: #{som.global_error(SOM_DATA)}\n\n"
 end

--- a/examples/som/som_single_example.rb
+++ b/examples/som/som_single_example.rb
@@ -2,23 +2,18 @@ require File.dirname(__FILE__) + '/../../lib/ai4r/som/som'
 require File.dirname(__FILE__) + '/som_data'
 require 'benchmark'
 
-som = Ai4r::Som::Som.new 4, 8, Ai4r::Som::TwoPhaseLayer.new(10)
+# Train a small SOM and stop early when the global error drops below 1000.
+som = Ai4r::Som::Som.new 4, 8, 8, Ai4r::Som::TwoPhaseLayer.new(10)
 som.initiate_map
 
-som.nodes.each do |node|
-  p node.weights
-end
+puts "Initial global error: #{som.global_error(SOM_DATA)}"
 
-puts "global error distance: #{som.global_error(SOM_DATA)}"
-puts "\ntraining the som\n"
-
+puts "\nTraining the SOM (early stopping threshold = 1000)\n"
 times = Benchmark.measure do
-  som.train SOM_DATA
-end
-
-som.nodes.each do |node|
-  p node.weights
+  som.train(SOM_DATA, error_threshold: 1000) do |error|
+    puts "Epoch #{som.epoch}: error = #{error}"
+  end
 end
 
 puts "Elapsed time for training: #{times}"
-puts "global error distance: #{som.global_error(SOM_DATA)}\n\n"
+puts "Final global error: #{som.global_error(SOM_DATA)}\n"

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -107,6 +107,14 @@ module Ai4r
         assert_equal [1, 1], [som.get_node(1, 1).x, som.get_node(1, 1).y]
       end
 
+      def test_train_with_error_threshold
+        som = Som.new 2, 3, 3, Layer.new(3, 3, 10)
+        som.initiate_map
+        errors = som.train([[0, 0], [1, 1]], error_threshold: 0.01)
+        assert errors.length < som.layer.epochs
+        assert_operator errors.last, :<=, 0.01
+      end
+
       private
 
       def distancer(x1, y1, x2, y2)


### PR DESCRIPTION
## Summary
- add optional `error_threshold` to SOM training and emit per-epoch error
- update SOM examples to show early stopping
- cover early stopping in test suite

## Testing
- `bundle exec rake test TEST=test/som/som_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_68719e50e4a483268e84341ef36deef3