### PR TITLE
Expand DBSCAN example and fix cluster count

### DIFF
--- a/docs/dbscan.md
+++ b/docs/dbscan.md
@@ -23,3 +23,40 @@ clusterer = DBSCAN.new
 clusterer.set_parameters(epsilon: 4, min_points: 1).build(set)
 pp clusterer.clusters
 ```
+
+## Illustrative Example
+
+The minimal dataset above shows the mechanics of the algorithm.  To gain
+intuition about parameter tuning, try running DBSCAN on a slightly larger
+synthetic set:
+
+```ruby
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [
+  [1,1], [1,2], [1,3], [2,1], [2,2], [2,3],
+  [8,8], [8,9], [8,10], [9,8], [9,9], [9,10],
+  [5,5], [1,9], [10,0]
+]
+set = DataSet.new(data_items: points)
+clusterer = DBSCAN.new
+clusterer.set_parameters(epsilon: 10, min_points: 2).build(set)
+pp clusterer.labels
+pp clusterer.clusters
+```
+
+The output shows two clusters and three points labelled as noise:
+
+```
+[1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, :noise, :noise, :noise]
+[
+  [[1,1], [1,2], [1,3], [2,1], [2,2], [2,3]],
+  [[8,8], [8,9], [8,10], [9,8], [9,9], [9,10]]
+]
+```
+
+With `epsilon` set to `10` (squared radius) and `min_points` set to `2`,
+DBSCAN groups points within each dense region while ignoring the scattered
+items.

--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -61,6 +61,7 @@ module Ai4r
           end
         end
 
+        @number_of_clusters = number_of_clusters
         self
       end
 


### PR DESCRIPTION
## Summary
- assign number_of_clusters after DBSCAN build finishes
- extend DBSCAN documentation with a larger example and expected output

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68753e3ca75083268a1b3980a12d1449