### PR TITLE
Fix DBSCAN cluster count and validate labels

### DIFF
--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -61,6 +61,13 @@ module Ai4r
           end
         end
 
+        @number_of_clusters = number_of_clusters
+        raise 'number_of_clusters must be positive' if !@clusters.empty? && @number_of_clusters <= 0
+        valid_labels = (1..@number_of_clusters).to_a << :noise
+        unless @labels.all? { |l| valid_labels.include?(l) }
+          raise 'labels must be cluster ids or :noise'
+        end
+
         self
       end
 

--- a/test/clusterers/dbscan_test.rb
+++ b/test/clusterers/dbscan_test.rb
@@ -38,6 +38,7 @@ class DBSCANTest < Minitest::Test
     data_set = DataSet.new(:data_items => @@data, :data_labels => ["X", "Y"])
     clusterer = DBSCAN.new.set_parameters(:epsilon => 8, :min_points => 3).build(data_set)
     assert_equal clusterer.clusters.length, clusterer.number_of_clusters
+    assert clusterer.number_of_clusters.positive?
   end
 
   def test_build_resets_state
@@ -83,6 +84,7 @@ class DBSCANTest < Minitest::Test
     assert clusterer.labels.all?{ |label| label == :noise}
     # Verify that none cluster has been created
     assert_equal 0, clusterer.clusters.length
+    assert_equal 0, clusterer.number_of_clusters
   end
 
   def test_undefined_epsilon
@@ -93,6 +95,13 @@ class DBSCANTest < Minitest::Test
   def test_eval_unsupported
     clusterer = DBSCAN.new
     assert_raises(NotImplementedError) { clusterer.eval([0, 0]) }
+  end
+
+  def test_labels_are_valid
+    data_set = DataSet.new(:data_items => @@data, :data_labels => ["X", "Y"])
+    clusterer = DBSCAN.new.set_parameters(:epsilon => 8, :min_points => 3).build(data_set)
+    valid = (1..clusterer.number_of_clusters).to_a + [:noise]
+    assert clusterer.labels.all? { |label| valid.include?(label) }
   end
 
   private


### PR DESCRIPTION
## Summary
- ensure `build` sets `@number_of_clusters`
- validate cluster count and labels in DBSCAN
- test for positive number of clusters and valid labels

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68753e6d2b1c8326bf3f3a531f06d516