### PR TITLE
Enable discretization in Prism

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,7 +15,7 @@ This project aims to produce ruby implementations of algorithms covering several
 
   require "ai4r"
 
-OneR now supports numeric attributes by discretizing them into a fixed
+OneR and Prism now support numeric attributes by discretizing them into a fixed
 number of bins. The amount of bins can be controlled with the
 `bin_count` parameter.
 

--- a/lib/ai4r/classifiers/prism.rb
+++ b/lib/ai4r/classifiers/prism.rb
@@ -26,8 +26,15 @@ module Ai4r
     # J. Cendrowska (1987). PRISM: An algorithm for inducing modular rules. 
     # International Journal of Man-Machine Studies. 27(4):349-370.
     class Prism < Classifier
-            
+
       attr_reader :data_set, :rules
+
+      parameters_info :bin_count => 'Number of bins used to discretize numeric attributes.'
+
+      def initialize
+        @bin_count = 10
+        @attr_bins = {}
+      end
 
       # Build a new Prism classifier. You must provide a DataSet instance
       # as parameter. The last attribute of each item is considered as 
@@ -36,6 +43,12 @@ module Ai4r
         data_set.check_not_empty
         @data_set = data_set
         domains = @data_set.build_domains
+        @attr_bins = {}
+        domains[0...-1].each_with_index do |domain, i|
+          if domain.is_a?(Array) && domain.length == 2 && domain.all? { |v| v.is_a? Numeric }
+            @attr_bins[@data_set.data_labels[i]] = discretize_range(domain, @bin_count)
+          end
+        end
         instances = @data_set.data_items.collect {|data| data }
         @rules = []
         domains.last.each do |class_value|
@@ -105,7 +118,12 @@ module Ai4r
       
       def matches_conditions(data, conditions)
         conditions.each_pair do |attr_label, attr_value|
-          return false if get_attr_value(data, attr_label) != attr_value
+          value = get_attr_value(data, attr_label)
+          if attr_value.is_a?(Range)
+            return false unless attr_value.include?(value)
+          else
+            return false unless value == attr_value
+          end
         end
         return true
       end
@@ -138,9 +156,13 @@ module Ai4r
         rule_instances.each do |data|
           attributes.each do |attr_label|
             attr_freqs = freq_table[attr_label] || Hash.new([0, 0])
-            pt = attr_freqs[get_attr_value(data, attr_label)]
+            value = get_attr_value(data, attr_label)
+            if (bins = @attr_bins[attr_label])
+              value = bins.find { |b| b.include?(value) }
+            end
+            pt = attr_freqs[value]
             pt = [(data.last == class_value) ? pt[0]+1 : pt[0], pt[1]+1]
-            attr_freqs[get_attr_value(data, attr_label)] = pt
+            attr_freqs[value] = pt
             freq_table[attr_label] = attr_freqs
           end
         end
@@ -179,11 +201,27 @@ module Ai4r
         return true if a>b || (a==b && pt[0]>best_pt[0])
         return false
       end
+
+      def discretize_range(range, bins)
+        min, max = range
+        step = (max - min).to_f / bins
+        ranges = []
+        bins.times do |i|
+          low = min + i * step
+          high = (i == bins - 1) ? max : min + (i + 1) * step
+          ranges << (i == bins - 1 ? (low..high) : (low...high))
+        end
+        ranges
+      end
       
       def join_terms(rule)
         terms = []
-        rule[:conditions].each do |attr_label, attr_value| 
-            terms << "#{attr_label} == '#{attr_value}'"
+        rule[:conditions].each do |attr_label, attr_value|
+            if attr_value.is_a?(Range)
+              terms << "(#{attr_value}).include?(#{attr_label})"
+            else
+              terms << "#{attr_label} == '#{attr_value}'"
+            end
         end
         "#{terms.join(" and ")}"
       end

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -25,6 +25,18 @@ class PrismTest < Test::Unit::TestCase
               ]
 
   @@data_labels = [ 'city', 'age_range', 'gender', 'marketing_target'  ]
+
+  @@numeric_examples = [
+    ['New York', 20, 'M', 'Y'],
+    ['Chicago', 25, 'M', 'Y'],
+    ['New York', 28, 'M', 'Y'],
+    ['New York', 35, 'F', 'N'],
+    ['Chicago', 40, 'F', 'Y'],
+    ['New York', 45, 'F', 'N'],
+    ['Chicago', 55, 'M', 'N']
+  ]
+
+  @@numeric_labels = [ 'city', 'age', 'gender', 'marketing_target' ]
   
   def test_build
     assert_raise(ArgumentError) { Prism.new.build(DataSet.new) } 
@@ -80,6 +92,15 @@ class PrismTest < Test::Unit::TestCase
 
     assert classifier.matches_conditions(['New York', '<30', 'M', 'Y'], {"age_range" => "<30"})
     assert !classifier.matches_conditions(['New York', '<30', 'M', 'Y'], {"age_range" => "[50-80]"})
+  end
+
+  def test_numeric_data
+    classifier = Prism.new.build(DataSet.new(
+      :data_items => @@numeric_examples,
+      :data_labels => @@numeric_labels))
+    assert classifier.rules.any? { |r| r[:conditions].values.any? { |v| v.is_a?(Range) } }
+    assert_equal('Y', classifier.eval(['New York', 20, 'M']))
+    assert_equal('N', classifier.eval(['Chicago', 55, 'M']))
   end
 end
 


### PR DESCRIPTION
## Summary
- support `bin_count` parameter for Prism
- bin numeric attributes when building rules
- handle numeric ranges when evaluating conditions
- document numeric support for Prism
- test Prism with numeric attributes

## Testing
- `bundle exec rake test` *(fails: NoMethodError in unrelated WardLinkageHierarchicalTest)*
- `bundle exec ruby -Ilib:test test/classifiers/prism_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6871a0860fec8326895496ddcd1f7db2