### PR TITLE
Migrate tests to Minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "rake", "~> 13"
 gem "rdoc", "~> 6"
 gem "csv", "~> 3"
-gem "test-unit", "~> 3"
+gem "minitest", "~> 5"
 
 group :development do
   gem "rubocop", "~> 1.78", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,11 @@ GEM
     json (2.12.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    minitest (5.25.5)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
-    power_assert (2.0.5)
     prism (1.4.0)
     psych (5.2.6)
       date
@@ -40,8 +40,6 @@ GEM
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
     stringio (3.1.7)
-    test-unit (3.7.0)
-      power_assert
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -52,10 +50,10 @@ PLATFORMS
 
 DEPENDENCIES
   csv (~> 3)
+  minitest (~> 5)
   rake (~> 13)
   rdoc (~> 6)
   rubocop (~> 1.78)
-  test-unit (~> 3)
 
 BUNDLED WITH
    2.6.7

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -12,7 +12,7 @@ AI4R welcomes contributions of all sizes. This document explains how to get star
 
 ## Development Environment
 
-AI4R works with modern versions of Ruby. The `Gemfile` lists all development dependencies. After cloning the project, run `bundle install` to set up your environment. Bundler will install `rake`, `test-unit`, `rubocop` and other gems needed to build and test the project.
+AI4R works with modern versions of Ruby. The `Gemfile` lists all development dependencies. After cloning the project, run `bundle install` to set up your environment. Bundler will install `rake`, `minitest`, `rubocop` and other gems needed to build and test the project.
 
 Use the provided `Rakefile.rb` to run tasks:
 

--- a/docs/test_suite_improvements.md
+++ b/docs/test_suite_improvements.md
@@ -4,7 +4,7 @@ This document outlines several ways to improve the current AI4R test suite.
 
 ## Use Modern Test Frameworks
 
-The project relies on `Test::Unit`. Migrating to `Minitest` (or to `RSpec` for a behavior-driven approach) would provide a larger ecosystem of plugins and clearer syntax while still running with `rake test`.
+The project now uses `Minitest` instead of the older `Test::Unit`. This brings a larger ecosystem of plugins and clearer syntax while still running with `rake test`.
 
 ## Centralize Mock Data
 

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -8,7 +8,7 @@
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'ai4r/classifiers/hyperpipes'
-require 'test/unit'
+require 'minitest/autorun'
 require 'set'
 require 'yaml'
 
@@ -19,7 +19,7 @@ end
 include Ai4r::Classifiers
 include Ai4r::Data
 
-class HyperpipesTest < Test::Unit::TestCase
+class HyperpipesTest < Minitest::Test
 
   fixture = YAML.load_file(File.expand_path('../fixtures/marketing_target_numeric.yml', __dir__))
 
@@ -38,7 +38,7 @@ class HyperpipesTest < Test::Unit::TestCase
   end
   
   def test_build
-    assert_raise(ArgumentError) { Hyperpipes.new.build(DataSet.new) }
+    assert_raises(ArgumentError) { Hyperpipes.new.build(DataSet.new) }
     classifier = Hyperpipes.new.build(@data_set)
     assert classifier.pipes.include?("Y")
     assert classifier.pipes.include?("N")

--- a/test/classifiers/ib1_test.rb
+++ b/test/classifiers/ib1_test.rb
@@ -8,14 +8,14 @@
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'ai4r/classifiers/ib1'
-require 'test/unit'
+require 'minitest/autorun'
 
 
 
 include Ai4r::Classifiers
 include Ai4r::Data
 
-class IB1Test < Test::Unit::TestCase
+class IB1Test < Minitest::Test
 
   @@data_labels = [ 'city', 'age', 'gender', 'marketing_target'  ]
 
@@ -49,7 +49,7 @@ class IB1Test < Test::Unit::TestCase
   end
   
   def test_build
-    assert_raise(ArgumentError) { IB1.new.build(DataSet.new) }
+    assert_raises(ArgumentError) { IB1.new.build(DataSet.new) }
     assert @classifier.data_set
     assert_equal [nil, 18, nil, nil], @classifier.min_values
     assert_equal [nil, 85, nil, nil], @classifier.max_values

--- a/test/classifiers/id3_test.rb
+++ b/test/classifiers/id3_test.rb
@@ -13,7 +13,7 @@
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'ai4r/classifiers/id3'
-require 'test/unit'
+require 'minitest/autorun'
 
 DATA_LABELS = [ 'city', 'age_range', 'gender', 'marketing_target'  ]
 
@@ -112,7 +112,7 @@ EXPECTED_NUMERIC_RULES_STRING =
 include Ai4r::Classifiers
 include Ai4r::Data
 
-class ID3Test < Test::Unit::TestCase
+class ID3Test < Minitest::Test
 
   def test_build
     Ai4r::Classifiers::ID3.send(:public, *Ai4r::Classifiers::ID3.protected_instance_methods)
@@ -252,7 +252,7 @@ class ID3Test < Test::Unit::TestCase
             ]
     bad_data_labels = ['bogus', 'target']
     id3 = ID3.new.build(DataSet.new(:data_items =>bad_data_items, :data_labels => bad_data_labels))
-    assert_raise ModelFailureError do
+    assert_raises ModelFailureError do
       id3.eval(['c'])
     end
     assert_equal true, true

--- a/test/classifiers/multilayer_perceptron_test.rb
+++ b/test/classifiers/multilayer_perceptron_test.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/classifiers/multilayer_perceptron'
 require 'ai4r/data/data_set'
 
@@ -9,7 +9,7 @@ class Ai4r::Classifiers::MultilayerPerceptron
   public :data_to_output
 end
 
-class MultilayerPerceptronTest < Test::Unit::TestCase
+class MultilayerPerceptronTest < Minitest::Test
   
   include Ai4r::Classifiers
   include Ai4r::Data
@@ -36,7 +36,7 @@ class MultilayerPerceptronTest < Test::Unit::TestCase
   end
   
   def test_build
-    assert_raise(ArgumentError) { MultilayerPerceptron.new.build(DataSet.new) }
+    assert_raises(ArgumentError) { MultilayerPerceptron.new.build(DataSet.new) }
     classifier = MultilayerPerceptron.new
     classifier.training_iterations = 1
     classifier.build(@@data_set)

--- a/test/classifiers/naive_bayes_test.rb
+++ b/test/classifiers/naive_bayes_test.rb
@@ -1,11 +1,11 @@
 require 'ai4r/classifiers/naive_bayes'
 require 'ai4r/data/data_set'
-require 'test/unit'
+require 'minitest/autorun'
 
 include Ai4r::Classifiers
 include Ai4r::Data
 
-class NaiveBayesTest < Test::Unit::TestCase
+class NaiveBayesTest < Minitest::Test
 
   @@data_labels = %w(Color Type Origin Stolen?)
 
@@ -55,7 +55,7 @@ class NaiveBayesTest < Test::Unit::TestCase
   end
 
   def test_unknown_value_error
-    assert_raise RuntimeError do
+    assert_raises RuntimeError do
       NaiveBayes.new.set_parameters(:unknown_value_strategy => :error).build(@data_set).eval(%w(Blue SUV Domestic))
     end
   end

--- a/test/classifiers/one_r_test.rb
+++ b/test/classifiers/one_r_test.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/classifiers/one_r'
 
-class OneRTest < Test::Unit::TestCase
+class OneRTest < Minitest::Test
   
   include Ai4r::Classifiers
   include Ai4r::Data
@@ -18,16 +18,16 @@ class OneRTest < Test::Unit::TestCase
   @@data_labels = [ 'city', 'age', 'gender', 'marketing_target'  ]
   
   def test_build
-    assert_raise(ArgumentError) { OneR.new.build(DataSet.new) } 
+    assert_raises(ArgumentError) { OneR.new.build(DataSet.new) } 
     classifier = OneR.new.build(DataSet.new(:data_items => @@data_examples))
-    assert_not_nil(classifier.data_set.data_labels)
-    assert_not_nil(classifier.rule)
+    refute_nil(classifier.data_set.data_labels)
+    refute_nil(classifier.rule)
     assert_equal("attribute_1", classifier.data_set.data_labels.first)
     assert_equal("class_value", classifier.data_set.category_label)
     classifier = OneR.new.build(DataSet.new(:data_items => @@data_examples,
       :data_labels => @@data_labels))
-    assert_not_nil(classifier.data_set.data_labels)
-    assert_not_nil(classifier.rule)
+    refute_nil(classifier.data_set.data_labels)
+    refute_nil(classifier.rule)
     assert_equal("city", classifier.data_set.data_labels.first)
     assert_equal("marketing_target", classifier.data_set.category_label)
     assert_equal(1, classifier.rule[:attr_index])

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/classifiers/prism'
 require 'yaml'
 
 
-class PrismTest < Test::Unit::TestCase
+class PrismTest < Minitest::Test
 
   include Ai4r::Classifiers
   include Ai4r::Data
@@ -19,16 +19,16 @@ class PrismTest < Test::Unit::TestCase
   @@numeric_labels   = numeric_fixture['data_labels']
   
   def test_build
-    assert_raise(ArgumentError) { Prism.new.build(DataSet.new) } 
+    assert_raises(ArgumentError) { Prism.new.build(DataSet.new) } 
     classifier = Prism.new.build(DataSet.new(:data_items=>@@data_examples))
-    assert_not_nil(classifier.data_set.data_labels)
-    assert_not_nil(classifier.rules)
+    refute_nil(classifier.data_set.data_labels)
+    refute_nil(classifier.rules)
     assert_equal("attribute_1", classifier.data_set.data_labels.first)
     assert_equal("class_value", classifier.data_set.category_label)
     classifier = Prism.new.build(DataSet.new(:data_items => @@data_examples, 
         :data_labels => @@data_labels))
-    assert_not_nil(classifier.data_set.data_labels)
-    assert_not_nil(classifier.rules)
+    refute_nil(classifier.data_set.data_labels)
+    refute_nil(classifier.rules)
     assert_equal("city", classifier.data_set.data_labels.first)
     assert_equal("marketing_target", classifier.data_set.category_label)
     assert !classifier.rules.empty?
@@ -126,7 +126,7 @@ class PrismTest < Test::Unit::TestCase
     labels = ['color', 'kind']
     classifier = Prism.new.build(DataSet.new(:data_items => examples,
                                              :data_labels => labels))
-    assert_not_nil classifier.rules
+    refute_nil classifier.rules
     assert !classifier.rules.empty?
     classifier.rules.each do |rule|
       assert rule[:conditions].keys.size <= 1

--- a/test/classifiers/simple_linear_regression_test.rb
+++ b/test/classifiers/simple_linear_regression_test.rb
@@ -1,11 +1,11 @@
 require 'ai4r/classifiers/simple_linear_regression'
 require 'ai4r/data/data_set'
-require 'test/unit'
+require 'minitest/autorun'
 
 include Ai4r::Classifiers
 include Ai4r::Data
 
-class SimpleLinearRegressionTest < Test::Unit::TestCase
+class SimpleLinearRegressionTest < Minitest::Test
 
   @@data_labels = ["symboling", "normalized-losses", "wheel-base", "length", "width", "height", "curb-weight",
                    "engine-size", "bore" , "stroke", "compression-ratio", "horsepower", "peak-rpm", "city-mpg",

--- a/test/classifiers/votes_test.rb
+++ b/test/classifiers/votes_test.rb
@@ -8,9 +8,9 @@
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'ai4r/classifiers/votes'
-require 'test/unit'
+require 'minitest/autorun'
 
-class VotesTest < Test::Unit::TestCase
+class VotesTest < Minitest::Test
   def setup
     @votes = Votes.new
   end

--- a/test/classifiers/zero_r_test.rb
+++ b/test/classifiers/zero_r_test.rb
@@ -1,8 +1,8 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/classifiers/zero_r'
 require 'ai4r/data/data_set'
 
-class ZeroRTest < Test::Unit::TestCase
+class ZeroRTest < Minitest::Test
   
   include Ai4r::Classifiers
   include Ai4r::Data

--- a/test/clusterers/average_linkage_test.rb
+++ b/test/clusterers/average_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/average_linkage'
 
 class Ai4r::Clusterers::AverageLinkage < Ai4r::Clusterers::SingleLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix
 end
 
-class AverageLinkageTest < Test::Unit::TestCase
+class AverageLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data
@@ -49,7 +49,7 @@ class AverageLinkageTest < Test::Unit::TestCase
 
   def test_eval_unsupported
     clusterer = Ai4r::Clusterers::AverageLinkage.new
-    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+    assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
   def test_supports_eval

--- a/test/clusterers/bisecting_k_means_test.rb
+++ b/test/clusterers/bisecting_k_means_test.rb
@@ -7,10 +7,10 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/bisecting_k_means'
 
-class BisectingKMeansTest < Test::Unit::TestCase
+class BisectingKMeansTest < Minitest::Test
   
   include Ai4r::Clusterers
   include Ai4r::Data

--- a/test/clusterers/centroid_linkage_test.rb
+++ b/test/clusterers/centroid_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/centroid_linkage'
 
 class Ai4r::Clusterers::CentroidLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix, :index_clusters
 end
 
-class Ai4r::Clusterers::CentroidLinkageTest < Test::Unit::TestCase
+class Ai4r::Clusterers::CentroidLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data
@@ -51,7 +51,7 @@ class Ai4r::Clusterers::CentroidLinkageTest < Test::Unit::TestCase
 
   def test_eval_unsupported
     clusterer = Ai4r::Clusterers::CentroidLinkage.new
-    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+    assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
   def test_supports_eval

--- a/test/clusterers/complete_linkage_test.rb
+++ b/test/clusterers/complete_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/complete_linkage'
 
 class Ai4r::Clusterers::CompleteLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix
 end
 
-class CompleteLinkageTest < Test::Unit::TestCase
+class CompleteLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data

--- a/test/clusterers/diana_test.rb
+++ b/test/clusterers/diana_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/diana'
 
 class Ai4r::Clusterers::Diana
   attr_accessor :data_set, :number_of_clusters, :clusters
 end
 
-class DianaTest < Test::Unit::TestCase
+class DianaTest < Minitest::Test
 
   @@data = [  [10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
               [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]

--- a/test/clusterers/hierarchical_silhouette_test.rb
+++ b/test/clusterers/hierarchical_silhouette_test.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/ward_linkage'
 
-class HierarchicalSilhouetteTest < Test::Unit::TestCase
+class HierarchicalSilhouetteTest < Minitest::Test
   include Ai4r::Clusterers
   include Ai4r::Data
 

--- a/test/clusterers/k_means_test.rb
+++ b/test/clusterers/k_means_test.rb
@@ -7,10 +7,10 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/k_means'
 
-class KMeansTest < Test::Unit::TestCase
+class KMeansTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data
@@ -94,7 +94,7 @@ class KMeansTest < Test::Unit::TestCase
       [10, 10, "London", 50])
 
     # Ensure default distance raises error for nil argument
-    exception = assert_raise(TypeError) {clusterer.distance([1, 10], [nil, nil])}
+    exception = assert_raises(TypeError) {clusterer.distance([1, 10], [nil, nil])}
 
     # Test new distance definition
     manhattan_distance = lambda do |a, b|
@@ -127,10 +127,10 @@ class KMeansTest < Test::Unit::TestCase
     # centroid_indices can be specified:
     KMeans.new.set_parameters({:centroid_indices=>[0,1,2,3]}).build(data_set, 4)
     # raises exception if number of clusters differs from length of centroid_indices:
-    exception = assert_raise(ArgumentError) {KMeans.new.set_parameters({:centroid_indices=>[0,1,2,3]}).build(data_set, 2)}
+    exception = assert_raises(ArgumentError) {KMeans.new.set_parameters({:centroid_indices=>[0,1,2,3]}).build(data_set, 2)}
     assert_equal('Length of centroid indices array differs from the specified number of clusters', exception.message)
     # raises exception for bad centroid index:
-    exception = assert_raise(ArgumentError) {KMeans.new.set_parameters({:centroid_indices=>[0,1,2,@@data.size+10]}).build(data_set, 4)}
+    exception = assert_raises(ArgumentError) {KMeans.new.set_parameters({:centroid_indices=>[0,1,2,@@data.size+10]}).build(data_set, 4)}
     assert_equal("Invalid centroid index #{@@data.size+10}", exception.message)
   end
 
@@ -166,10 +166,10 @@ class KMeansTest < Test::Unit::TestCase
     # Verify that eliminate is the on_empty default
     assert_equal 'eliminate', clusterer.on_empty
     # Verify that invalid on_empty option throws an argument error
-    exception = assert_raise(ArgumentError) {KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices, :on_empty=>'ldkfje'}).build(data_set, @@empty_centroid_indices.size)}
+    exception = assert_raises(ArgumentError) {KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices, :on_empty=>'ldkfje'}).build(data_set, @@empty_centroid_indices.size)}
     assert_equal("Invalid value for on_empty", exception.message)
     # Verify that on_empty option 'terminate' raises an error when an empty cluster arises
-    exception = assert_raise(TypeError) {KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices, :on_empty=>'terminate'}).build(data_set, @@empty_centroid_indices.size)}
+    exception = assert_raises(TypeError) {KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices, :on_empty=>'terminate'}).build(data_set, @@empty_centroid_indices.size)}
     clusterer = KMeans.new.set_parameters({:centroid_indices=>@@empty_centroid_indices, :on_empty=>'random'}).build(data_set, @@empty_centroid_indices.size)
     # Verify that cluster was not eliminated
     assert_equal @@empty_centroid_indices.size, clusterer.clusters.length

--- a/test/clusterers/median_linkage_test.rb
+++ b/test/clusterers/median_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/median_linkage'
 
 class Ai4r::Clusterers::MedianLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix, :index_clusters
 end
 
-class Ai4r::Clusterers::MedianLinkageTest < Test::Unit::TestCase
+class Ai4r::Clusterers::MedianLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data
@@ -51,7 +51,7 @@ class Ai4r::Clusterers::MedianLinkageTest < Test::Unit::TestCase
 
   def test_eval_unsupported
     clusterer = Ai4r::Clusterers::MedianLinkage.new
-    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+    assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
   def test_supports_eval

--- a/test/clusterers/single_linkage_test.rb
+++ b/test/clusterers/single_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/single_linkage'
 
 class Ai4r::Clusterers::SingleLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix
 end
 
-class SingleLinkageTest < Test::Unit::TestCase
+class SingleLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data

--- a/test/clusterers/ward_linkage_hierarchical_test.rb
+++ b/test/clusterers/ward_linkage_hierarchical_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require File.dirname(__FILE__) + '/../../lib/ai4r/clusterers/ward_linkage_hierarchical'
 
 class Ai4r::Clusterers::WardLinkageHierarchical
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix, :index_clusters
 end
 
-class Ai4r::Clusterers::WardLinkageHierarchicalTest < Test::Unit::TestCase
+class Ai4r::Clusterers::WardLinkageHierarchicalTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data

--- a/test/clusterers/ward_linkage_test.rb
+++ b/test/clusterers/ward_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/ward_linkage'
 
 class Ai4r::Clusterers::WardLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix, :index_clusters
 end
 
-class Ai4r::Clusterers::WardLinkageTest < Test::Unit::TestCase
+class Ai4r::Clusterers::WardLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data
@@ -51,7 +51,7 @@ class Ai4r::Clusterers::WardLinkageTest < Test::Unit::TestCase
 
   def test_eval_unsupported
     clusterer = Ai4r::Clusterers::WardLinkage.new
-    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+    assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
   def test_supports_eval

--- a/test/clusterers/weighted_average_linkage_test.rb
+++ b/test/clusterers/weighted_average_linkage_test.rb
@@ -7,14 +7,14 @@
 # the Mozilla Public License version 1.1  as published by the
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/clusterers/weighted_average_linkage'
 
 class Ai4r::Clusterers::WeightedAverageLinkage
   attr_accessor :data_set, :number_of_clusters, :clusters, :distance_matrix, :index_clusters
 end
 
-class Ai4r::Clusterers::WeightedAverageLinkageTest < Test::Unit::TestCase
+class Ai4r::Clusterers::WeightedAverageLinkageTest < Minitest::Test
 
   include Ai4r::Clusterers
   include Ai4r::Data
@@ -51,7 +51,7 @@ class Ai4r::Clusterers::WeightedAverageLinkageTest < Test::Unit::TestCase
 
   def test_eval_unsupported
     clusterer = Ai4r::Clusterers::WeightedAverageLinkage.new
-    assert_raise(NotImplementedError) { clusterer.eval([0, 0]) }
+    assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
   end
 
   def test_supports_eval

--- a/test/data/data_set_test.rb
+++ b/test/data/data_set_test.rb
@@ -7,12 +7,12 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/data/data_set'
 
 module Ai4r
   module Data
-    class DataSetTest < Test::Unit::TestCase
+    class DataSetTest < Minitest::Test
       
       def test_load_csv_with_labels
         set = DataSet.new.load_csv_with_labels("#{File.dirname(__FILE__)}/data_set.csv")
@@ -67,7 +67,7 @@ module Ai4r
         set = DataSet.new(:data_labels => labels)
         assert_equal labels, set.data_labels
         set = DataSet.new(:data_items => [[ 1, 2, 3]])
-        assert_raise(ArgumentError) { set.set_data_labels(labels) }
+        assert_raises(ArgumentError) { set.set_data_labels(labels) }
       end
 
       def test_set_data_items
@@ -81,9 +81,9 @@ module Ai4r
         assert_equal items, set.data_items
         assert_equal 3, set.data_labels.length
         items << items.first[0..-2]
-        assert_raise(ArgumentError) { set.set_data_items(items) }
-        assert_raise(ArgumentError) { set.set_data_items(nil) }
-        assert_raise(ArgumentError) { set.set_data_items([1]) }
+        assert_raises(ArgumentError) { set.set_data_items(items) }
+        assert_raises(ArgumentError) { set.set_data_items(nil) }
+        assert_raises(ArgumentError) { set.set_data_items([1]) }
       end
      
       def test_get_mean_or_mode

--- a/test/data/proximity_test.rb
+++ b/test/data/proximity_test.rb
@@ -7,12 +7,12 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/data/proximity'
 
 module Ai4r
   module Data
-    class ProximityTest < Test::Unit::TestCase
+    class ProximityTest < Minitest::Test
           
       @@delta = 0.0000001    
       @@data1 = [rand*10, rand*10, rand*-10]

--- a/test/data/statistics_test.rb
+++ b/test/data/statistics_test.rb
@@ -7,12 +7,12 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/data/statistics'
 
 module Ai4r
   module Data
-    class StatisticsTest < Test::Unit::TestCase
+    class StatisticsTest < Minitest::Test
       
       DELTA = 0.00001
       

--- a/test/experiment/classifier_evaluator_test.rb
+++ b/test/experiment/classifier_evaluator_test.rb
@@ -7,7 +7,7 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/experiment/classifier_evaluator'
 require 'ai4r/classifiers/classifier'
 
@@ -32,7 +32,7 @@ end
 
 module Ai4r
   module Experiment
-    class ClassifierEvaluatorTest < Test::Unit::TestCase
+    class ClassifierEvaluatorTest < Minitest::Test
       
       def test_add_classifier
         evaluator = ClassifierEvaluator.new

--- a/test/genetic_algorithm/chromosome_test.rb
+++ b/test/genetic_algorithm/chromosome_test.rb
@@ -10,7 +10,7 @@
 
 require 'ai4r/genetic_algorithm/genetic_algorithm'
 require 'ai4r/genetic_algorithm/tsp_chromosome'
-require 'test/unit'
+require 'minitest/autorun'
 
 module Ai4r
   
@@ -29,7 +29,7 @@ module Ai4r
               [ 11,       11,       22,       9,        28,     26,       27,         19,     22,        0]
   ]
 
-    class ChromosomeTest < Test::Unit::TestCase
+    class ChromosomeTest < Minitest::Test
 
       def test_chromosome_seed
         TspChromosome.set_cost_matrix(COST)
@@ -60,7 +60,7 @@ module Ai4r
         mutated_data = chromosome.data.dup
         expected_fitness = TspChromosome.new(mutated_data).fitness
         assert_equal expected_fitness, chromosome.fitness
-        assert_not_equal original_fitness, chromosome.fitness
+        refute_equal original_fitness, chromosome.fitness
       end
 
     end

--- a/test/genetic_algorithm/genetic_algorithm_test.rb
+++ b/test/genetic_algorithm/genetic_algorithm_test.rb
@@ -9,7 +9,7 @@
  
 require 'ai4r/genetic_algorithm/genetic_algorithm'
 require 'ai4r/genetic_algorithm/tsp_chromosome'
-require 'test/unit'
+require 'minitest/autorun'
 
 module Ai4r
   
@@ -32,7 +32,7 @@ module Ai4r
   ]
 
 
-    class GeneticAlgorithmTest < Test::Unit::TestCase
+    class GeneticAlgorithmTest < Minitest::Test
 
       def test_chromosome_seed
         TspChromosome.set_cost_matrix(COSTS)

--- a/test/genetic_algorithm/genetic_search_edge_cases_test.rb
+++ b/test/genetic_algorithm/genetic_search_edge_cases_test.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/genetic_algorithm/genetic_algorithm'
 
 module Ai4r
@@ -28,7 +28,7 @@ module Ai4r
       end
     end
 
-    class GeneticSearchEdgeCasesTest < Test::Unit::TestCase
+    class GeneticSearchEdgeCasesTest < Minitest::Test
       def test_selection_with_identical_fitness_sets_normalized_to_one
         search = GeneticSearch.new(4, 1, FixedChromosome)
         search.generate_initial_population
@@ -57,7 +57,7 @@ module Ai4r
       def test_missing_chromosome_methods_raise_not_implemented
         klass = Class.new(ChromosomeBase)
         search = GeneticSearch.new(1, 1, klass)
-        assert_raise(NotImplementedError) { search.generate_initial_population }
+        assert_raises(NotImplementedError) { search.generate_initial_population }
       end
     end
 

--- a/test/integration/examples_test.rb
+++ b/test/integration/examples_test.rb
@@ -1,6 +1,6 @@
-require 'test/unit'
+require 'minitest/autorun'
 
-class ExamplesTest < Test::Unit::TestCase
+class ExamplesTest < Minitest::Test
   EXAMPLES_DIR = File.expand_path('../../examples/classifiers', __dir__)
 
   def run_example(name)

--- a/test/integration/normalization_pipeline_test.rb
+++ b/test/integration/normalization_pipeline_test.rb
@@ -1,7 +1,7 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r'
 
-class NormalizationPipelineTest < Test::Unit::TestCase
+class NormalizationPipelineTest < Minitest::Test
   include Ai4r::Data
   include Ai4r::Clusterers
   include Ai4r::Classifiers

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -16,7 +16,7 @@
 
 
 require 'ai4r/neural_network/backpropagation'
-require 'test/unit'
+require 'minitest/autorun'
 require_relative '../test_helper.rb'
 
 Ai4r::NeuralNetwork::Backpropagation.send(:public, *Ai4r::NeuralNetwork::Backpropagation.protected_instance_methods)
@@ -27,7 +27,7 @@ module Ai4r
   module NeuralNetwork
 
 
-    class BackpropagationTest < Test::Unit::TestCase
+    class BackpropagationTest < Minitest::Test
 
 
       def test_init_network

--- a/test/neural_network/hopfield_test.rb
+++ b/test/neural_network/hopfield_test.rb
@@ -9,7 +9,7 @@
 # the Mozilla Public License version 1.1  as published by the 
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/neural_network/hopfield'
 require 'ai4r/data/data_set'
 
@@ -20,7 +20,7 @@ module Ai4r
   module NeuralNetwork
 
 
-    class HopfieldTest < Test::Unit::TestCase
+    class HopfieldTest < Minitest::Test
       
       def setup
         @data_set = Ai4r::Data::DataSet.new :data_items => [
@@ -152,14 +152,14 @@ module Ai4r
       def test_train_validates_values
         net = Hopfield.new
         invalid = Ai4r::Data::DataSet.new :data_items => [[1, 0, -1]]
-        assert_raise(ArgumentError) { net.train(invalid) }
+        assert_raises(ArgumentError) { net.train(invalid) }
 
         net.active_node_value = 1
         net.inactive_node_value = 0
         valid = Ai4r::Data::DataSet.new :data_items => [[1,0,1,0]]
         net.train(valid)
         invalid2 = Ai4r::Data::DataSet.new :data_items => [[1,2,0]]
-        assert_raise(ArgumentError) { net.train(invalid2) }
+        assert_raises(ArgumentError) { net.train(invalid2) }
       end
 
       def test_weight_scaling_changes_weights
@@ -170,7 +170,7 @@ module Ai4r
         scaled_net.set_parameters(weight_scaling: 0.5)
         scaled_net.train @data_set
 
-        assert_not_equal default_net.weights, scaled_net.weights
+        refute_equal default_net.weights, scaled_net.weights
         assert_in_delta default_net.read_weight(1,0) * 2,
           scaled_net.read_weight(1,0), 0.00001
       end

--- a/test/som/node_test.rb
+++ b/test/som/node_test.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/som/node'
 
 module Ai4r
   module Som
-    class NodeTest < Test::Unit::TestCase
+    class NodeTest < Minitest::Test
       def test_distance_to_input
         node = Node.new
         node.weights = [0.0, 0.0]

--- a/test/som/som_test.rb
+++ b/test/som/som_test.rb
@@ -11,7 +11,7 @@
 # Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
 
 require 'ai4r/som/som'
-require 'test/unit'
+require 'minitest/autorun'
 require 'tmpdir'
 require_relative '../test_helper'
 
@@ -19,7 +19,7 @@ module Ai4r
 
   module Som
 
-    class SomTest < Test::Unit::TestCase
+    class SomTest < Minitest::Test
 
       def setup
         @som = Som.new 2, 5, 5, Layer.new(3, 3)
@@ -52,10 +52,10 @@ module Ai4r
       end
 
       def test_access_to_nodes
-        ex = assert_raise(ArgumentError) { @som.get_node(5, 5) }
+        ex = assert_raises(ArgumentError) { @som.get_node(5, 5) }
         assert_equal 'invalid node coordinates (5, 5)', ex.message
 
-        ex = assert_raise(ArgumentError) { @som.get_node(5, -3) }
+        ex = assert_raises(ArgumentError) { @som.get_node(5, -3) }
         assert_equal 'invalid node coordinates (5, -3)', ex.message
 
         assert_equal Node, @som.get_node(0, 0).class

--- a/test/som/training_test.rb
+++ b/test/som/training_test.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/som/som'
 
 module Ai4r
   module Som
-    class TrainingTest < Test::Unit::TestCase
+    class TrainingTest < Minitest::Test
       DATA = [[0.0, 0.0], [1.0, 1.0]]
 
       def setup

--- a/test/som/two_phase_layer_test.rb
+++ b/test/som/two_phase_layer_test.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ai4r/som/two_phase_layer'
 
 module Ai4r
   module Som
-    class TwoPhaseLayerTest < Test::Unit::TestCase
+    class TwoPhaseLayerTest < Minitest::Test
       def setup
         # Use small phase sizes to make schedule deterministic
         @layer = TwoPhaseLayer.new(6, 0.9, 2, 3, 0.5, 0.1)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,8 @@
 #
 
 
-require 'test/unit'
+require 'minitest/autorun'
+Minitest::Test.i_suck_and_my_tests_are_order_dependent!
 
 
 def assert_approximate_equality(expected, real, delta=0.01)


### PR DESCRIPTION
## Summary
- move from Test::Unit to Minitest
- update contributor guide and docs
- keep tests ordered to preserve behaviour

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68722f2b6af08326912ac7cabad0a0ee