### PR TITLE
Add structured rule export for Prism

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,6 +74,17 @@ RNG before choosing initial centroids.
   kmeans = Ai4r::Clusterers::KMeans.new
   kmeans.set_parameters(:random_seed => 1).build(data, 2)
 
+== Prism rule hashes
+
+Prism exposes rules as Ruby hashes so you can iterate over them without
+evaluating Ruby code:
+
+  data = Ai4r::Data::DataSet.new.load_csv_with_labels 'examples/classifiers/zero_one_r_data.csv'
+  prism = Ai4r::Classifiers::Prism.new.build(data)
+  prism.rules_as_hash.each do |rule|
+    puts "If #{rule[:conditions]} then marketing_target='#{rule[:class_value]}'"
+  end
+
 = Documentation
 
 Tutorials for genetic algorithms, ID3 decision trees and neural networks are available in the +docs/+ directory.

--- a/lib/ai4r/classifiers/prism.rb
+++ b/lib/ai4r/classifiers/prism.rb
@@ -76,14 +76,25 @@ module Ai4r
       #         'Y'
       def get_rules
         out = "if #{join_terms(@rules.first)} then #{then_clause(@rules.first)}"
-        @rules[1...-1].each do |rule| 
+        @rules[1...-1].each do |rule|
           out += "\nelsif #{join_terms(rule)} then #{then_clause(rule)}"
         end
         out += "\nelse #{then_clause(@rules.last)}" if @rules.size > 1
         out += "\nend"
         return out
       end
-      
+
+      # Returns the generated rules as a Ruby data structure.  Each rule is a
+      # hash containing a ``:class_value'' key and a ``:conditions'' hash with
+      # attribute/value pairs.  This method is useful for iterating over the
+      # rules without evaluating Ruby code.
+      def rules_as_hash
+        @rules.map do |rule|
+          { :class_value => rule[:class_value],
+            :conditions  => rule[:conditions].dup }
+        end
+      end
+
       protected
       
       def get_attr_value(data, attr)

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -25,6 +25,13 @@ class PrismTest < Test::Unit::TestCase
               ]
 
   @@data_labels = [ 'city', 'age_range', 'gender', 'marketing_target'  ]
+
+  EXPECTED_RULES = [
+    { :class_value => 'Y', :conditions => { 'age_range' => '<30' } },
+    { :class_value => 'Y', :conditions => { 'age_range' => '>80' } },
+    { :class_value => 'Y', :conditions => { 'city' => 'Chicago', 'age_range' => '[30-50)' } },
+    { :class_value => 'N', :conditions => {} }
+  ]
   
   def test_build
     assert_raise(ArgumentError) { Prism.new.build(DataSet.new) } 
@@ -53,7 +60,7 @@ class PrismTest < Test::Unit::TestCase
   end
   
   def test_get_rules
-    classifier = Prism.new.build(DataSet.new(:data_items => @@data_examples, 
+    classifier = Prism.new.build(DataSet.new(:data_items => @@data_examples,
         :data_labels => @@data_labels))
     marketing_target = nil
     age_range = nil
@@ -70,8 +77,14 @@ class PrismTest < Test::Unit::TestCase
     eval(classifier.get_rules) 
     assert_equal("N", marketing_target)
     age_range = '[50-80]'
-    eval(classifier.get_rules) 
-    assert_equal("N", marketing_target)   
+    eval(classifier.get_rules)
+    assert_equal("N", marketing_target)
+  end
+
+  def test_rules_as_hash
+    classifier = Prism.new.build(DataSet.new(:data_items => @@data_examples,
+        :data_labels => @@data_labels))
+    assert_equal(EXPECTED_RULES, classifier.rules_as_hash)
   end
     
   def test_matches_conditions


### PR DESCRIPTION
## Summary
- expose `Prism#rules_as_hash` for programmatic access
- test the new method
- document how to iterate over the rules

## Testing
- `bundle exec ruby -Ilib:test test/classifiers/prism_test.rb`
- `bundle exec rake test` *(fails: 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a08977d88326a9e483ecb021a793