### PR TITLE
Add neural network test framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  neural-network-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - run: bundle exec rake test:nn
+      - run: bundle exec rake e2e
+      - run: |
+          echo "Coverage $(grep -A1 '^COVERAGE' coverage/.last_run.json)"

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,14 @@ source 'https://rubygems.org'
 gem "rake", "~> 13"
 gem "rdoc", "~> 6"
 gem "csv", "~> 3"
-gem "minitest", "~> 5"
 
 group :development do
   gem "rubocop", "~> 1.78", require: false
+end
+
+group :test do
+  gem 'minitest', '~> 5.22'
+  gem 'rspec-parameterized', '~> 1.0'
+  gem 'simplecov', '~> 0.22', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     csv (3.3.5)
     date (3.4.1)
+    debug_inspector (1.2.0)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
     erb (5.0.1)
     json (2.12.2)
     language_server-protocol (3.17.0.5)
@@ -14,6 +19,10 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
+    proc_to_ast (0.2.0)
+      parser
+      rouge
+      unparser
     psych (5.2.6)
       date
       stringio
@@ -24,6 +33,31 @@ GEM
       erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    rouge (4.5.2)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-parameterized (1.0.2)
+      rspec-parameterized-core (< 2)
+      rspec-parameterized-table_syntax (< 2)
+    rspec-parameterized-core (1.0.1)
+      parser
+      proc_to_ast (>= 0.2.0)
+      rspec (>= 2.13, < 4)
+      unparser
+    rspec-parameterized-table_syntax (1.0.1)
+      binding_of_caller
+      rspec-parameterized-core (< 2)
+    rspec-support (3.13.4)
     rubocop (1.78.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -39,10 +73,20 @@ GEM
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.7)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    unparser (0.8.0)
+      diff-lcs (~> 1.6)
+      parser (>= 3.3.0)
+      prism (>= 1.4)
 
 PLATFORMS
   ruby
@@ -50,10 +94,12 @@ PLATFORMS
 
 DEPENDENCIES
   csv (~> 3)
-  minitest (~> 5)
+  minitest (~> 5.22)
   rake (~> 13)
   rdoc (~> 6)
+  rspec-parameterized (~> 1.0)
   rubocop (~> 1.78)
+  simplecov (~> 0.22)
 
 BUNDLED WITH
    2.6.7

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -7,6 +7,22 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
+namespace :test do
+  desc 'Run neural network unit and integration tests'
+  task :nn do
+    files = Dir['test/unit/neural_network/**/*_test.rb'] +
+            Dir['test/integration/**/*_test.rb']
+    script = 'ARGV.each { |f| require File.expand_path(f) }'
+    ruby '-Ilib:test', '-e', script, *files
+  end
+end
+
+task :e2e do
+  files = Dir['test/e2e/**/*_test.rb']
+  script = 'ARGV.each { |f| require File.expand_path(f) }'
+  ruby '-Ilib:test', '-e', script, *files
+end
+
 Rake::RDocTask.new do |rd|
   rd.main = "README.rdoc"
   rd.rdoc_dir = "rdoc"

--- a/TESTING_NN.md
+++ b/TESTING_NN.md
@@ -1,0 +1,22 @@
+# Neural Network Testing Guide
+
+This document describes how to run the neural network test suite.
+
+## Running tests
+
+```
+bundle install
+bundle exec rake test:nn
+bundle exec rake e2e
+```
+
+## Fixtures
+
+Fixtures live in `test/fixtures/nn`. Each YAML file defines network
+parameters and a small dataset. Use `load_fixture(id)` to load them.
+If `weight_init` is `fixed_seed`, the loader seeds Ruby's RNG with `1234`.
+
+## Adding new algorithms
+
+Place tests under `test/unit/neural_network` and add fixtures as needed.
+Use the helper modules in `test/helpers` for numeric assertions.

--- a/test/e2e/hopfield_digits_test.rb
+++ b/test/e2e/hopfield_digits_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+require 'ai4r/neural_network/hopfield'
+
+class HopfieldDigitsTest < Minitest::Test
+  DIGITS = Array.new(10) { |i| Array.new(15) { ((i >> (_1/3)) & 1) * 2 - 1 } }
+
+  def test_recall_from_noise
+    data = Ai4r::Data::DataSet.new(data_items: DIGITS)
+    net = Ai4r::NeuralNetwork::Hopfield.new.train(data)
+    noisy = DIGITS[3].dup
+    4.times { |i| noisy[i] *= -1 }
+    result = net.eval(noisy)
+    assert_equal 15, result.length
+  end
+end

--- a/test/e2e/som_iris_test.rb
+++ b/test/e2e/som_iris_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+require 'ai4r/som/two_phase_layer'
+require 'ai4r/som/som'
+
+class SomIrisTest < Minitest::Test
+  DATA = File.readlines('examples/som/som_data.rb').grep(/\[.*\]/).first(30).map do |line|
+    line.strip.sub(/[\[\],]/,'').split(',').map(&:to_f)
+  end
+
+  def test_purity
+    layer = Ai4r::Som::TwoPhaseLayer.new(3, 0.5, 1, 1, 0.5, 0.2)
+    som = Ai4r::Som::Som.new(4, 3, 3, layer)
+    som.initiate_map
+    som.train(DATA)
+    assert som.nodes.any?
+  end
+end

--- a/test/e2e/xor_scenario_test.rb
+++ b/test/e2e/xor_scenario_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+require 'ai4r/neural_network/backpropagation'
+
+class XorScenarioTest < Minitest::Test
+  def test_learns_xor
+    data = [[0,0,0],[0,1,1],[1,0,1],[1,1,0]]
+    inputs = data.map{ |r| r[0,2] }
+    outputs = data.map{ |r| [r[2]] }
+    net = Ai4r::NeuralNetwork::Backpropagation.new([2,2,1])
+    net.train_epochs(inputs, outputs, epochs: 5000)
+    preds = inputs.map { |i| net.eval(i).first.round }
+    assert_equal outputs.flatten, preds
+  end
+end

--- a/test/fixtures/nn/fi01_topo_tiny_sigmoid_clean.yml
+++ b/test/fixtures/nn/fi01_topo_tiny_sigmoid_clean.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: sigmoid
+weight_init: zero
+learning_rate: 0.0001
+corruption_pct: 0
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 0

--- a/test/fixtures/nn/fi02_topo_deep_tanh_clean.yml
+++ b/test/fixtures/nn/fi02_topo_deep_tanh_clean.yml
@@ -1,0 +1,23 @@
+---
+topology:
+- 2
+- 4
+- 3
+- 1
+activation: tanh
+weight_init: glorot
+learning_rate: 0.1
+corruption_pct: 0
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 0

--- a/test/fixtures/nn/fi03_topo_deep_sigmoid_25pc.yml
+++ b/test/fixtures/nn/fi03_topo_deep_sigmoid_25pc.yml
@@ -1,0 +1,23 @@
+---
+topology:
+- 2
+- 4
+- 3
+- 1
+activation: sigmoid
+weight_init: fixed_seed
+learning_rate: 5.0
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi04_topo_tiny_tanh_clean.yml
+++ b/test/fixtures/nn/fi04_topo_tiny_tanh_clean.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: tanh
+weight_init: fixed_seed
+learning_rate: 5.0
+corruption_pct: 0
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 0

--- a/test/fixtures/nn/fi05_topo_tiny_tanh_25pc.yml
+++ b/test/fixtures/nn/fi05_topo_tiny_tanh_25pc.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: tanh
+weight_init: glorot
+learning_rate: 0.0001
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi06_topo_deep_sigmoid_25pc.yml
+++ b/test/fixtures/nn/fi06_topo_deep_sigmoid_25pc.yml
@@ -1,0 +1,23 @@
+---
+topology:
+- 2
+- 4
+- 3
+- 1
+activation: sigmoid
+weight_init: zero
+learning_rate: 0.1
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi07_topo_deep_sigmoid_25pc.yml
+++ b/test/fixtures/nn/fi07_topo_deep_sigmoid_25pc.yml
@@ -1,0 +1,23 @@
+---
+topology:
+- 2
+- 4
+- 3
+- 1
+activation: sigmoid
+weight_init: glorot
+learning_rate: 0.0001
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi08_topo_tiny_tanh_25pc.yml
+++ b/test/fixtures/nn/fi08_topo_tiny_tanh_25pc.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: tanh
+weight_init: zero
+learning_rate: 5.0
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi09_topo_tiny_tanh_25pc.yml
+++ b/test/fixtures/nn/fi09_topo_tiny_tanh_25pc.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: tanh
+weight_init: fixed_seed
+learning_rate: 0.1
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi10_topo_tiny_tanh_25pc.yml
+++ b/test/fixtures/nn/fi10_topo_tiny_tanh_25pc.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: tanh
+weight_init: fixed_seed
+learning_rate: 0.0001
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi11_topo_tiny_tanh_25pc.yml
+++ b/test/fixtures/nn/fi11_topo_tiny_tanh_25pc.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: tanh
+weight_init: glorot
+learning_rate: 5.0
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/fixtures/nn/fi12_topo_deep_tanh_clean.yml
+++ b/test/fixtures/nn/fi12_topo_deep_tanh_clean.yml
@@ -1,0 +1,23 @@
+---
+topology:
+- 2
+- 4
+- 3
+- 1
+activation: tanh
+weight_init: fixed_seed
+learning_rate: 0.1
+corruption_pct: 0
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 0

--- a/test/fixtures/nn/fi13_topo_deep_sigmoid_clean.yml
+++ b/test/fixtures/nn/fi13_topo_deep_sigmoid_clean.yml
@@ -1,0 +1,23 @@
+---
+topology:
+- 2
+- 4
+- 3
+- 1
+activation: sigmoid
+weight_init: zero
+learning_rate: 5.0
+corruption_pct: 0
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 0

--- a/test/fixtures/nn/fi14_topo_tiny_sigmoid_25pc.yml
+++ b/test/fixtures/nn/fi14_topo_tiny_sigmoid_25pc.yml
@@ -1,0 +1,22 @@
+---
+topology:
+- 2
+- 2
+- 1
+activation: sigmoid
+weight_init: glorot
+learning_rate: 0.1
+corruption_pct: 25
+dataset:
+- - 0
+  - 0
+  - 0
+- - 0
+  - 1
+  - 1
+- - 1
+  - 0
+  - 1
+- - 1
+  - 1
+  - 1

--- a/test/helpers/fixture_loader.rb
+++ b/test/helpers/fixture_loader.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'yaml'
+require 'ai4r/data/data_set'
+
+module FixtureLoader
+  FIXTURE_DIR = File.expand_path('../fixtures/nn', __dir__)
+
+  def load_fixture(id)
+    fname = format('fi%02d', id.to_i)
+    path = Dir[File.join(FIXTURE_DIR, "#{fname}*_*.yml")].first
+    raise "Fixture not found: #{id}" unless path
+    data = YAML.safe_load(File.read(path))
+    srand(1234) if data['weight_init'] == 'fixed_seed'
+    dataset = Ai4r::Data::DataSet.new(data_items: data['dataset'])
+    params = data.reject { |k, _| k == 'dataset' }
+    [dataset, params]
+  end
+end

--- a/test/helpers/numeric_assertions.rb
+++ b/test/helpers/numeric_assertions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module NumericAssertions
+  def assert_float_equal(expected, actual, eps = 1e-6)
+    assert (expected - actual).abs <= eps,
+           "Expected #{expected} within +/-#{eps}, got #{actual}"
+  end
+
+  def assert_matrix_equal(m1, m2, eps = 1e-6)
+    assert_equal m1.size, m2.size
+    m1.zip(m2) do |row1, row2|
+      assert_equal row1.size, row2.size
+      row1.zip(row2) { |a, b| assert_float_equal a, b, eps }
+    end
+  end
+
+  def assert_monotonic_decrease(enum)
+    last = enum.first
+    enum.each do |val|
+      assert val <= last, "Sequence not monotonically decreasing"
+      last = val
+    end
+  end
+end

--- a/test/integration/nn_dataset_flow_test.rb
+++ b/test/integration/nn_dataset_flow_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+require 'ai4r/neural_network/backpropagation'
+
+class NNDatasetFlowTest < Minitest::Test
+  def test_load_params
+    yml = {'epochs'=>3,'lr'=>0.05}
+    File.write('tmp.yml', yml.to_yaml)
+    params = YAML.safe_load(File.read('tmp.yml'))
+    nn = Ai4r::NeuralNetwork::Backpropagation.new([2,1])
+    nn.learning_rate = params['lr']
+    assert_equal 0.05, nn.learning_rate
+    File.delete('tmp.yml')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,8 +14,20 @@
 #
 
 
+require 'simplecov'
+SimpleCov.start do
+  enable_coverage :branch
+  add_filter '/test/'
+end
+
 require 'minitest/autorun'
 Minitest::Test.i_suck_and_my_tests_are_order_dependent!
+
+require_relative 'helpers/numeric_assertions'
+require_relative 'helpers/fixture_loader'
+
+Minitest::Test.include NumericAssertions
+Minitest::Test.include FixtureLoader
 
 
 def assert_approximate_equality(expected, real, delta=0.01)

--- a/test/unit/neural_network/mlp_test.rb
+++ b/test/unit/neural_network/mlp_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/classifiers/multilayer_perceptron'
+
+# == P-01 ===============================================================
+# Build raises when dataset empty
+class MLPBuildTest < Minitest::Test
+  def test_build_requires_examples
+    mlp = Ai4r::Classifiers::MultilayerPerceptron.new
+    empty = Ai4r::Data::DataSet.new
+    assert_raises(ArgumentError) { mlp.build(empty) }
+  end
+end
+
+# == P-03 ===============================================================
+# One training step must reduce mean-square error
+class MLPTrainingTest < Minitest::Test
+  def test_single_epoch_improves_mse
+    dataset, params = load_fixture(1)
+    net = Ai4r::NeuralNetwork::Backpropagation.new(params['topology'])
+    inputs  = dataset.data_items.map { |row| row[0, 2] }
+    outputs = dataset.data_items.map { |row| [row[2]] }
+    preds = inputs.map { |i| net.eval(i).first }
+    mse_before = preds.zip(outputs).map { |p, o| (p - o.first)**2 }.sum / outputs.length.to_f
+    errors = net.train_epochs(inputs, outputs, epochs: 1)
+    assert errors.last < mse_before
+  end
+end


### PR DESCRIPTION
## Summary
- add CI workflow for neural network tests
- add helper modules and YAML fixtures
- provide unit/integration/e2e test skeletons
- add rake tasks for running the new tests
- document usage in TESTING_NN.md

## Testing
- `bundle exec rake test:nn`
- `bundle exec rake e2e`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687541270bf08326996b389cfb0eb735