### PR TITLE
Add basic user guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ require 'ai4r'
 
 ## Practical Examples
 
+* [User Guide](user_guide.md) – start with the basics and explore the library in depth.
 * **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
 * **Neural Networks** – simple OCR recognition of visual patterns.
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,71 @@
+# AI4R User Guide
+
+This guide introduces the AI4R gem. It begins with a minimal example and gradually explains more features.
+
+## Quick Start
+
+1. Install the gem:
+
+   ```bash
+   gem install ai4r
+   ```
+
+2. Require the library in your project:
+
+   ```ruby
+   require 'ai4r'
+   ```
+
+### Minimal Example
+
+Create a tiny dataset and build a classifier with the ID3 algorithm:
+
+```ruby
+require 'ai4r'
+
+items = [
+  ['sunny', 'warm', 'yes'],
+  ['sunny', 'cold', 'no']
+]
+labels = ['weather', 'temperature', 'play']
+
+data = Ai4r::Data::DataSet.new(:data_items => items, :data_labels => labels)
+id3  = Ai4r::Classifiers::ID3.new.build(data)
+puts id3.eval(['sunny', 'warm'])
+```
+
+Running this script prints `"yes"`.
+
+## Working with Data
+
+Datasets can be loaded from CSV files or created directly from arrays. Numeric attributes support normalization with either z-score or min-max scaling.
+
+## Algorithm Overview
+
+AI4R includes several algorithms:
+
+- Decision trees such as ID3
+- Neural networks with backpropagation
+- Genetic algorithms for optimization
+- Clustering methods including KMeans and hierarchical clustering
+- Baseline classifiers like OneR, ZeroR and Hyperpipes
+
+See the documents in this directory for detailed tutorials on each topic.
+
+## Advanced Features
+
+Algorithms expose parameters through `set_parameters`. Explore available parameters with `get_parameters_info` to tune learning rate, random seeds and more.
+
+## Running Examples
+
+Example scripts live under the `examples/` directory. They demonstrate usage of classifiers, clustering techniques, neural networks and genetic algorithms.
+
+## Testing
+
+Install the development dependencies and run the test suite:
+
+```bash
+bundle install
+bundle exec rake test
+```
+


### PR DESCRIPTION
## Summary
- add a short user guide that starts with a minimal example
- link the user guide from the documentation index

## Testing
- `bundle exec rake test` *(fails: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871d104b7448326a57b01d457be5fa1