### PR TITLE
Fix DBSCAN eval raising

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rake", "~> 13"
 gem "rdoc", "~> 6"
 gem "csv", "~> 3"
 gem "minitest", "~> 5"
+gem "test-unit", "~> 3"
 
 group :development do
   gem "rubocop", "~> 1.78", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    power_assert (2.0.5)
     prism (1.4.0)
     psych (5.2.6)
       date
@@ -40,6 +41,8 @@ GEM
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
     stringio (3.1.7)
+    test-unit (3.7.0)
+      power_assert
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -54,6 +57,7 @@ DEPENDENCIES
   rake (~> 13)
   rdoc (~> 6)
   rubocop (~> 1.78)
+  test-unit (~> 3)
 
 BUNDLED WITH
    2.6.7

--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -63,7 +63,8 @@ module Ai4r
       # This algorithms does not allow classification of new data items
       # once it has been built. Rebuild the cluster including you data element.
       def eval(data_item)
-        Raise "Eval of new data is not supported by this algorithm."
+        raise NotImplementedError,
+              'Eval of new data is not supported by this algorithm.'
       end
 
       def distance(a, b)


### PR DESCRIPTION
## Summary
- fix `eval` method in DBSCAN clusterer to use `raise NotImplementedError`
- include `test-unit` dependency so test suite loads

## Testing
- `bundle install`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_687509c544f88326bd512a6a515a5f23