### PR TITLE
Clarify DBSCAN distance metric and fix cluster count

### DIFF
--- a/docs/dbscan.md
+++ b/docs/dbscan.md
@@ -1,14 +1,16 @@
 # DBSCAN Clustering
 
-DBSCAN groups together densely packed points and labels isolated points as noise. The implementation operates on numeric attributes and uses squared Euclidean distance by default.
+DBSCAN groups together densely packed points and labels isolated points as noise. The implementation operates on numeric attributes and uses squared Euclidean distance by default. Squaring the distance avoids an expensive square root for every comparison.
 
 ## Parameters
 
 `Ai4r::Clusterers::DBSCAN` exposes parameters via `set_parameters`:
 
-* `epsilon` – squared radius for the neighbourhood. The squared distance between two points must be `<= epsilon` to be considered neighbours.
+* `epsilon` – squared radius for the neighbourhood. The squared distance between two points must be `<= epsilon` to be considered neighbours. If you want a real radius `r`, pass `epsilon: r**2`.
 * `min_points` – minimum number of neighbouring points **excluding the point itself** required to create or expand a cluster.
 * `distance_function` – optional custom distance measure. Provide a closure receiving two items and returning a distance. When omitted, squared Euclidean distance is used.
+
+For example, a radius of `3` units corresponds to `epsilon: 9`.
 
 ## Example
 

--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -42,8 +42,6 @@ module Ai4r
 
         raise ArgumentError, 'epsilon must be defined' if @epsilon.nil?
 
-        number_of_clusters = 0
-
         # Detect if the neighborhood of the current item
         # is dense enough
         data_set.data_items.each_with_index do |data_item, data_index|
@@ -53,11 +51,11 @@ module Ai4r
           if neighbors.size < @min_points
             @labels[data_index] = :noise
           else
-            number_of_clusters += 1
-            @labels[data_index] = number_of_clusters
+            @number_of_clusters += 1
+            @labels[data_index] = @number_of_clusters
             @clusters.push([data_item])
             @cluster_indices.push([data_index])
-            extend_cluster(neighbors, number_of_clusters)
+            extend_cluster(neighbors, @number_of_clusters)
           end
         end
 


### PR DESCRIPTION
## Summary
- explain the squared distance metric in `docs/dbscan.md`
- fix DBSCAN to track `@number_of_clusters`

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68753deed3c08326b4b7306ad0cb663f