### PR TITLE
Add IB1 incremental learning support

### DIFF
--- a/docs/ib1.md
+++ b/docs/ib1.md
@@ -1,0 +1,29 @@
+# IB1 Classifier
+
+IB1 performs nearest neighbour classification while automatically normalizing numeric attributes. It stores every training instance and compares them to new data when evaluating.
+
+```ruby
+require 'ai4r/classifiers/ib1'
+require 'ai4r/data/data_set'
+
+labels = %w[city age gender marketing_target]
+items = [
+  ['New York', 25, 'M', 'Y'],
+  ['Chicago', 43, 'M', 'Y']
+]
+
+set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
+classifier = Ai4r::Classifiers::IB1.new.build(set)
+```
+
+## Incremental learning
+
+New training instances can be added at any time using `add_instance`:
+
+```ruby
+classifier.add_instance(['Chicago', 55, 'M', 'N'])
+```
+
+`add_instance` appends the item to the internal dataset and updates the
+stored minimum and maximum values so that distance calculations remain
+normalized.

--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -41,6 +41,16 @@ module Ai4r
         data_set.data_items.each { |data_item| update_min_max(data_item[0...-1]) }
         return self
       end
+
+      # Append a new instance to the internal dataset. The last element is
+      # considered the class label. Minimum and maximum values for numeric
+      # attributes are updated so that future distance calculations remain
+      # normalized.
+      def add_instance(data_item)
+        @data_set << data_item
+        update_min_max(data_item[0...-1])
+        self
+      end
       
       # You can evaluate new data, predicting its class.
       # e.g.

--- a/test/classifiers/ib1_test.rb
+++ b/test/classifiers/ib1_test.rb
@@ -70,7 +70,17 @@ class IB1Test < Test::Unit::TestCase
     assert_equal('N', classifier.eval(['Chicago',  55, 'M']))
     assert_equal('N', classifier.eval(['New York', 35, 'F']))
     assert_equal('Y', classifier.eval(['New York', 25, 'M']))
-    assert_equal('Y', classifier.eval(['Chicago',  85, 'F'])) 
+    assert_equal('Y', classifier.eval(['Chicago',  85, 'F']))
+  end
+
+  def test_add_instance
+    items = @@data_items[0...7]
+    data_set = DataSet.new(data_items: items, data_labels: @@data_labels)
+    classifier = IB1.new.build(data_set)
+    assert_equal('Y', classifier.eval(['Chicago', 55, 'M']))
+    classifier.add_instance(['Chicago', 55, 'M', 'N'])
+    assert_equal('N', classifier.eval(['Chicago', 55, 'M']))
+    assert_equal 8, classifier.data_set.data_items.length
   end
 
 end


### PR DESCRIPTION
## Summary
- implement `add_instance` for IB1 classifier
- document incremental learning in `docs/ib1.md`
- test adding instances

## Testing
- `bundle exec rake test` *(fails: SyntaxError in backpropagation.rb)*

------
https://chatgpt.com/codex/tasks/task_e_6871c9df644c8326a047fbab889732b3