### PR TITLE
Add hyperpipes documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,7 +76,7 @@ RNG before choosing initial centroids.
 
 = Documentation
 
-Tutorials for genetic algorithms, ID3 decision trees and neural networks are available in the +docs/+ directory.
+Tutorials for genetic algorithms, ID3 decision trees, Hyperpipes and neural networks are available in the +docs/+ directory.
 
 = Disclaimer
 

--- a/docs/hyperpipes.md
+++ b/docs/hyperpipes.md
@@ -1,0 +1,32 @@
+# Hyperpipes Classifier
+
+Hyperpipes is a fast baseline algorithm that creates one "pipe" per class.
+A pipe records value ranges for numeric attributes and sets of observed values
+for nominal attributes. New records are classified by counting how many
+attributes match each pipe.
+
+## Parameters
+
+`tie_strategy` – determines how to break ties when several classes receive the
+same number of votes. Options are `:first`, `:last` or `:random`.
+
+`margin` – expands numeric boundaries by this amount when building the pipes.
+A larger margin makes the classifier more tolerant to unseen values.
+
+```ruby
+require 'ai4r/classifiers/hyperpipes'
+require 'ai4r/data/data_set'
+
+labels = %w[city age gender marketing_target]
+items = [
+  ['New York', 25, 'M', 'Y'],
+  ['Chicago', 43, 'M', 'Y'],
+  ['Chicago', 55, 'M', 'N']
+]
+
+set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
+classifier = Ai4r::Classifiers::Hyperpipes.new
+classifier.set_parameters(tie_strategy: :last, margin: 0.5)
+classifier.build(set)
+classifier.eval(['New York', 30, 'M'])
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ require 'ai4r'
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
 * [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * **Automatic Classifiers** – identify relevant marketing targets using decision trees.
+* [Hyperpipes](hyperpipes.md) – baseline classifier using value ranges.
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- document the Hyperpipes classifier
- reference new doc from docs index and README

## Testing
- `bundle exec rake test` *(fails: wrong number of arguments errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a06a04408326912e548dfa64b669