### PR TITLE
Add accessors and docs for NaiveBayes internals

### DIFF
--- a/docs/naive_bayes.md
+++ b/docs/naive_bayes.md
@@ -1,0 +1,10 @@
+# Naive Bayes
+
+`Ai4r::Classifiers::NaiveBayes` computes several probability tables when built. These attributes are exposed as read-only accessors:
+
+* `class_prob` – Probability of each class in the training set.
+* `pcc` – Count of occurrences for every attribute value and class. Layout is `[attribute][value][class]`.
+* `pcp` – Conditional probability of an attribute value given a class. Shares the same layout as `pcc` and is derived from it using the `:m` parameter.
+
+Inspecting these arrays helps you understand the learned model.
+

--- a/examples/classifiers/naive_bayes_attributes_example.rb
+++ b/examples/classifiers/naive_bayes_attributes_example.rb
@@ -1,0 +1,15 @@
+require File.dirname(__FILE__) + '/../../lib/ai4r/classifiers/naive_bayes'
+require File.dirname(__FILE__) + '/../../lib/ai4r/data/data_set'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+file = File.dirname(__FILE__) + '/naive_bayes_data.csv'
+set = DataSet.new.load_csv_with_labels(file)
+
+bayes = NaiveBayes.new.set_parameters(:m => 3).build(set)
+
+puts bayes.class_prob.inspect
+puts bayes.pcc.inspect
+puts bayes.pcp.inspect
+

--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -58,6 +58,8 @@ module Ai4r
     
     class NaiveBayes < Classifier
 
+      attr_reader :class_prob, :pcc, :pcp
+
       parameters_info :m => 'Default value is set to 0. It may be set to a value greater than ' +
         '0 when the size of the dataset is relatively small'
           


### PR DESCRIPTION
## Summary
- expose `class_prob`, `pcc` and `pcp` via `attr_reader`
- document the new attributes
- show how to inspect them in an example

## Testing
- `bundle exec rake test` *(fails: 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a07b3e3483268fe3418d9f6b8bca