### PR TITLE
Replace 1.0/0 with Float::INFINITY

### DIFF
--- a/lib/ai4r/clusterers/diana.rb
+++ b/lib/ai4r/clusterers/diana.rb
@@ -117,7 +117,7 @@ module Ai4r
       # A positive value means that the items is closer to the
       # splinter group than to its current cluster.
       def max_distance_difference(cluster_to_split, splinter_cluster)
-        max_diff = -1.0/0
+        max_diff = -Float::INFINITY
         max_diff_index = 0
         cluster_to_split.data_items.each_with_index do |item, index|
           dist_a = distance_sum(item, cluster_to_split) / (cluster_to_split.data_items.length-1)

--- a/lib/ai4r/clusterers/single_linkage.rb
+++ b/lib/ai4r/clusterers/single_linkage.rb
@@ -53,7 +53,7 @@ module Ai4r
       # number_of_clusters are reached or no distance among clusters are below :distance
       def build(data_set, number_of_clusters = 1, **options)
         @data_set = data_set
-        distance = options[:distance] || (1.0/0)
+        distance = options[:distance] || (Float::INFINITY)
 
         @index_clusters = create_initial_index_clusters
         create_distance_matrix(data_set)
@@ -228,7 +228,7 @@ module Ai4r
       # Returns ans array with the indexes of the two closest
       # clusters => [index_cluster_a, index_cluster_b]
       def get_closest_clusters(index_clusters)
-        min_distance = 1.0/0
+        min_distance = Float::INFINITY
         closest_clusters = [1, 0]
         index_clusters.each_index do |index_a|
           index_a.times do |index_b|
@@ -243,7 +243,7 @@ module Ai4r
       end
 
       def distance_between_item_and_cluster(data_item, cluster)
-        min_dist = 1.0/0
+        min_dist = Float::INFINITY
         cluster.data_items.each do |another_item|
           dist = @distance_function.call(data_item, another_item)
           min_dist = dist if dist < min_dist

--- a/lib/ai4r/data/statistics.rb
+++ b/lib/ai4r/data/statistics.rb
@@ -61,14 +61,14 @@ module Ai4r
       def self.max(data_set, attribute)
         index = data_set.get_index(attribute)
         item = data_set.data_items.max_by { |item| item[index] }
-        return (item) ? item[index] : (-1.0/0)
+        return (item) ? item[index] : (-Float::INFINITY)
       end
 
       # Get the minimum value of an attribute in the data set
       def self.min(data_set, attribute)
         index = data_set.get_index(attribute)
         item = data_set.data_items.min_by { |item| item[index] }
-        return (item) ? item[index] : (1.0/0)
+        return (item) ? item[index] : (Float::INFINITY)
       end
 
     end


### PR DESCRIPTION
## Summary
- use `Float::INFINITY` instead of `1.0/0`
- use `-Float::INFINITY` instead of `-1.0/0`

## Testing
- `bundle exec rake test` *(fails: syntax error in backpropagation.rb)*

------
https://chatgpt.com/codex/tasks/task_e_6871cd93cda0832693cec39dd87250c8