### PR TITLE
Add overview snippet to docs and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,30 @@ This repository contains the AI4R Ruby gem. Follow these guidelines to speed up 
 - Documentation lives under the `docs/` directory. Update or create new docs as needed.
 - Ensure that `bundle exec rake test` succeeds before opening a PR.
 
+
+## Purpose
+
+This project is an educational Ruby library for machine learning and artificial intelligence, featuring clean, minimal implementations of classical algorithms such as decision trees, neural networks, k-means, and genetic algorithms.
+
+It is intentionally lightweight: no GPU support, no production optimizations, and no large dependencies. The goal is to offer a readable, testable, hands-on way to explore the structure and behavior of fundamental AI algorithms.
+
+## Audience
+
+- Developers exploring classic ML techniques
+- Educators using Ruby for instructional demos
+- Students learning algorithm trade-offs by example
+- AI-curious programmers who prefer clarity over speed
+
+## Philosophy
+
+Maintained over the years mostly for the joy of it (and perhaps a misplaced sense of duty to Ruby), this open-source library supports developers, students, and educators who want to understand machine learning in Ruby without drowning in complexity.
+
+## Limitations
+
+- Not optimized for performance
+- No support for GPU, parallelism, or distributed training
+- Not intended for production deployment
+
+## Keywords
+
+ruby machine learning, educational AI library, neural networks ruby, decision trees ruby, genetic algorithm ruby, open-source AI ruby, AI4R

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+= AI4R — Artificial Intelligence for Ruby
+
+A Ruby library of AI algorithms for learning and experimentation.
+
+---
+
+This project is an educational Ruby library for machine learning and artificial intelligence, featuring clean, minimal implementations of classical algorithms such as decision trees, neural networks, k-means, and genetic algorithms. It’s intentionally lightweight—no GPU support, no external dependencies, no production overhead—just a practical way to experiment, compare, and learn the fundamental building blocks of AI. Ideal for small-scale explorations, course demos, or simply understanding how these algorithms actually work, line by line.
+
+Maintained over the years mostly for the joy of it (and perhaps a misplaced sense of duty to Ruby), this open-source library supports developers, students, and educators who want to understand machine learning in Ruby without drowning in complexity.
+
 # AI4R
 
 AI4R is a collection of artificial intelligence algorithms implemented in Ruby. It includes classifiers, clustering methods, neural networks and more. The library is distributed as a gem and works with modern versions of Ruby.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,12 @@
-# AI4R Documentation
+= AI4R — Artificial Intelligence for Ruby
 
-AI4R provides a collection of machine learning algorithms implemented in Ruby. Algorithms include genetic algorithms, self-organizing maps, neural networks, automatic classifiers and clustering methods.
+A Ruby library of AI algorithms for learning and experimentation.
+
+---
+
+This project is an educational Ruby library for machine learning and artificial intelligence, featuring clean, minimal implementations of classical algorithms such as decision trees, neural networks, k-means, and genetic algorithms. It’s intentionally lightweight—no GPU support, no external dependencies, no production overhead—just a practical way to experiment, compare, and learn the fundamental building blocks of AI. Ideal for small-scale explorations, course demos, or simply understanding how these algorithms actually work, line by line.
+
+Maintained over the years mostly for the joy of it (and perhaps a misplaced sense of duty to Ruby), this open-source library supports developers, students, and educators who want to understand machine learning in Ruby without drowning in complexity.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- feature short project overview at the top of the README and docs index
- document project purpose, audience and limitations in AGENTS.md
- clean docs index heading

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68722dcf57d08326a97ac9a7abc2f74d