### PR TITLE
Sort domain information in NaiveBayes

### DIFF
--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -121,7 +121,7 @@ module Ai4r
         @domains = data.build_domains
         @data_items = data.data_items.map { |item| DataEntry.new(item[0...-1], item.last) }
         @data_labels = data.data_labels[0...-1]
-        @klasses = @domains.last.to_a
+        @klasses = @domains.last.to_a.sort
       end
 
 
@@ -166,7 +166,7 @@ module Ai4r
 
         0.upto(@data_labels.length - 1) do |index|
           @values[index] = {}
-          @domains[index].each_with_index do |d, d_index|
+          @domains[index].to_a.sort.each_with_index do |d, d_index|
             @values[index][d] = d_index
           end
         end


### PR DESCRIPTION
## Summary
- ensure NaiveBayes builds class domain information in sorted order
- sort attribute values while creating the lookup tables

## Testing
- `bundle exec rake test` *(fails: 20 errors)*


------
https://chatgpt.com/codex/tasks/task_e_6871a077ad048326a439065fce98b84f