### PR TITLE
Add cross validation support to experiments

### DIFF
--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -75,14 +75,9 @@ module Ai4r
       # classifier state unchanged. Use +update_with_instance+ to
       # incorporate new samples.
       def eval(data)
-        min_distance = 1.0/0
-        klass = nil
-        @data_set.data_items.each do |train_item|
-          d = distance(data, train_item)
-          if d < min_distance
-            min_distance = d
-            klass = train_item.last
-          end
+        metric = @distance_function || method(:distance)
+        neighbors = @data_set.data_items.map do |train_item|
+          [metric.call(data, train_item), train_item.last]
         end
         neighbors.sort_by! { |d, _| d }
         k_neighbors = neighbors.first([@k, @data_set.data_items.length].min)

--- a/lib/ai4r/experiment/classifier_evaluator.rb
+++ b/lib/ai4r/experiment/classifier_evaluator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'benchmark'
-require_relative '../data/data_set' 
+require_relative '../data/data_set'
+require_relative 'split'
 
 
 module Ai4r
@@ -78,8 +79,49 @@ module Ai4r
         @classifiers.each do |classifier|
           result_data_items << test_classifier(classifier, data_set)
         end
-        return Ai4r::Data::DataSet.new(:data_items => result_data_items, 
+        return Ai4r::Data::DataSet.new(:data_items => result_data_items,
           :data_labels => ["Classifier","Testing Time","Errors","Success rate"])
+      end
+
+      # Perform k-fold cross validation on all classifiers.
+      # The dataset is split into +k+ folds using the Split utility. For each
+      # fold, classifiers are trained on the remaining folds and then tested on
+      # the held-out fold. The method returns a DataSet with the average time
+      # (build and test) and accuracy for each classifier.
+      # @param data_set [Ai4r::Data::DataSet] data to evaluate
+      # @param k [Integer] number of folds
+      # @return [Ai4r::Data::DataSet]
+      def cross_validate(data_set, k:)
+        folds = Split.split(data_set, k: k)
+        times = Array.new(@classifiers.length, 0.0)
+        accuracies = Array.new(@classifiers.length, 0.0)
+
+        folds.each_with_index do |test_set, i|
+          train_items = []
+          folds.each_with_index do |fold, j|
+            next if i == j
+            train_items.concat(fold.data_items)
+          end
+          train_set = Ai4r::Data::DataSet.new(
+            data_items: train_items,
+            data_labels: data_set.data_labels
+          )
+
+          @classifiers.each_with_index do |classifier, idx|
+            build_time = Benchmark.measure { classifier.build(train_set) }.real
+            result = test_classifier(classifier, test_set)
+            times[idx] += build_time + result[1]
+            accuracies[idx] += result[3]
+          end
+        end
+
+        result_items = @classifiers.each_index.map do |idx|
+          [@classifiers[idx], times[idx] / k, accuracies[idx] / k]
+        end
+        Ai4r::Data::DataSet.new(
+          data_items: result_items,
+          data_labels: ["Classifier", "Avg. Time", "Avg. Success rate"]
+        )
       end
       
       private

--- a/lib/ai4r/experiment/split.rb
+++ b/lib/ai4r/experiment/split.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# Author::    Sergio Fierens
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       https://github.com/SergioFierens/ai4r
+#
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+require_relative '../data/data_set'
+
+module Ai4r
+  module Experiment
+    # Utility methods for experiment workflows.
+    module Split
+      module_function
+
+      # Split a dataset into +k+ folds.
+      # @param data_set [Ai4r::Data::DataSet] dataset to split
+      # @param k [Integer] number of folds
+      # @return [Array<Ai4r::Data::DataSet>] list of folds
+      def split(data_set, k:)
+        raise ArgumentError, 'k must be greater than 0' unless k.positive?
+
+        items = data_set.data_items.dup
+        labels = data_set.data_labels
+        fold_size = (items.length.to_f / k).ceil
+        folds = []
+        k.times do |i|
+          part = items.slice(i * fold_size, fold_size) || []
+          folds << Ai4r::Data::DataSet.new(data_items: part, data_labels: labels)
+        end
+        folds
+      end
+    end
+  end
+end

--- a/test/experiment/classifier_evaluator_test.rb
+++ b/test/experiment/classifier_evaluator_test.rb
@@ -60,7 +60,7 @@ module Ai4r
       def test_test
         evaluator = ClassifierEvaluator.new
         5.times { |x| evaluator << MockClassifier.new(x) }
-        input = Ai4r::Data::DataSet.new :data_items => 
+        input = Ai4r::Data::DataSet.new :data_items =>
           [[0],[0],[0],[1],[2],[3]]
         output = evaluator.test input
         assert_equal 5, output.data_items.length # 5 classifiers, 5 result rows
@@ -69,6 +69,18 @@ module Ai4r
         assert_equal 0.5, output.data_items.first[3] # succes rate
         assert_equal 6, output.data_items.last[2] # 6 errors for the last classifier
         assert_equal 0, output.data_items.last[3] # succes rate
+      end
+
+      def test_cross_validate
+        evaluator = ClassifierEvaluator.new
+        evaluator << MockClassifier.new(0) << MockClassifier.new(1)
+        input = Ai4r::Data::DataSet.new(data_items: [[0], [0], [1], [1]])
+        output = evaluator.cross_validate(input, k: 2)
+        assert_equal 2, output.data_items.length
+        output.data_items.each do |row|
+          assert_in_delta 0.5, row[2], 0.0001
+          assert row[1] >= 0
+        end
       end
       
     end


### PR DESCRIPTION
## Summary
- add `Experiment::Split` helper for splitting datasets into folds
- extend `ClassifierEvaluator` with `cross_validate` using the split utility
- fix IB1#eval missing neighbors computation
- test `cross_validate` behavior

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871cfb3d15c83268c62eb1a4a3053c7