### PR TITLE
Fix DBSCAN state reuse and track cluster count

### DIFF
--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -35,10 +35,12 @@ module Ai4r
 
       def build(data_set)
         @data_set = data_set
+        @clusters = []
+        @cluster_indices = []
         @labels = Array.new(data_set.data_items.size)
+        @number_of_clusters = 0
 
         raise ArgumentError, 'epsilon must be defined' unless !@epsilon.nil?
-        number_of_clusters = 0
 
         # Detect if the neighborhood of the current item
         # is dense enough
@@ -48,11 +50,11 @@ module Ai4r
             if neighbors.size < @min_points
               @labels[data_index] = :noise
             else
-              number_of_clusters += 1
-              @labels[data_index] = number_of_clusters
+              @number_of_clusters += 1
+              @labels[data_index] = @number_of_clusters
               @clusters.push([data_item])
               @cluster_indices.push([data_index])
-              extend_cluster(neighbors, number_of_clusters)
+              extend_cluster(neighbors, @number_of_clusters)
             end
           end
         }

--- a/test/clusterers/dbscan_test.rb
+++ b/test/clusterers/dbscan_test.rb
@@ -34,6 +34,22 @@ class DBSCANTest < Minitest::Test
     end
   end
 
+  def test_number_of_clusters_attribute
+    data_set = DataSet.new(:data_items => @@data, :data_labels => ["X", "Y"])
+    clusterer = DBSCAN.new.set_parameters(:epsilon => 8, :min_points => 3).build(data_set)
+    assert_equal clusterer.clusters.length, clusterer.number_of_clusters
+  end
+
+  def test_build_resets_state
+    data_set = DataSet.new(:data_items => @@data, :data_labels => ["X", "Y"])
+    clusterer = DBSCAN.new.set_parameters(:epsilon => 8, :min_points => 3)
+    first = clusterer.build(data_set)
+    assert_equal first.clusters.length, first.number_of_clusters
+    second = clusterer.build(data_set)
+    assert_equal  first.clusters.length, second.clusters.length
+    assert_equal second.clusters.length, second.number_of_clusters
+  end
+
   def test_distance
     clusterer = DBSCAN.new.set_parameters(:epsilon => 2)
     # By default, distance returns the euclidean distance to the power of 2


### PR DESCRIPTION
## Summary
- reset DBSCAN state on `build`
- expose `@number_of_clusters`
- test that the cluster count matches cluster length
- ensure consecutive builds do not accumulate state

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875292691b88326a3d752e1a26fd3a5