### PR TITLE
Fix DBSCAN eval handling

### DIFF
--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -61,9 +61,16 @@ module Ai4r
       end
 
       # This algorithms does not allow classification of new data items
-      # once it has been built. Rebuild the cluster including you data element.
-      def eval(data_item)
-        Raise "Eval of new data is not supported by this algorithm."
+      # once it has been built. Rebuild the cluster including your data element.
+      # @param _data_item [Object]
+      # @return [Object]
+      def eval(_data_item)
+        raise NotImplementedError, 'Eval of new data is not supported by this algorithm.'
+      end
+
+      # @return [Object]
+      def supports_eval?
+        false
       end
 
       def distance(a, b)

--- a/test/clusterers/dbscan_test.rb
+++ b/test/clusterers/dbscan_test.rb
@@ -74,6 +74,11 @@ class DBSCANTest < Minitest::Test
     assert_raises(ArgumentError) {DBSCAN.new.build(data_set)}
   end
 
+  def test_eval_unsupported
+    clusterer = DBSCAN.new
+    assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
+
   private
   def draw_map(clusterer)
     map = Array.new(11) {Array.new(11, 0)}


### PR DESCRIPTION
## Summary
- raise NotImplementedError in DBSCAN#eval
- add supports_eval? to DBSCAN
- test that eval raises NotImplementedError

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68752923ecb88326b69b3bce147b1a39