### PR TITLE
Add SOM layer and training tests

### DIFF
--- a/test/som/node_test.rb
+++ b/test/som/node_test.rb
@@ -1,0 +1,25 @@
+require 'test/unit'
+require 'ai4r/som/node'
+
+module Ai4r
+  module Som
+    class NodeTest < Test::Unit::TestCase
+      def test_distance_to_input
+        node = Node.new
+        node.weights = [0.0, 0.0]
+        assert_in_delta 0.0, node.distance_to_input([0.0, 0.0]), 1e-6
+        assert_in_delta 5.0, node.distance_to_input([3.0, 4.0]), 1e-6
+      end
+
+      def test_distance_to_node
+        a = Node.new
+        a.x = 0
+        a.y = 0
+        b = Node.new
+        b.x = 3
+        b.y = 2
+        assert_equal 3, a.distance_to_node(b)
+      end
+    end
+  end
+end

--- a/test/som/training_test.rb
+++ b/test/som/training_test.rb
@@ -1,0 +1,23 @@
+require 'test/unit'
+require 'ai4r/som/som'
+
+module Ai4r
+  module Som
+    class TrainingTest < Test::Unit::TestCase
+      DATA = [[0.0, 0.0], [1.0, 1.0]]
+
+      def setup
+        layer = TwoPhaseLayer.new(4, 0.5, 1, 1, 0.5, 0.2)
+        @som = Som.new(2, 2, 2, layer, { range: 0..1, seed: 1 })
+        @som.initiate_map
+      end
+
+      def test_global_error_decreases
+        before = @som.global_error(DATA)
+        @som.train(DATA)
+        after = @som.global_error(DATA)
+        assert after < before, "expected error to decrease"
+      end
+    end
+  end
+end

--- a/test/som/two_phase_layer_test.rb
+++ b/test/som/two_phase_layer_test.rb
@@ -1,0 +1,28 @@
+require 'test/unit'
+require 'ai4r/som/two_phase_layer'
+
+module Ai4r
+  module Som
+    class TwoPhaseLayerTest < Test::Unit::TestCase
+      def setup
+        # Use small phase sizes to make schedule deterministic
+        @layer = TwoPhaseLayer.new(6, 0.9, 2, 3, 0.5, 0.1)
+      end
+
+      def test_radius_schedule
+        assert_equal 2, @layer.radius_decay(0)
+        assert_equal 2, @layer.radius_decay(1)
+        assert_equal 1, @layer.radius_decay(2)
+        assert_equal 1, @layer.radius_decay(3)
+      end
+
+      def test_learning_rate_schedule
+        assert_in_delta 0.7, @layer.learning_rate_decay(0), 1e-6
+        assert_in_delta 0.5, @layer.learning_rate_decay(1), 1e-6
+        assert_in_delta 0.5, @layer.learning_rate_decay(2), 1e-6
+        assert_in_delta 0.366666, @layer.learning_rate_decay(3), 1e-4
+        assert_in_delta 0.233333, @layer.learning_rate_decay(4), 1e-4
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add tests for `TwoPhaseLayer` schedule
- cover `Node#distance_to_input` and `distance_to_node`
- add deterministic training test that checks global error decreases

## Testing
- `bundle exec rake test` *(fails: 16 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68719e548d4083268952924bb0f55445