### PR TITLE
Add numeric parsing option to CSV loader

### DIFF
--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -75,14 +75,9 @@ module Ai4r
       # classifier state unchanged. Use +update_with_instance+ to
       # incorporate new samples.
       def eval(data)
-        min_distance = 1.0/0
-        klass = nil
-        @data_set.data_items.each do |train_item|
-          d = distance(data, train_item)
-          if d < min_distance
-            min_distance = d
-            klass = train_item.last
-          end
+        metric = @distance_function || method(:distance)
+        neighbors = @data_set.data_items.map do |train_item|
+          [metric.call(data, train_item), train_item.last]
         end
         neighbors.sort_by! { |d, _| d }
         k_neighbors = neighbors.first([@k, @data_set.data_items.length].min)

--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -68,12 +68,16 @@ module Ai4r
       # Load data items from csv file
       # @param filepath [Object]
       # @return [Object]
-      def load_csv(filepath)
-        items = []
-        open_csv_file(filepath) do |entry|
-          items << entry
+      def load_csv(filepath, parse_numeric: false)
+        if parse_numeric
+          parse_csv(filepath)
+        else
+          items = []
+          open_csv_file(filepath) do |entry|
+            items << entry
+          end
+          set_data_items(items)
         end
-        set_data_items(items)
       end
 
       # Open a CSV file and yield each row to the provided block.
@@ -89,8 +93,8 @@ module Ai4r
       # Load data items from csv file. The first row is used as data labels.
       # @param filepath [Object]
       # @return [Object]
-      def load_csv_with_labels(filepath)
-        load_csv(filepath)
+      def load_csv_with_labels(filepath, parse_numeric: false)
+        load_csv(filepath, parse_numeric: parse_numeric)
         @data_labels = @data_items.shift
         return self
       end
@@ -112,9 +116,7 @@ module Ai4r
       # @param filepath [Object]
       # @return [Object]
       def parse_csv_with_labels(filepath)
-        parse_csv(filepath)
-        @data_labels = @data_items.shift
-        return self
+        load_csv_with_labels(filepath, parse_numeric: true)
       end
 
       # Set data labels.

--- a/test/data/data_set_test.rb
+++ b/test/data/data_set_test.rb
@@ -19,6 +19,9 @@ module Ai4r
         assert_equal 120, set.data_items.length
         assert_equal ["zone", "rooms", "size", "price"], set.data_labels
         assert_equal ["Moron Sur (GBA)","2","[28 m2 - 39 m2]","[29K-35K]"], set.data_items.first
+
+        set = DataSet.new.load_csv_with_labels("#{File.dirname(__FILE__)}/data_set.csv", parse_numeric: true)
+        assert_equal ["Moron Sur (GBA)",2.0,"[28 m2 - 39 m2]","[29K-35K]"], set.data_items.first
       end
 
       def test_parse_csv_with_labels


### PR DESCRIPTION
## Summary
- allow optional numeric parsing when loading CSV data
- support same option in `load_csv_with_labels`
- test the new behavior
- fix `IB1#eval` to avoid updating ranges during evaluation

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871cfa2ce6083269b6d7d24ad468bed