### PR TITLE
Add genetic algorithm unit tests

### DIFF
--- a/test/helpers/genetic/bit_chromosome.rb
+++ b/test/helpers/genetic/bit_chromosome.rb
@@ -1,0 +1,33 @@
+module Ai4r
+  module GeneticAlgorithm
+    class BitChromosome < ChromosomeBase
+      LENGTH = 10
+
+      def fitness
+        @data.sum
+      end
+
+      def self.seed
+        new(Array.new(LENGTH) { rand(2) })
+      end
+
+      def self.reproduce(a, b, crossover_rate = 0.4)
+        return new(a.data.dup) if crossover_rate.zero?
+
+        cut = LENGTH / 2
+        if crossover_rate >= 1 || rand < crossover_rate
+          new(a.data[0...cut] + b.data[cut..-1])
+        else
+          new(a.data.dup)
+        end
+      end
+
+      def self.mutate(chromosome, mutation_rate = 0.3)
+        chromosome.data = chromosome.data.map do |bit|
+          rand < mutation_rate ? 1 - bit : bit
+        end
+        chromosome.instance_variable_set(:@fitness, nil)
+      end
+    end
+  end
+end

--- a/test/helpers/numeric_assertions.rb
+++ b/test/helpers/numeric_assertions.rb
@@ -21,4 +21,14 @@ module NumericAssertions
       last = val
     end
   end
+
+  def assert_pct_between(expected_pct, actual_pct, tolerance = 0.05)
+    delta = expected_pct * tolerance
+    assert_in_delta expected_pct, actual_pct, delta,
+                    "Expected #{actual_pct} within #{delta} of #{expected_pct}"
+  end
+
+  def assert_improves(before, after)
+    assert after > before, "Expected #{after} to improve over #{before}"
+  end
 end

--- a/test/unit/genetic/test_genetic_algorithm.rb
+++ b/test/unit/genetic/test_genetic_algorithm.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/genetic_algorithm/genetic_algorithm'
+require_relative '../../helpers/genetic/bit_chromosome'
+
+class GeneticAlgorithmUnitTest < Minitest::Test
+  include Ai4r::GeneticAlgorithm
+
+  def test_initialize_requires_population_positive
+    assert_raises(ArgumentError) { GeneticSearch.new(0, 1, BitChromosome) }
+  end
+
+  def test_generation_keeps_population_size
+    srand(1234)
+    search = GeneticSearch.new(4, 1, BitChromosome)
+    search.run
+    assert_equal 4, search.population.size
+  end
+
+  def test_selection_returns_existing_chromosomes
+    search = GeneticSearch.new(6, 1, BitChromosome)
+    search.generate_initial_population
+    selected = search.selection
+    assert selected.all? { |c| search.population.include?(c) }
+  end
+
+  def test_crossover_zero_no_change
+    p1 = BitChromosome.new([1, 1, 0, 0])
+    p2 = BitChromosome.new([0, 0, 1, 1])
+    child = BitChromosome.reproduce(p1, p2, 0)
+    assert_equal p1.data, child.data
+  end
+
+  def test_crossover_one_changes_child
+    p1 = BitChromosome.new([1, 1, 1, 1])
+    p2 = BitChromosome.new([0, 0, 0, 0])
+    child = BitChromosome.reproduce(p1, p2, 1)
+    assert child.data != p1.data || child.data != p2.data
+  end
+
+  def test_mutation_zero_keeps_genome
+    chrom = BitChromosome.new([1, 0, 1, 0])
+    BitChromosome.mutate(chrom, 0)
+    assert_equal [1, 0, 1, 0], chrom.data
+  end
+
+  def test_mutation_flips_expected_percentage
+    data = Array.new(100, 0)
+    chrom = BitChromosome.new(data.dup)
+    BitChromosome.mutate(chrom, 0.3)
+    changed = data.zip(chrom.data).count { |a, b| a != b }
+    pct = changed.to_f / data.size
+    assert_pct_between 0.3, pct
+  end
+
+  def test_sort_by_fitness_is_stable
+    c1 = BitChromosome.new([0])
+    c2 = BitChromosome.new([0])
+    c3 = BitChromosome.new([0])
+    pop = [c1, c2, c3]
+    sorted = pop.sort_by(&:fitness)
+    assert_equal pop, sorted
+  end
+
+  def test_best_chromosome_highest_fitness
+    search = GeneticSearch.new(3, 1, BitChromosome)
+    c1 = BitChromosome.new([0, 0])
+    c2 = BitChromosome.new([1, 0])
+    c3 = BitChromosome.new([1, 1])
+    search.population = [c1, c2, c3]
+    assert_equal c3, search.best_chromosome
+  end
+
+  def test_run_stops_at_max_generations
+    search = GeneticSearch.new(4, 2, BitChromosome)
+    search.run
+    assert_equal 2, search.instance_variable_get(:@generation)
+  end
+end

--- a/test/unit/genetic/test_genetic_search.rb
+++ b/test/unit/genetic/test_genetic_search.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/genetic_algorithm/genetic_algorithm'
+require_relative '../../helpers/genetic/bit_chromosome'
+
+module Ai4r
+  module GeneticAlgorithm
+    class ErrorChromosome < ChromosomeBase
+      def fitness
+        raise 'boom'
+      end
+
+      def self.seed
+        new([0])
+      end
+
+      def self.reproduce(a, b, _rate = 0.4)
+        new(a.data.dup)
+      end
+
+      def self.mutate(_c, _r = 0.3); end
+    end
+  end
+end
+
+class GeneticSearchUnitTest < Minitest::Test
+  include Ai4r::GeneticAlgorithm
+
+  def test_empty_search_space_raises
+    assert_raises(ArgumentError) { GeneticSearch.new(0, 1, BitChromosome) }
+  end
+
+  def test_fitness_error_propagates
+    search = GeneticSearch.new(2, 1, ErrorChromosome)
+    assert_raises(RuntimeError) { search.run }
+  end
+
+  def test_best_fitness_improves_over_initial_average
+    srand(123)
+    search = GeneticSearch.new(20, 5, BitChromosome)
+    search.generate_initial_population
+    avg_before = search.population.map(&:fitness).sum / search.population.size.to_f
+    best = search.run
+    improvement = (best.fitness - avg_before) / avg_before
+    assert_improves 0.0, improvement
+    assert improvement >= 0.20
+  end
+end


### PR DESCRIPTION
## Summary
- add helper `bit_chromosome` for GA tests
- extend numeric assertions with GA helpers
- implement GA unit tests
- implement GeneticSearch unit tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68755aecf12c8326a064151941a5031e