### PR TITLE
Accept random_seed for SOM

### DIFF
--- a/lib/ai4r/som/node.rb
+++ b/lib/ai4r/som/node.rb
@@ -50,6 +50,9 @@ module Ai4r
       # @param columns [Object]
       # @param dimensions [Object]
       # @param options [Object]
+      # @option options [Range] :range (0..1) range used to initialize weights
+      # @option options [Integer] :random_seed Seed for Ruby's RNG. The
+      #   deprecated :seed key is supported for backward compatibility.
       # @return [Object]
       def self.create(id, rows, columns, dimensions, options = {})
         n = Node.new
@@ -65,10 +68,14 @@ module Ai4r
       # for backup reasons, the instantiated weight is stored into @instantiated_weight  as well
       # @param dimensions [Object]
       # @param options [Object]
+      # @option options [Range] :range (0..1) range used to initialize weights
+      # @option options [Integer] :random_seed Seed for Ruby's RNG. The
+      #   deprecated :seed key is supported for backward compatibility.
       # @return [Object]
       def instantiate_weight(dimensions, options = {})
-        opts = { range: 0..1, seed: nil }.merge(options)
-        srand(opts[:seed]) unless opts[:seed].nil?
+        opts = { range: 0..1, random_seed: nil, seed: nil }.merge(options)
+        seed = opts[:random_seed] || opts[:seed]
+        srand(seed) unless seed.nil?
         range = opts[:range] || (0..1)
         min = range.first.to_f
         max = range.last.to_f

--- a/lib/ai4r/som/som.rb
+++ b/lib/ai4r/som/som.rb
@@ -62,16 +62,18 @@ module Ai4r
                       :dimension => "sets the dimension of the input",
                       :layer => "instance of a layer, defines how the training algorithm works",
                       :epoch => "number of finished epochs",
-                      :init_weight_options => "Hash with :range and :seed to initialize node weights"
+                      :init_weight_options => "Hash with :range and :random_seed to initialize node weights (also accepts :seed)"
 
       # @param dim [Object]
       # @param rows [Object]
       # @param columns [Object]
       # @param layer [Object]
       # @param init_weight_options [Object]
-      # @param seed [Object]
+      #   Hash with :range and :random_seed used when initializing node weights.
+      #   The deprecated :seed key is still supported.
+      # @param random_seed [Object]
       # @return [Object]
-      def initialize(dim, rows, columns, layer, init_weight_options = { range: 0..1, seed: nil })
+      def initialize(dim, rows, columns, layer, init_weight_options = { range: 0..1, random_seed: nil })
         @layer = layer
         @dimension = dim
         @rows = rows
@@ -79,7 +81,9 @@ module Ai4r
         @nodes = Array.new(rows * columns)
         @epoch = 0
         @cache = {}
-        @init_weight_options = init_weight_options
+        opts = { range: 0..1, random_seed: nil, seed: nil }.merge(init_weight_options)
+        opts[:random_seed] = opts[:random_seed] || opts[:seed]
+        @init_weight_options = opts
       end
 
       # finds the best matching unit (bmu) of a certain input in all the @nodes
@@ -179,7 +183,8 @@ module Ai4r
       # intitiates the map by creating (@rows * @columns) nodes
       # @return [Object]
       def initiate_map
-        srand(@init_weight_options[:seed]) unless @init_weight_options[:seed].nil?
+        seed = @init_weight_options[:random_seed]
+        srand(seed) unless seed.nil?
         @nodes.each_with_index do |node, i|
           options = @init_weight_options.merge(distance_metric: @layer.distance_metric)
           @nodes[i] = Node.create i, @rows, @columns, @dimension, options

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -85,7 +85,7 @@ module Ai4r
       end
 
       def test_weight_options
-        som = Som.new 2, 2, 2, Layer.new(3, 3), { range: -1..0, seed: 1 }
+        som = Som.new 2, 2, 2, Layer.new(3, 3), { range: -1..0, random_seed: 1 }
         som.initiate_map
         som.nodes.each do |node|
           node.weights.each do |w|
@@ -95,7 +95,15 @@ module Ai4r
         end
 
         other = Som.new 2, 2, 2, Layer.new(3, 3)
-        other.set_parameters({ :init_weight_options => { range: -1..0, seed: 1 } })
+        other.set_parameters({ :init_weight_options => { range: -1..0, random_seed: 1 } })
+        other.initiate_map
+        assert_equal som.nodes.map(&:weights), other.nodes.map(&:weights)
+      end
+
+      def test_seed_alias
+        som = Som.new 2, 2, 2, Layer.new(3, 3), { range: -1..0, seed: 2 }
+        som.initiate_map
+        other = Som.new 2, 2, 2, Layer.new(3, 3), { range: -1..0, random_seed: 2 }
         other.initiate_map
         assert_equal som.nodes.map(&:weights), other.nodes.map(&:weights)
       end

--- a/test/som/training_test.rb
+++ b/test/som/training_test.rb
@@ -8,7 +8,7 @@ module Ai4r
 
       def setup
         layer = TwoPhaseLayer.new(4, 0.5, 1, 1, 0.5, 0.2)
-        @som = Som.new(2, 2, 2, layer, { range: 0..1, seed: 1 })
+        @som = Som.new(2, 2, 2, layer, { range: 0..1, random_seed: 1 })
         @som.initiate_map
       end
 


### PR DESCRIPTION
## Summary
- update Node and Som to use `random_seed` instead of `seed`
- maintain `seed` as a deprecated alias
- update SOM unit tests to use the new option and add coverage for the alias

## Testing
- `bundle exec rake test` *(fails: NameError in IB1Test)*

------
https://chatgpt.com/codex/tasks/task_e_6871cfaa07b08326baeb7880c20692f2