### PR TITLE
Support shuffling in Backpropagation#train_epochs

### DIFF
--- a/lib/ai4r/neural_network/backpropagation.rb
+++ b/lib/ai4r/neural_network/backpropagation.rb
@@ -195,20 +195,31 @@ module Ai4r
       end
 
       # Train for a number of epochs over the dataset. Optionally define a batch size.
+      # Data can be shuffled between epochs passing +shuffle: true+ (default).
+      # Use +random_seed+ to make shuffling deterministic.
       # Returns an array with the average loss of each epoch.
       def train_epochs(data_inputs, data_outputs, epochs:, batch_size: 1,
-                       early_stopping_patience: nil, min_delta: 0.0)
+                       early_stopping_patience: nil, min_delta: 0.0,
+                       shuffle: true, random_seed: nil)
         raise ArgumentError, "Inputs and outputs size mismatch" if data_inputs.length != data_outputs.length
         losses = []
         best_loss = Float::INFINITY
         patience = early_stopping_patience
         patience_counter = 0
+        rng = random_seed.nil? ? Random.new : Random.new(random_seed)
         epochs.times do
           epoch_error = 0.0
+          epoch_inputs = data_inputs
+          epoch_outputs = data_outputs
+          if shuffle
+            indices = (0...data_inputs.length).to_a.shuffle(random: rng)
+            epoch_inputs = data_inputs.values_at(*indices)
+            epoch_outputs = data_outputs.values_at(*indices)
+          end
           index = 0
-          while index < data_inputs.length
-            batch_in = data_inputs[index, batch_size]
-            batch_out = data_outputs[index, batch_size]
+          while index < epoch_inputs.length
+            batch_in = epoch_inputs[index, batch_size]
+            batch_out = epoch_outputs[index, batch_size]
             batch_error = train_batch(batch_in, batch_out)
             epoch_error += batch_error * batch_in.length
             index += batch_size

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -122,6 +122,52 @@ module Ai4r
         assert history[0] > history[1]
       end
 
+      def test_train_epochs_shuffling
+        net = Backpropagation.new([1, 1])
+        order = []
+        net.define_singleton_method(:train_batch) do |batch_in, _|
+          order << batch_in.first.first
+          0.0
+        end
+        inputs = [[0], [1], [2], [3]]
+        outputs = [[0], [1], [2], [3]]
+        net.train_epochs(inputs, outputs, epochs: 1, batch_size: 1, shuffle: false)
+        assert_equal [0, 1, 2, 3], order
+
+        order.clear
+        seed = 42
+        net.train_epochs(inputs, outputs, epochs: 1, batch_size: 1,
+                         shuffle: true, random_seed: seed)
+        expected = (0...4).to_a.shuffle(random: Random.new(seed))
+        assert_equal expected, order
+      end
+
+      def test_train_epochs_shuffling_reproducible
+        inputs = [[0], [1], [2], [3]]
+        outputs = [[0], [1], [2], [3]]
+        seed = 99
+
+        order1 = []
+        net1 = Backpropagation.new([1, 1])
+        net1.define_singleton_method(:train_batch) do |batch_in, _|
+          order1 << batch_in.first.first
+          0.0
+        end
+        net1.train_epochs(inputs, outputs, epochs: 1, batch_size: 1,
+                          shuffle: true, random_seed: seed)
+
+        order2 = []
+        net2 = Backpropagation.new([1, 1])
+        net2.define_singleton_method(:train_batch) do |batch_in, _|
+          order2 << batch_in.first.first
+          0.0
+        end
+        net2.train_epochs(inputs, outputs, epochs: 1, batch_size: 1,
+                          shuffle: true, random_seed: seed)
+
+        assert_equal order1, order2
+      end
+
 
     end
 


### PR DESCRIPTION
## Summary
- allow `train_epochs` to shuffle training data each epoch
- support a deterministic `random_seed`
- test new shuffling behaviour and deterministic results

## Testing
- `bundle exec rake test` *(fails: SyntaxError in k_means.rb)*

------
https://chatgpt.com/codex/tasks/task_e_6871c30fc87c8326ac03cec51494292a