### PR TITLE
Enhance Hyperpipes classifier

### DIFF
--- a/lib/ai4r/classifiers/votes.rb
+++ b/lib/ai4r/classifiers/votes.rb
@@ -24,10 +24,17 @@ module Ai4r
         tally_sheet[category]
       end
 
-      def get_winner
+      def get_winner(tie_strategy = :last)
         n = 0 # used to create a stable sort of the tallys
         sorted_sheet = tally_sheet.sort_by { |_, score| n += 1; [score, n] }
-        sorted_sheet.last.first
+        return nil if sorted_sheet.empty?
+        if tie_strategy == :random
+          max_score = sorted_sheet.last[1]
+          tied = sorted_sheet.select { |_, score| score == max_score }.map(&:first)
+          tied.sample
+        else
+          sorted_sheet.last.first
+        end
       end
 
       private

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -75,6 +75,21 @@ class HyperpipesTest < Test::Unit::TestCase
     eval classifier.get_rules
     assert_equal 'N', marketing_target
   end
+
+  def test_tie_strategy
+    classifier = Hyperpipes.new.set_parameters(:tie_strategy => :last).build(@data_set)
+    assert_equal 'N', classifier.eval(['Chicago', 40, 'F'])
+    srand(2)
+    classifier = Hyperpipes.new.set_parameters(:tie_strategy => :random).build(@data_set)
+    assert_equal 'Y', classifier.eval(['Chicago', 40, 'F'])
+  end
+
+  def test_margin
+    classifier = Hyperpipes.new.build(@data_set)
+    assert_equal 'Y', classifier.eval(['Chicago', 30, 'F'])
+    classifier = Hyperpipes.new.set_parameters(:margin => 5).build(@data_set)
+    assert_equal 'N', classifier.eval(['Chicago', 30, 'F'])
+  end
 end
 
   


### PR DESCRIPTION
## Summary
- add tie strategy & margin parameters to Hyperpipes
- support tie strategy in Votes
- expand numeric ranges using margin
- respect tie strategy in rule generation
- test new tie strategies and margin behaviour

## Testing
- `bundle exec rake test TEST=test/classifiers/hyperpipes_test.rb`
- `bundle exec rake test` *(fails: 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a06015f483269d101dbf8eed3ecf