### PR TITLE
Fix deterministic test for XOR

### DIFF
--- a/test/e2e/xor_scenario_test.rb
+++ b/test/e2e/xor_scenario_test.rb
@@ -4,11 +4,15 @@ require 'ai4r/neural_network/backpropagation'
 
 class XorScenarioTest < Minitest::Test
   def test_learns_xor
-    data = [[0,0,0],[0,1,1],[1,0,1],[1,1,0]]
-    inputs = data.map{ |r| r[0,2] }
-    outputs = data.map{ |r| [r[2]] }
-    net = Ai4r::NeuralNetwork::Backpropagation.new([2,2,1])
-    net.train_epochs(inputs, outputs, epochs: 5000)
+    data = [[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 0]]
+    inputs  = data.map { |r| r[0, 2] }
+    outputs = data.map { |r| [r[2]] }
+
+    # Ensure deterministic results across runs
+    Random.srand(1234)
+    net = Ai4r::NeuralNetwork::Backpropagation.new([2, 2, 1])
+    net.train_epochs(inputs, outputs, epochs: 5000, random_seed: 1234)
+
     preds = inputs.map { |i| net.eval(i).first.round }
     assert_equal outputs.flatten, preds
   end


### PR DESCRIPTION
## Summary
- stabilize XOR scenario test by seeding randomness

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875522e76f883269b093e3c6d3db9ac