### PR TITLE
Support per-layer activation functions

### DIFF
--- a/lib/ai4r/neural_network/activation_functions.rb
+++ b/lib/ai4r/neural_network/activation_functions.rb
@@ -15,13 +15,20 @@ module Ai4r
       FUNCTIONS = {
         sigmoid: ->(x) { 1.0 / (1.0 + Math.exp(-x)) },
         tanh: ->(x) { Math.tanh(x) },
-        relu: ->(x) { x > 0 ? x : 0 }
+        relu: ->(x) { x > 0 ? x : 0 },
+        softmax: lambda do |arr|
+          max = arr.max
+          exps = arr.map { |v| Math.exp(v - max) }
+          sum = exps.inject(:+)
+          exps.map { |e| e / sum }
+        end
       }
 
       DERIVATIVES = {
         sigmoid: ->(y) { y * (1 - y) },
         tanh: ->(y) { 1.0 - y**2 },
-        relu: ->(y) { y > 0 ? 1.0 : 0.0 }
+        relu: ->(y) { y > 0 ? 1.0 : 0.0 },
+        softmax: ->(y) { y * (1 - y) }
       }
     end
   end

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -77,11 +77,27 @@ module Ai4r
       end
       def test_activation_parameter
         net = Backpropagation.new([2, 1], :tanh)
-        assert_equal :tanh, net.activation
-        assert_in_delta Math.tanh(0.5), net.instance_variable_get(:@propagation_function).call(0.5), 0.0001
+        assert_equal [:tanh], net.activation
+        assert_in_delta Math.tanh(0.5), net.instance_variable_get(:@propagation_functions).first.call(0.5), 0.0001
         net.set_parameters(activation: :relu)
-        assert_equal :relu, net.activation
-        assert_equal 0.0, net.instance_variable_get(:@derivative_propagation_function).call(-1.0)
+        assert_equal [:relu], net.activation
+        assert_equal 0.0, net.instance_variable_get(:@derivative_functions).first.call(-1.0)
+      end
+
+      def test_layer_specific_activation
+        net = Backpropagation.new([2, 2, 2], [:relu, :softmax])
+        net.disable_bias = true
+        net.init_network
+        net.weights = [
+          [[1.0, -1.0], [1.0, -1.0]],
+          [[1.0, 0.0], [0.0, 1.0]]
+        ]
+        net.feedforward([1, 1])
+        assert_equal [2.0, 0.0], net.activation_nodes[1]
+        exp2 = Math.exp(2)
+        soft = [exp2 / (exp2 + 1), 1.0 / (exp2 + 1)]
+        assert_in_delta soft[0], net.activation_nodes.last[0], 0.000001
+        assert_in_delta soft[1], net.activation_nodes.last[1], 0.000001
       end
 
       def test_weight_init_parameter


### PR DESCRIPTION
## Summary
- extend activation functions with softmax
- allow Backpropagation networks to specify activations per-layer
- update feedforward and delta calculations for multiple activations
- test per-layer activation usage

## Testing
- `bundle exec ruby -Ilib test/neural_network/backpropagation_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6871c30fbb9c8326b2911e73c15d4321