### PR TITLE
Add RuboCop configuration and task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.1
+
+Layout/LineLength:
+  Max: 100
+
+Layout/IndentationStyle:
+  EnforcedStyle: spaces
+
+Layout/IndentationWidth:
+  Width: 2

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gem "rake", "~> 13"
 gem "rdoc", "~> 6"
 gem "csv", "~> 3"
 gem "test-unit", "~> 3"
+
+group :development do
+  gem "rubocop", "~> 1.78", require: false
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,50 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     csv (3.3.5)
     date (3.4.1)
     erb (5.0.1)
+    json (2.12.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    parallel (1.27.0)
+    parser (3.3.8.0)
+      ast (~> 2.4.1)
+      racc
     power_assert (2.0.5)
+    prism (1.4.0)
     psych (5.2.6)
       date
       stringio
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.3.0)
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    regexp_parser (2.10.0)
+    rubocop (1.78.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.45.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.45.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     stringio (3.1.7)
     test-unit (3.7.0)
       power_assert
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
@@ -24,6 +54,7 @@ DEPENDENCIES
   csv (~> 3)
   rake (~> 13)
   rdoc (~> 6)
+  rubocop (~> 1.78)
   test-unit (~> 3)
 
 BUNDLED WITH

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,6 +1,7 @@
 require 'rake'
 require 'rake/testtask'
 require 'rdoc/task'
+require 'rubocop/rake_task'
 
 Rake::TestTask.new do |t|
   t.test_files = FileList["test/**/*_test.rb"]
@@ -12,4 +13,6 @@ Rake::RDocTask.new do |rd|
   rd.rdoc_files.include("README.rdoc", "lib/**/*.rb")
   rd.title = "ar4r - Artificial Intelligence For Ruby - API DOC"
 end
+
+RuboCop::RakeTask.new(:rubocop)
 


### PR DESCRIPTION
## Summary
- add RuboCop in the development group
- configure rubocop style rules
- add `rubocop` Rake task

## Testing
- `bundle exec rake test` *(fails: syntax errors)*
- `bundle exec rake rubocop` *(fails: many offenses)*

------
https://chatgpt.com/codex/tasks/task_e_6871cdd230b88326a837ddd7ebe28e34