### PR TITLE
Refactor tests to use dataset fixtures

### DIFF
--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -75,14 +75,9 @@ module Ai4r
       # classifier state unchanged. Use +update_with_instance+ to
       # incorporate new samples.
       def eval(data)
-        min_distance = 1.0/0
-        klass = nil
-        @data_set.data_items.each do |train_item|
-          d = distance(data, train_item)
-          if d < min_distance
-            min_distance = d
-            klass = train_item.last
-          end
+        metric = @distance_function || method(:distance)
+        neighbors = @data_set.data_items.map do |train_item|
+          [metric.call(data, train_item), train_item.last]
         end
         neighbors.sort_by! { |d, _| d }
         k_neighbors = neighbors.first([@k, @data_set.data_items.length].min)

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -10,6 +10,7 @@
 require 'ai4r/classifiers/hyperpipes'
 require 'test/unit'
 require 'set'
+require 'yaml'
 
 class Ai4r::Classifiers::Hyperpipes
   attr_accessor :data_set, :pipes
@@ -20,22 +21,10 @@ include Ai4r::Data
 
 class HyperpipesTest < Test::Unit::TestCase
 
-  @@data_labels = [ 'city', 'age', 'gender', 'marketing_target'  ]
+  fixture = YAML.load_file(File.expand_path('../fixtures/marketing_target_numeric.yml', __dir__))
 
-  @@data_items = [['New York',  25, 'M', 'Y'],
-              ['New York',  23, 'M', 'Y'],
-              ['New York',  18, 'M', 'Y'],
-              ['Chicago',   43, 'M', 'Y'],
-              ['New York',  34, 'F', 'N'],
-              ['Chicago',   33, 'F', 'Y'],
-              ['New York',  31, 'F', 'N'],
-              ['Chicago',   55, 'M', 'N'],
-              ['New York',  58, 'F', 'N'],
-              ['New York',  59, 'M', 'N'],
-              ['Chicago',   71, 'M', 'N'],
-              ['New York',  60, 'F', 'N'],
-              ['Chicago',   85, 'F', 'Y']
-            ]
+  @@data_labels = fixture['data_labels']
+  @@data_items  = fixture['data_items']
   
   
   def setup

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -1,42 +1,22 @@
 require 'test/unit'
 require 'ai4r/classifiers/prism'
+require 'yaml'
 
 
 class PrismTest < Test::Unit::TestCase
-  
+
   include Ai4r::Classifiers
   include Ai4r::Data
 
-  @@data_examples = [   ['New York',  '<30',      'M', 'Y'],
-                ['Chicago',     '<30',      'M', 'Y'],
-                ['Chicago',     '<30',      'F', 'Y'],
-                ['New York',  '<30',      'M', 'Y'],
-                ['New York',  '<30',      'M', 'Y'],
-                ['Chicago',     '[30-50)',  'M', 'Y'],
-                ['New York',  '[30-50)',  'F', 'N'],
-                ['Chicago',     '[30-50)',  'F', 'Y'],
-                ['New York',  '[30-50)',  'F', 'N'],
-                ['Chicago',     '[50-80]', 'M', 'N'],
-                ['New York',  '[50-80]', 'F', 'N'],
-                ['New York',  '[50-80]', 'M', 'N'],
-                ['Chicago',     '[50-80]', 'M', 'N'],
-                ['New York',  '[50-80]', 'F', 'N'],
-                ['Chicago',     '>80',      'F', 'Y']
-              ]
+  fixture = YAML.load_file(File.expand_path('../fixtures/marketing_target_age_range.yml', __dir__))
 
-  @@data_labels = [ 'city', 'age_range', 'gender', 'marketing_target'  ]
+  @@data_examples = fixture['data_items']
+  @@data_labels   = fixture['data_labels']
 
-  @@numeric_examples = [
-    ['New York', 20, 'M', 'Y'],
-    ['Chicago', 25, 'M', 'Y'],
-    ['New York', 28, 'M', 'Y'],
-    ['New York', 35, 'F', 'N'],
-    ['Chicago', 40, 'F', 'Y'],
-    ['New York', 45, 'F', 'N'],
-    ['Chicago', 55, 'M', 'N']
-  ]
+  numeric_fixture = YAML.load_file(File.expand_path('../fixtures/prism_numeric_examples.yml', __dir__))
 
-  @@numeric_labels = [ 'city', 'age', 'gender', 'marketing_target' ]
+  @@numeric_examples = numeric_fixture['data_items']
+  @@numeric_labels   = numeric_fixture['data_labels']
   
   def test_build
     assert_raise(ArgumentError) { Prism.new.build(DataSet.new) } 

--- a/test/fixtures/marketing_target_age_range.yml
+++ b/test/fixtures/marketing_target_age_range.yml
@@ -1,0 +1,67 @@
+---
+data_labels:
+  - city
+  - age_range
+  - gender
+  - marketing_target
+data_items:
+  - - New York
+    - '<30'
+    - M
+    - Y
+  - - Chicago
+    - '<30'
+    - M
+    - Y
+  - - Chicago
+    - '<30'
+    - F
+    - Y
+  - - New York
+    - '<30'
+    - M
+    - Y
+  - - New York
+    - '<30'
+    - M
+    - Y
+  - - Chicago
+    - '[30-50)'
+    - M
+    - Y
+  - - New York
+    - '[30-50)'
+    - F
+    - N
+  - - Chicago
+    - '[30-50)'
+    - F
+    - Y
+  - - New York
+    - '[30-50)'
+    - F
+    - N
+  - - Chicago
+    - '[50-80]'
+    - M
+    - N
+  - - New York
+    - '[50-80]'
+    - F
+    - N
+  - - New York
+    - '[50-80]'
+    - M
+    - N
+  - - Chicago
+    - '[50-80]'
+    - M
+    - N
+  - - New York
+    - '[50-80]'
+    - F
+    - N
+  - - Chicago
+    - '>80'
+    - F
+    - Y

--- a/test/fixtures/marketing_target_numeric.yml
+++ b/test/fixtures/marketing_target_numeric.yml
@@ -1,0 +1,59 @@
+---
+data_labels:
+  - city
+  - age
+  - gender
+  - marketing_target
+data_items:
+  - - New York
+    - 25
+    - M
+    - Y
+  - - New York
+    - 23
+    - M
+    - Y
+  - - New York
+    - 18
+    - M
+    - Y
+  - - Chicago
+    - 43
+    - M
+    - Y
+  - - New York
+    - 34
+    - F
+    - N
+  - - Chicago
+    - 33
+    - F
+    - Y
+  - - New York
+    - 31
+    - F
+    - N
+  - - Chicago
+    - 55
+    - M
+    - N
+  - - New York
+    - 58
+    - F
+    - N
+  - - New York
+    - 59
+    - M
+    - N
+  - - Chicago
+    - 71
+    - M
+    - N
+  - - New York
+    - 60
+    - F
+    - N
+  - - Chicago
+    - 85
+    - F
+    - Y

--- a/test/fixtures/prism_numeric_examples.yml
+++ b/test/fixtures/prism_numeric_examples.yml
@@ -1,0 +1,35 @@
+---
+data_labels:
+  - city
+  - age
+  - gender
+  - marketing_target
+data_items:
+  - - New York
+    - 20
+    - M
+    - Y
+  - - Chicago
+    - 25
+    - M
+    - Y
+  - - New York
+    - 28
+    - M
+    - Y
+  - - New York
+    - 35
+    - F
+    - N
+  - - Chicago
+    - 40
+    - F
+    - Y
+  - - New York
+    - 45
+    - F
+    - N
+  - - Chicago
+    - 55
+    - M
+    - N


### PR DESCRIPTION
## Summary
- create fixtures for marketing datasets
- load fixtures in Hyperpipes and Prism tests
- patch IB1#eval to define neighbor list

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6871d0504bb48326a698341fc54f9787