### PR TITLE
Add weight_scaling docs and test

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -52,9 +52,20 @@ The resulting plot shows how the energy decreases as the network converges.
 * `active_node_value` – value representing an active neuron (default `1`).
 * `inactive_node_value` – value representing an inactive neuron (default `-1`).
 * `threshold` – activation threshold used during propagation (default `0`).
+* `weight_scaling` – scale factor applied when computing weights (default
+  `1.0 / patterns_count`). Increasing it strengthens pattern recall while
+  smaller values soften convergence.
 
 ```ruby
 net.set_parameters(eval_iterations: 1000, threshold: 0.2)
+```
+
+You can also change the weight scaling factor:
+
+```ruby
+net = Ai4r::NeuralNetwork::Hopfield.new
+net.set_parameters(weight_scaling: 0.5)
+net.train(data)
 ```
 
 ## Theory

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -150,6 +150,19 @@ module Ai4r
         assert_raise(ArgumentError) { net.train(invalid2) }
       end
 
+      def test_weight_scaling_changes_weights
+        default_net = Hopfield.new
+        default_net.train @data_set
+
+        scaled_net = Hopfield.new
+        scaled_net.set_parameters(weight_scaling: 0.5)
+        scaled_net.train @data_set
+
+        assert_not_equal default_net.weights, scaled_net.weights
+        assert_in_delta default_net.read_weight(1,0) * 2,
+          scaled_net.read_weight(1,0), 0.00001
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Summary
- document `weight_scaling` in Hopfield docs
- example usage for adjusting weight scaling
- add unit test to ensure different weight_scaling values produce different weights

## Testing
- `bundle exec rake test TEST=test/neural_network/hopfield_test.rb` *(fails: syntax errors in clusterer files)*

------
https://chatgpt.com/codex/tasks/task_e_6871c3261ef48326948d6c5da5345aae