### PR TITLE
Inject per-instance RNG

### DIFF
--- a/lib/ai4r/classifiers/hyperpipes.rb
+++ b/lib/ai4r/classifiers/hyperpipes.rb
@@ -28,12 +28,15 @@ module Ai4r
 
       parameters_info tie_strategy: 'Strategy used when more than one class has the same maximal vote. ' +
         'Valid values are :last (default) and :random.',
-        margin: 'Numeric margin added to the bounds of numeric attributes.'
+        margin: 'Numeric margin added to the bounds of numeric attributes.',
+        random_seed: 'Seed for random tie-breaking when tie_strategy is :random.'
 
       # @return [Object]
       def initialize
         @tie_strategy = :last
         @margin = 0
+        @random_seed = nil
+        @rng = nil
       end
 
       # Build a new Hyperpipes classifier. You must provide a DataSet instance
@@ -70,7 +73,8 @@ module Ai4r
             end
           end
         end
-        return votes.get_winner(@tie_strategy)
+        rng = @rng || (@random_seed.nil? ? Random.new : Random.new(@random_seed))
+        return votes.get_winner(@tie_strategy, rng: rng)
       end
 
       # This method returns the generated rules in ruby code.

--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -32,13 +32,16 @@ module Ai4r
 
       parameters_info k: 'Number of nearest neighbors to consider. Default is 1.',
         distance_function: 'Optional custom distance metric taking two instances.',
-        tie_break: 'Strategy used when neighbors vote tie. Valid values are :first (default) and :random.'
+        tie_break: 'Strategy used when neighbors vote tie. Valid values are :first (default) and :random.',
+        random_seed: 'Seed for random tie-breaking when :tie_break is :random.'
 
       # @return [Object]
       def initialize
         @k = 1
         @distance_function = nil
         @tie_break = :first
+        @random_seed = nil
+        @rng = nil
       end
 
       # Build a new IB1 classifier. You must provide a DataSet instance
@@ -97,9 +100,11 @@ module Ai4r
 
         return tied.first if tied.length == 1
 
+        rng = @rng || (@random_seed.nil? ? Random.new : Random.new(@random_seed))
+
         case @tie_break
         when :random
-          tied.sample
+          tied.sample(random: rng)
         else
           k_neighbors.each { |_, klass| return klass if tied.include?(klass) }
         end

--- a/lib/ai4r/classifiers/votes.rb
+++ b/lib/ai4r/classifiers/votes.rb
@@ -31,14 +31,14 @@ module Ai4r
 
       # @param tie_strategy [Object]
       # @return [Object]
-      def get_winner(tie_strategy = :last)
+      def get_winner(tie_strategy = :last, rng: Random.new)
         n = 0 # used to create a stable sort of the tallys
         sorted_sheet = tally_sheet.sort_by { |_, score| n += 1; [score, n] }
         return nil if sorted_sheet.empty?
         if tie_strategy == :random
           max_score = sorted_sheet.last[1]
           tied = sorted_sheet.select { |_, score| score == max_score }.map(&:first)
-          tied.sample
+          tied.sample(random: rng)
         else
           sorted_sheet.last.first
         end

--- a/lib/ai4r/classifiers/zero_r.rb
+++ b/lib/ai4r/classifiers/zero_r.rb
@@ -29,12 +29,15 @@ module Ai4r
         "dataset is empty.",
         tie_strategy: "Strategy used when more than one class has the " +
           "same maximal frequency. Valid values are :first (default) " +
-          "and :random."
+          "and :random.",
+        random_seed: "Seed for tie resolution when using :random strategy."
 
       # @return [Object]
       def initialize
         @default_class = nil
         @tie_strategy = :first
+        @random_seed = nil
+        @rng = nil
       end
     
       # Build a new ZeroR classifier. You must provide a DataSet instance
@@ -66,12 +69,14 @@ module Ai4r
           end
         end
 
+        rng = @rng || (@random_seed.nil? ? Random.new : Random.new(@random_seed))
+
         if tied_classes.length == 1
           @class_value = tied_classes.first
         else
           @class_value = case @tie_strategy
                          when :random
-                           tied_classes.sample
+                           tied_classes.sample(random: rng)
                          else
                            tied_classes.first
                          end

--- a/lib/ai4r/som/node.rb
+++ b/lib/ai4r/som/node.rb
@@ -73,17 +73,20 @@ module Ai4r
       #   deprecated :seed key is supported for backward compatibility.
       # @return [Object]
       def instantiate_weight(dimensions, options = {})
-        opts = { range: 0..1, random_seed: nil, seed: nil }.merge(options)
-        seed = opts[:random_seed] || opts[:seed]
-        srand(seed) unless seed.nil?
+        opts = { range: 0..1, random_seed: nil, seed: nil, rng: nil }.merge(options)
+        rng = opts[:rng]
+        unless rng
+          seed = opts[:random_seed] || opts[:seed]
+          rng = seed.nil? ? Random.new : Random.new(seed)
+        end
         range = opts[:range] || (0..1)
         min = range.first.to_f
         max = range.last.to_f
         span = max - min
         @weights = Array.new dimensions
         @instantiated_weight = Array.new dimensions
-        @weights.each_with_index do |weight, index|
-          @weights[index] = min + rand * span
+        @weights.each_index do |index|
+          @weights[index] = min + rng.rand * span
           @instantiated_weight[index] = @weights[index]
         end
       end

--- a/lib/ai4r/som/som.rb
+++ b/lib/ai4r/som/som.rb
@@ -176,9 +176,9 @@ module Ai4r
       # @return [Object]
       def initiate_map
         seed = @init_weight_options[:random_seed]
-        srand(seed) unless seed.nil?
-        @nodes.each_with_index do |node, i|
-          options = @init_weight_options.merge(distance_metric: @layer.distance_metric)
+        rng = seed.nil? ? Random.new : Random.new(seed)
+        @nodes.each_index do |i|
+          options = @init_weight_options.merge(distance_metric: @layer.distance_metric, rng: rng)
           @nodes[i] = Node.create i, @rows, @columns, @dimension, options
         end
       end

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -87,8 +87,7 @@ class HyperpipesTest < Test::Unit::TestCase
   def test_tie_strategy
     classifier = Hyperpipes.new.set_parameters(:tie_strategy => :last).build(@data_set)
     assert_equal 'N', classifier.eval(['Chicago', 40, 'F'])
-    srand(2)
-    classifier = Hyperpipes.new.set_parameters(:tie_strategy => :random).build(@data_set)
+    classifier = Hyperpipes.new.set_parameters(tie_strategy: :random, random_seed: 2).build(@data_set)
     assert_equal 'Y', classifier.eval(['Chicago', 40, 'F'])
   end
 

--- a/test/classifiers/ib1_test.rb
+++ b/test/classifiers/ib1_test.rb
@@ -96,8 +96,7 @@ class IB1Test < Test::Unit::TestCase
   def test_tie_break
     classifier = IB1.new.set_parameters(:k => 2, :tie_break => :first).build(@data_set)
     assert_equal('Y', classifier.eval(['Chicago', 47, 'M']))
-    srand(1)
-    classifier = IB1.new.set_parameters(:k => 2, :tie_break => :random).build(@data_set)
+    classifier = IB1.new.set_parameters(k: 2, tie_break: :random, random_seed: 1).build(@data_set)
     assert_equal('N', classifier.eval(['Chicago', 47, 'M']))
   end
 

--- a/test/classifiers/zero_r_test.rb
+++ b/test/classifiers/zero_r_test.rb
@@ -57,8 +57,7 @@ class ZeroRTest < Test::Unit::TestCase
     data_set = DataSet.new(:data_items => data)
     classifier = ZeroR.new.set_parameters({:tie_strategy => :first}).build(data_set)
     assert_equal('Y', classifier.class_value)
-    srand(1)
-    classifier = ZeroR.new.set_parameters({:tie_strategy => :random}).build(data_set)
+    classifier = ZeroR.new.set_parameters(tie_strategy: :random, random_seed: 1).build(data_set)
     assert_equal('N', classifier.class_value)
   end
   


### PR DESCRIPTION
## Summary
- remove global `srand` calls
- inject RNG objects for KMeans and SOM initialization
- add `random_seed` support to ZeroR, IB1 and Hyperpipes
- allow specifying RNG to `Votes#get_winner`
- adjust tests to configure deterministic seeds

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68722e4d271c8326809172b222a9cc6b