### PR TITLE
Add initializer parameters for Hopfield

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -16,7 +16,7 @@ patterns = [
 ]
 
 data = Ai4r::Data::DataSet.new(data_items: patterns)
-net = Ai4r::NeuralNetwork::Hopfield.new.train(data)
+net = Ai4r::NeuralNetwork::Hopfield.new(eval_iterations: 1000).train(data)
 ```
 
 Evaluation uses the same vector format:
@@ -46,7 +46,7 @@ The resulting plot shows how the energy decreases as the network converges.
 
 ## Parameters
 
-`Ai4r::NeuralNetwork::Hopfield` supports several parameters which can be set with `set_parameters`:
+`Ai4r::NeuralNetwork::Hopfield` supports several parameters which can be set when the network is created or later with `set_parameters`:
 
 * `eval_iterations` – maximum number of iterations when calling `eval` (default `500`).
 * `active_node_value` – value representing an active neuron (default `1`).
@@ -54,6 +54,8 @@ The resulting plot shows how the energy decreases as the network converges.
 * `threshold` – activation threshold used during propagation (default `0`).
 
 ```ruby
+# equivalent ways to configure parameters
+net = Ai4r::NeuralNetwork::Hopfield.new(eval_iterations: 1000, threshold: 0.2)
 net.set_parameters(eval_iterations: 1000, threshold: 0.2)
 ```
 

--- a/examples/neural_network/hopfield_example.rb
+++ b/examples/neural_network/hopfield_example.rb
@@ -25,7 +25,7 @@ noisy_patterns = [
 ]
 
 data = Ai4r::Data::DataSet.new(data_items: patterns)
-net = Ai4r::NeuralNetwork::Hopfield.new.train(data)
+net = Ai4r::NeuralNetwork::Hopfield.new(eval_iterations: 1000).train(data)
 
 puts 'Evaluation of noisy patterns:'
 noisy_patterns.each do |p|

--- a/lib/ai4r/neural_network/hopfield.rb
+++ b/lib/ai4r/neural_network/hopfield.rb
@@ -49,7 +49,7 @@ require_relative '../data/parameterizable'
         :update_strategy => "Update mode: :async_random (default), " +
           ":async_sequential, :synchronous"
             
-      def initialize
+      def initialize(params = {})
         @eval_iterations = 500
         @active_node_value = 1
         @inactive_node_value = -1
@@ -57,6 +57,7 @@ require_relative '../data/parameterizable'
         @weight_scaling = nil
         @stop_when_stable = false
         @update_strategy = :async_sequential
+        set_parameters(params) if params && !params.empty?
       end
 
       # Prepares the network to memorize the given data set.

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -9,8 +9,9 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'ai4r'
 require 'test/unit'
+require 'ai4r/neural_network/hopfield'
+require 'ai4r/data/data_set'
 
 Ai4r::NeuralNetwork::Hopfield.send(:public, *Ai4r::NeuralNetwork::Hopfield.protected_instance_methods)  
 
@@ -43,6 +44,12 @@ module Ai4r
         assert_equal 15, net.weights.length
         net.weights.each_with_index {|w_row, i| assert_equal i+1, w_row.length}
         assert_in_delta 1.0, net.read_weight(1,0), 0.00001
+      end
+
+      def test_initialize_with_params
+        net = Hopfield.new(eval_iterations: 42, threshold: 0.5)
+        assert_equal 42, net.eval_iterations
+        assert_in_delta 0.5, net.threshold, 0.00001
       end
       
       def test_run


### PR DESCRIPTION
## Summary
- allow `Hopfield.new` to accept an optional hash of parameters
- document passing parameters on initialization
- update Hopfield example script
- test initialization with parameters

## Testing
- `bundle exec rake test` *(fails: syntax error in k_means.rb)*
- `bundle exec rake test TEST=test/neural_network/hopfield_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6871c3249be48326b632b51f385ba692