### PR TITLE
Update Hopfield example to demonstrate tracing

### DIFF
--- a/examples/neural_network/hopfield_example.rb
+++ b/examples/neural_network/hopfield_example.rb
@@ -25,9 +25,19 @@ noisy_patterns = [
 ]
 
 data = Ai4r::Data::DataSet.new(data_items: patterns)
-net = Ai4r::NeuralNetwork::Hopfield.new.train(data)
+
+# Use random asynchronous updates instead of the default sequential
+# strategy.  Random updates are closer to the original Hopfield
+# formulation and may help the network escape shallow local minima.
+net = Ai4r::NeuralNetwork::Hopfield.new
+net.set_parameters(update_strategy: :async_random)
+net.train(data)
 
 puts 'Evaluation of noisy patterns:'
 noisy_patterns.each do |p|
-  puts "#{p.inspect} => #{net.eval(p).inspect}"
+  # Pass `trace: true` to record the energy of each iteration so we can
+  # inspect how the network converges to a memorized pattern.
+  trace = net.eval(p, trace: true)
+  puts "#{p.inspect} => #{trace[:states].last.inspect}"
+  puts "Energy trace: #{trace[:energies].inspect}"
 end


### PR DESCRIPTION
## Summary
- configure Hopfield network with asynchronous random updates
- evaluate noisy patterns with tracing enabled and print energy history

## Testing
- `bundle exec rake test` *(fails: syntax errors in k_means.rb)*

------
https://chatgpt.com/codex/tasks/task_e_6871c322af808326b294a2c42343e7d5