### PR TITLE
Add Hyperpipes classifier example

### DIFF
--- a/docs/hyperpipes.md
+++ b/docs/hyperpipes.md
@@ -1,0 +1,21 @@
+# Hyperpipes Classifier
+
+Hyperpipes builds one "pipe" per class describing the observed attribute ranges. When classifying a new example each pipe receives a vote for every attribute that matches the stored range or value. The class with the most votes wins.
+
+```ruby
+require 'ai4r'
+include Ai4r::Classifiers
+include Ai4r::Data
+
+# Load training data from the repository
+file = 'examples/classifiers/hyperpipes_data.csv'
+data = DataSet.new.parse_csv_with_labels(file)
+
+classifier = Hyperpipes.new
+classifier.set_parameters(:tie_strategy => :random).build(data)
+
+pp classifier.pipes    # inspect pipes_summary
+puts classifier.eval(['Chicago', 85, 'F'])
+```
+
+See `examples/classifiers/hyperpipes_example.rb` for a runnable sample.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ require 'ai4r'
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
 * [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * **Automatic Classifiers** – identify relevant marketing targets using decision trees.
+* [Hyperpipes Classifier](hyperpipes.md) – baseline voting using attribute ranges.
 
 ## Contact
 

--- a/examples/classifiers/hyperpipes_data.csv
+++ b/examples/classifiers/hyperpipes_data.csv
@@ -1,0 +1,14 @@
+city,age,gender,marketing_target
+New York,25,M,Y
+New York,23,M,Y
+New York,18,M,Y
+Chicago,43,M,Y
+New York,34,F,N
+Chicago,33,F,Y
+New York,31,F,N
+Chicago,55,M,N
+New York,58,F,N
+New York,59,M,N
+Chicago,71,M,N
+New York,60,F,N
+Chicago,85,F,Y

--- a/examples/classifiers/hyperpipes_example.rb
+++ b/examples/classifiers/hyperpipes_example.rb
@@ -1,0 +1,21 @@
+require File.dirname(__FILE__) + '/../../lib/ai4r/classifiers/hyperpipes'
+require File.dirname(__FILE__) + '/../../lib/ai4r/data/data_set'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+# Load the training data
+file = File.dirname(__FILE__) + '/hyperpipes_data.csv'
+data = DataSet.new.parse_csv_with_labels(file)
+
+# Build the classifier using custom parameters
+classifier = Hyperpipes.new.set_parameters(:tie_strategy => :random).build(data)
+
+# Inspect the generated pipes
+pipes_summary = classifier.pipes
+puts 'Pipes summary:'
+pp pipes_summary
+
+# Classify new instances
+puts "Prediction for ['Chicago', 85, 'F']: #{classifier.eval(['Chicago', 85, 'F'])}"
+puts "Prediction for ['New York', 25, 'M']: #{classifier.eval(['New York', 25, 'M'])}"


### PR DESCRIPTION
## Summary
- add example dataset and hyperpipes demo
- document Hyperpipes usage and link from index

## Testing
- `bundle install`
- `bundle exec rake test` *(fails: 0 failures, 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a06bcc888326a11806413910264d