### PR TITLE
Add k-NN features to IB1 classifier

### DIFF
--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -27,8 +27,18 @@ module Ai4r
     # it normalizes its attributes' ranges, processes instances
     # incrementally, and has a simple policy for tolerating missing values
     class IB1 < Classifier
-      
+
       attr_reader :data_set
+
+      parameters_info :k => 'Number of nearest neighbors to consider. Default is 1.',
+        :distance_function => 'Optional custom distance metric taking two instances.',
+        :tie_break => 'Strategy used when neighbors vote tie. Valid values are :first (default) and :random.'
+
+      def initialize
+        @k = 1
+        @distance_function = nil
+        @tie_break = :first
+      end
 
       # Build a new IB1 classifier. You must provide a DataSet instance
       # as parameter. The last attribute of each item is considered as 
@@ -47,16 +57,26 @@ module Ai4r
       #   classifier.eval(['New York',  '<30', 'F'])  # => 'Y'      
       def eval(data)
         update_min_max(data)
-        min_distance = 1.0/0
-        klass = nil
-        @data_set.data_items.each do |train_item|
-          d = distance(data, train_item)
-          if d < min_distance
-            min_distance = d
-            klass = train_item.last
-          end
+        metric = @distance_function || method(:distance)
+        neighbors = @data_set.data_items.map do |train_item|
+          [metric.call(data, train_item), train_item.last]
         end
-        return klass
+        neighbors.sort_by! { |d, _| d }
+        k_neighbors = neighbors.first([@k, @data_set.data_items.length].min)
+
+        counts = Hash.new(0)
+        k_neighbors.each { |_, klass| counts[klass] += 1 }
+        max_votes = counts.values.max
+        tied = counts.select { |_, v| v == max_votes }.keys
+
+        return tied.first if tied.length == 1
+
+        case @tie_break
+        when :random
+          tied.sample
+        else
+          k_neighbors.each { |_, klass| return klass if tied.include?(klass) }
+        end
       end
       
       protected

--- a/test/classifiers/ib1_test.rb
+++ b/test/classifiers/ib1_test.rb
@@ -42,6 +42,13 @@ class IB1Test < Test::Unit::TestCase
     @data_set = DataSet.new(:data_items => @@data_items, :data_labels => @@data_labels)
     @classifier = IB1.new.build(@data_set)
   end
+
+  def test_default_parameters
+    c = IB1.new
+    assert_equal 1, c.k
+    assert_nil c.distance_function
+    assert_equal :first, c.tie_break
+  end
   
   def test_build
     assert_raise(ArgumentError) { IB1.new.build(DataSet.new) }
@@ -70,7 +77,26 @@ class IB1Test < Test::Unit::TestCase
     assert_equal('N', classifier.eval(['Chicago',  55, 'M']))
     assert_equal('N', classifier.eval(['New York', 35, 'F']))
     assert_equal('Y', classifier.eval(['New York', 25, 'M']))
-    assert_equal('Y', classifier.eval(['Chicago',  85, 'F'])) 
+    assert_equal('Y', classifier.eval(['Chicago',  85, 'F']))
+  end
+
+  def test_k_nearest
+    classifier = IB1.new.set_parameters(:k => 3).build(@data_set)
+    assert_equal('N', classifier.eval(['Chicago', 47, 'M']))
+  end
+
+  def test_tie_break
+    classifier = IB1.new.set_parameters(:k => 2, :tie_break => :first).build(@data_set)
+    assert_equal('Y', classifier.eval(['Chicago', 47, 'M']))
+    srand(1)
+    classifier = IB1.new.set_parameters(:k => 2, :tie_break => :random).build(@data_set)
+    assert_equal('N', classifier.eval(['Chicago', 47, 'M']))
+  end
+
+  def test_custom_distance
+    dist = proc { |a, b| a.first == b.first ? 0 : 1 }
+    classifier = IB1.new.set_parameters(:distance_function => dist).build(@data_set)
+    assert_equal('Y', classifier.eval(['Chicago', 55, 'M']))
   end
 
 end


### PR DESCRIPTION
## Summary
- allow setting parameters `k`, `distance_function`, and `tie_break`
- update `IB1#eval` to vote among the `k` nearest neighbors
- add tests for new options

## Testing
- `ruby -I lib test/classifiers/ib1_test.rb`
- `bundle exec rake test` *(fails: backpropagation syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871c9dcb5888326be4824b3d725d608