### PR TITLE
Fix parameters_info syntax

### DIFF
--- a/lib/ai4r/clusterers/k_means.rb
+++ b/lib/ai4r/clusterers/k_means.rb
@@ -54,7 +54,7 @@ module Ai4r
         :restarts => "Number of random initializations to perform. " +
           "The best run (lowest SSE) will be kept.",
         :track_history => "Keep centroids and assignments for each iteration " +
-          "when building the clusterer."
+          "when building the clusterer.",
       )
       
       # @return [Object]


### PR DESCRIPTION
## Summary
- fix trailing comma in KMeans parameters_info hash

## Testing
- `bundle exec rake test` *(fails: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871cfe8e29c8326b93fc5b207cf029e