### PR TITLE
Fix DBSCAN cluster count tracking

### DIFF
--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -61,6 +61,7 @@ module Ai4r
           end
         end
 
+        @number_of_clusters = number_of_clusters
         self
       end
 

--- a/test/clusterers/dbscan_test.rb
+++ b/test/clusterers/dbscan_test.rb
@@ -37,6 +37,7 @@ class DBSCANTest < Minitest::Test
   def test_number_of_clusters_attribute
     data_set = DataSet.new(:data_items => @@data, :data_labels => ["X", "Y"])
     clusterer = DBSCAN.new.set_parameters(:epsilon => 8, :min_points => 3).build(data_set)
+    assert_equal 3, clusterer.number_of_clusters
     assert_equal clusterer.clusters.length, clusterer.number_of_clusters
   end
 


### PR DESCRIPTION
## Summary
- ensure `DBSCAN#build` stores the number of discovered clusters
- assert the tracked cluster count explicitly in DBSCAN tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68753e615a2083269fef82a8e7be45d8