### PR TITLE
Add callback for training epochs

### DIFF
--- a/examples/neural_network/train_epochs_callback.rb
+++ b/examples/neural_network/train_epochs_callback.rb
@@ -1,0 +1,20 @@
+# Author::    Example contributor
+# License::   MPL 1.1
+# Project::   ai4r
+#
+# Simple example showing how to use Backpropagation#train_epochs with a callback.
+
+require File.dirname(__FILE__) + '/../../lib/ai4r/neural_network/backpropagation'
+
+inputs  = [[0,0], [0,1], [1,0], [1,1]]
+outputs = [[0], [1], [1], [0]]
+
+net = Ai4r::NeuralNetwork::Backpropagation.new([2, 2, 1])
+
+loss_history = []
+net.train_epochs(inputs, outputs, epochs: 200, batch_size: 1) do |epoch, loss, acc|
+  loss_history << [epoch, loss, acc]
+  puts "Epoch #{epoch}: loss #{format('%.4f', loss)} accuracy #{(acc*100).round(2)}%" if epoch % 50 == 0
+end
+
+puts 'Training finished.'

--- a/lib/ai4r/classifiers/prism.rb
+++ b/lib/ai4r/classifiers/prism.rb
@@ -29,15 +29,11 @@ module Ai4r
 
       attr_reader :data_set, :rules, :majority_class
 
-      parameters_info :fallback_class => 'Default class returned when no rule matches.'
+      parameters_info :fallback_class => 'Default class returned when no rule matches.',
+        :bin_count => 'Number of bins used to discretize numeric attributes.'
 
       def initialize
         @fallback_class = nil
-      end
-
-      parameters_info :bin_count => 'Number of bins used to discretize numeric attributes.'
-
-      def initialize
         @bin_count = 10
         @attr_bins = {}
       end

--- a/lib/ai4r/clusterers/k_means.rb
+++ b/lib/ai4r/clusterers/k_means.rb
@@ -51,7 +51,7 @@ module Ai4r
         :init_method => "Strategy to initialize centroids. Available values: " +
           ":random (default) and :kmeans_plus_plus.",
         :restarts => "Number of random initializations to perform. " +
-          "The best run (lowest SSE) will be kept."
+          "The best run (lowest SSE) will be kept.",
         :track_history => "Keep centroids and assignments for each iteration " +
           "when building the clusterer."
       

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -122,6 +122,22 @@ module Ai4r
         assert history[0] > history[1]
       end
 
+      def test_train_epochs_yields_epoch_and_loss
+        net = Backpropagation.new([1, 1])
+        losses = [0.2, 0.1]
+        net.define_singleton_method(:train_batch) do |_, _|
+          losses.shift
+        end
+        net.define_singleton_method(:eval) do |_|
+          [0]
+        end
+        yielded = []
+        net.train_epochs([[0]], [[0]], epochs: 2) do |epoch, loss, acc|
+          yielded << [epoch, loss, acc]
+        end
+        assert_equal [[0, 0.2, 1.0], [1, 0.1, 1.0]], yielded
+      end
+
 
     end
 


### PR DESCRIPTION
## Summary
- yield epoch info in Backpropagation#train_epochs
- add example using the new callback
- ensure Prism parameters are initialized correctly
- fix syntax issue in KMeans parameter list
- test train_epochs callback invocation

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871c314b97083269db078cbc3434358