### PR TITLE
Fix project URL typo in backpropagation.rb

### DIFF
--- a/lib/ai4r/neural_network/backpropagation.rb
+++ b/lib/ai4r/neural_network/backpropagation.rb
@@ -2,7 +2,7 @@
 # Author::    Sergio Fierens
 # License::   MPL 1.1
 # Project::   ai4r
-# Url::       hhttps://github.com/SergioFierens/ai4r
+# Url::       https://github.com/SergioFierens/ai4r
 #
 # You can redistribute it and/or modify it under the terms of 
 # the Mozilla Public License version 1.1  as published by the 


### PR DESCRIPTION
## Summary
- correct ai4r project URL in backpropagation.rb

## Testing
- `bundle exec rake test` *(fails: unmatched `end` in backpropagation.rb)*

------
https://chatgpt.com/codex/tasks/task_e_6871cd981de08326869370f5f3bd889f