### PR TITLE
Add dataset shuffle and split utilities

### DIFF
--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -75,14 +75,8 @@ module Ai4r
       # classifier state unchanged. Use +update_with_instance+ to
       # incorporate new samples.
       def eval(data)
-        min_distance = 1.0/0
-        klass = nil
-        @data_set.data_items.each do |train_item|
-          d = distance(data, train_item)
-          if d < min_distance
-            min_distance = d
-            klass = train_item.last
-          end
+        neighbors = @data_set.data_items.map do |train_item|
+          [distance(data, train_item), train_item.last]
         end
         neighbors.sort_by! { |d, _| d }
         k_neighbors = neighbors.first([@k, @data_set.data_items.length].min)
@@ -154,6 +148,7 @@ module Ai4r
       # @param b [Object]
       # @return [Object]
       def distance(a, b)
+        return @distance_function.call(a, b) if @distance_function
         d = 0
         a.each_with_index do |att_a, i|
           att_b = b[i]
@@ -166,7 +161,7 @@ module Ai4r
             end
           elsif att_a.is_a? Numeric
             if att_b.is_a? Numeric
-              diff = norm(att_a, i) - norm(att_b, i);
+              diff = norm(att_a, i) - norm(att_b, i)
             else
               diff = norm(att_a, i)
               diff = 1.0 - diff if diff < 0.5
@@ -178,7 +173,7 @@ module Ai4r
           end
           d += diff * diff
         end
-        return d
+        d
       end
 
       # Returns normalized value att

--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -300,6 +300,40 @@ module Ai4r
         self
       end
 
+      # Randomizes the order of data items in place.
+      # If a +seed+ is provided, it is used to initialize the random number
+      # generator for deterministic shuffling.
+      #
+      #   data_set.shuffle!(seed: 123)
+      #
+      # @param seed [Integer, nil] Seed for the RNG
+      # @return [DataSet] self
+      def shuffle!(seed: nil)
+        rng = seed ? Random.new(seed) : Random.new
+        @data_items.shuffle!(random: rng)
+        self
+      end
+
+      # Split the dataset into two new DataSet instances using the given ratio
+      # for the first set.
+      #
+      #   train, test = data_set.split(ratio: 0.8)
+      #
+      # @param ratio [Float] fraction of items to place in the first set
+      # @return [Array<DataSet, DataSet>] the two resulting datasets
+      def split(ratio:)
+        raise ArgumentError, 'ratio must be between 0 and 1' unless ratio.positive? && ratio < 1
+
+        pivot = (ratio * @data_items.length).round
+        first_items = @data_items[0...pivot].map { |row| row.dup }
+        second_items = @data_items[pivot..-1].map { |row| row.dup }
+
+        [
+          DataSet.new(data_items: first_items, data_labels: @data_labels.dup),
+          DataSet.new(data_items: second_items, data_labels: @data_labels.dup)
+        ]
+      end
+
       # Returns label of category
       # @return [Object]
       def category_label

--- a/test/data/data_set_test.rb
+++ b/test/data/data_set_test.rb
@@ -130,6 +130,27 @@ module Ai4r
         assert_equal items, set.data_items
         assert_equal [["A", 0.0, "x"], ["B", 0.5, "y"], ["A", 1.0, "z"]], copy.data_items
       end
+
+      def test_shuffle_deterministic
+        items = [[1], [2], [3], [4]]
+        set = DataSet.new(data_items: items, data_labels: ['val'])
+        expected = items.shuffle(random: Random.new(5))
+        result = set.shuffle!(seed: 5)
+        assert_equal set, result
+        assert_equal expected, set.data_items
+      end
+
+      def test_split_ratio
+        items = (1..5).map { |i| [i] }
+        labels = ['v']
+        set = DataSet.new(data_items: items, data_labels: labels)
+        first, second = set.split(ratio: 0.6)
+        assert_equal items, set.data_items
+        assert_equal [[1], [2], [3]], first.data_items
+        assert_equal [[4], [5]], second.data_items
+        assert_equal labels, first.data_labels
+        assert_equal labels, second.data_labels
+      end
      
     end
   end


### PR DESCRIPTION
## Summary
- add `DataSet#shuffle!` with deterministic seed
- add `DataSet#split` to create training/test subsets
- support custom distance functions in `IB1` classifier and fix neighbor logic
- test new `DataSet` utilities

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871cfb79a4c832687ead61268a2f7b5