### PR TITLE
Handle unknown values in NaiveBayes

### DIFF
--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -59,10 +59,13 @@ module Ai4r
     class NaiveBayes < Classifier
 
       parameters_info :m => 'Default value is set to 0. It may be set to a value greater than ' +
-        '0 when the size of the dataset is relatively small'
+        '0 when the size of the dataset is relatively small',
+        :unknown_value_strategy => 'Behaviour when evaluating unseen attribute values: ' +
+        ':ignore (default), :uniform or :error.'
           
       def initialize
         @m = 0
+        @unknown_value_strategy = :ignore
         @class_counts = []
         @class_prob = [] # stores the probability of the classes
         @pcc = [] # stores the number of instances divided into attribute/value/class
@@ -132,8 +135,23 @@ module Ai4r
       def calculate_class_probabilities_for_entry(data, prob)
         0.upto(prob.length - 1) do |prob_index|
           data.each_with_index do |att, index|
-            next if value_index(att, index).nil?
-            prob[prob_index] *= @pcp[index][value_index(att, index)][prob_index]
+            val_index = value_index(att, index)
+            if val_index.nil?
+              case @unknown_value_strategy
+              when :ignore
+                next
+              when :uniform
+                value_count = @pcc[index].count { |arr| arr[prob_index] > 0 }
+                value_count = 1 if value_count.zero?
+                prob[prob_index] *= 1.0 / value_count
+              when :error
+                raise "Unknown value '#{att}' for attribute #{@data_labels[index]}"
+              else
+                next
+              end
+            else
+              prob[prob_index] *= @pcp[index][val_index][prob_index]
+            end
           end
         end
         

--- a/test/classifiers/naive_bayes_test.rb
+++ b/test/classifiers/naive_bayes_test.rb
@@ -40,4 +40,24 @@ class NaiveBayesTest < Test::Unit::TestCase
     assert_in_delta 0.58, map['No'], 0.1
   end
 
+  def test_unknown_value_ignore
+    result = @b.eval(%w(Blue SUV Domestic))
+    assert_equal 'No', result
+  end
+
+  def test_unknown_value_uniform
+    labels = ['Color', 'Class']
+    items = [['Red','A'], ['Red','A'], ['Blue','B'], ['Green','B']]
+    ds = DataSet.new(:data_items => items, :data_labels => labels)
+    classifier = NaiveBayes.new.set_parameters(:unknown_value_strategy => :uniform).build(ds)
+    result = classifier.eval(['Yellow'])
+    assert_equal 'A', result
+  end
+
+  def test_unknown_value_error
+    assert_raise RuntimeError do
+      NaiveBayes.new.set_parameters(:unknown_value_strategy => :error).build(@data_set).eval(%w(Blue SUV Domestic))
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary
- add `unknown_value_strategy` parameter to `NaiveBayes`
- support `:ignore`, `:uniform`, and `:error` strategies
- test each strategy in NaiveBayes tests

## Testing
- `bundle exec rake test` *(fails: NoMethodError and ArgumentError in baseline tests)*

------
https://chatgpt.com/codex/tasks/task_e_6871a078cbc08326b4a8b120aad4dae6