### PR TITLE
Fix Hopfield update strategy default

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -52,6 +52,8 @@ The resulting plot shows how the energy decreases as the network converges.
 * `active_node_value` – value representing an active neuron (default `1`).
 * `inactive_node_value` – value representing an inactive neuron (default `-1`).
 * `threshold` – activation threshold used during propagation (default `0`).
+* `update_strategy` – update mode used during evaluation. `:async_random` (default) updates one randomly chosen neuron each step, while
+  `:async_sequential` and `:synchronous` offer alternative behaviors.
 
 ```ruby
 net.set_parameters(eval_iterations: 1000, threshold: 0.2)

--- a/lib/ai4r/neural_network/hopfield.rb
+++ b/lib/ai4r/neural_network/hopfield.rb
@@ -56,7 +56,7 @@ require_relative '../data/parameterizable'
         @threshold = 0
         @weight_scaling = nil
         @stop_when_stable = false
-        @update_strategy = :async_sequential
+        @update_strategy = :async_random
       end
 
       # Prepares the network to memorize the given data set.

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -9,7 +9,8 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'ai4r'
+require 'ai4r/neural_network/hopfield'
+require 'ai4r/data/data_set'
 require 'test/unit'
 
 Ai4r::NeuralNetwork::Hopfield.send(:public, *Ai4r::NeuralNetwork::Hopfield.protected_instance_methods)  
@@ -34,6 +35,11 @@ module Ai4r
         net = Hopfield.new
         data_set = Ai4r::Data::DataSet.new :data_items => [[1,1,0,0,1,1,0,0]]
         assert_equal [-1,-1,-1,-1,-1,-1,-1,-1], net.initialize_nodes(data_set)
+      end
+
+      def test_default_update_strategy
+        net = Hopfield.new
+        assert_equal :async_random, net.update_strategy
       end
       
       def test_initialize_weights


### PR DESCRIPTION
## Summary
- revert Hopfield initialization to `:async_random`
- test that new instances use the async random strategy
- document `update_strategy` parameter and default
- restrict Hopfield test dependencies to avoid unrelated syntax issues

## Testing
- `bundle exec rake test TEST=test/neural_network/hopfield_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6871c320a3b88326ab824b43bb49d5a9