### PR TITLE
Add clusterers unit tests

### DIFF
--- a/lib/ai4r/clusterers/k_means.rb
+++ b/lib/ai4r/clusterers/k_means.rb
@@ -82,6 +82,9 @@ module Ai4r
       def build(data_set, number_of_clusters)
         @data_set = data_set
         @number_of_clusters = number_of_clusters
+        if @number_of_clusters > @data_set.data_items.length
+          raise ArgumentError, 'Number of clusters larger than data items'
+        end
         raise ArgumentError, 'Length of centroid indices array differs from the specified number of clusters' unless @centroid_indices.empty? || @centroid_indices.length == @number_of_clusters
         raise ArgumentError, 'Invalid value for on_empty' unless @on_empty == 'eliminate' || @on_empty == 'terminate' || @on_empty == 'random' || @on_empty == 'outlier'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,3 +53,13 @@ def assert_equality_of_nested_list(expected, real)
     assert_equal expected, real
   end
 end
+
+def assert_sse_decreases(series)
+  series.each_cons(2) { |a, b| assert b <= a, 'SSE should not increase' }
+end
+
+def assert_purity(actual, truth, min)
+  correct = actual.zip(truth).count { |a, t| a == t }
+  purity = correct.to_f / actual.length
+  assert purity >= min, "Purity #{purity} below #{min}"
+end

--- a/test/unit/clusterers/test_bisecting_kmeans.rb
+++ b/test/unit/clusterers/test_bisecting_kmeans.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/clusterers/bisecting_k_means'
+require 'ai4r/clusterers/k_means'
+
+class TestBisectingKMeans < Minitest::Test
+  include Ai4r::Data
+  include Ai4r::Clusterers
+
+  DATA = [[1,1],[1,2],[2,1],[2,2],[8,8],[8,9],[9,8],[9,9]]
+
+  def test_final_cluster_count
+    ds = DataSet.new(data_items: DATA)
+    clusterer = BisectingKMeans.new.build(ds, 3)
+    assert_equal 3, clusterer.clusters.length
+  end
+
+  def test_split_reduces_sse
+    ds = DataSet.new(data_items: DATA)
+    sse1 = KMeans.new.build(ds,1).sse
+    sse2 = BisectingKMeans.new.build(ds,2).sse
+    assert_operator sse2, :<=, sse1 * 0.9
+  end
+end

--- a/test/unit/clusterers/test_diana.rb
+++ b/test/unit/clusterers/test_diana.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/clusterers/diana'
+
+class TestDiana < Minitest::Test
+  include Ai4r::Data
+  include Ai4r::Clusterers
+
+  DATA = [[1],[2],[3],[4]]
+
+  class CountingDiana < Diana
+    attr_reader :splits, :first_cluster
+    def initialize
+      super
+      @splits = 0
+    end
+    def build(ds, k)
+      @first_cluster = ds.data_items.clone
+      super
+    end
+    protected
+    def max_diameter_cluster(clusters)
+      @splits += 1
+      super
+    end
+  end
+
+  def test_dendrogram_height
+    ds = DataSet.new(data_items: DATA)
+    d = CountingDiana.new.build(ds, DATA.length)
+    assert_equal DATA.length - 1, d.splits
+  end
+
+  def test_first_cluster_has_all_points
+    ds = DataSet.new(data_items: DATA)
+    d = CountingDiana.new.build(ds, 3)
+    assert_equal DATA, d.first_cluster
+  end
+end

--- a/test/unit/clusterers/test_kmeans.rb
+++ b/test/unit/clusterers/test_kmeans.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/clusterers/k_means'
+
+class TestKMeans < Minitest::Test
+  include Ai4r::Data
+  include Ai4r::Clusterers
+
+  DATA = [[1,1],[1,2],[2,1],[2,2]]
+
+  def dataset(items = DATA)
+    DataSet.new(data_items: items)
+  end
+
+  def test_k_greater_than_items
+    ds = dataset(DATA.first(2))
+    assert_raises(ArgumentError) { KMeans.new.build(ds, 3) }
+  end
+
+  def test_fixed_seed_deterministic
+    ds = dataset
+    c1 = KMeans.new.set_parameters(random_seed: 1).build(ds, 2)
+    c2 = KMeans.new.set_parameters(random_seed: 1).build(ds, 2)
+    assert_equal c1.centroids, c2.centroids
+  end
+
+  def test_sse_monotonic
+    ds = dataset
+    km = KMeans.new.set_parameters(track_history: true, random_seed: 1).build(ds, 2)
+    sse_series = km.history.map do |snap|
+      centroids = snap[:centroids]
+      assigns   = snap[:assignments]
+      ds.data_items.each_with_index.sum do |item, idx|
+        Ai4r::Data::Proximity.squared_euclidean_distance(item, centroids[assigns[idx]])
+      end
+    end
+    sse_series << km.sse
+    assert_sse_decreases sse_series
+  end
+
+  def test_empty_dataset
+    assert_raises(ArgumentError) { KMeans.new.build(DataSet.new(data_items: []), 1) }
+  end
+
+  def test_single_point_centroid
+    ds = DataSet.new(data_items: [[5, 5]])
+    km = KMeans.new.build(ds, 1)
+    assert_equal [5, 5], km.centroids.first
+  end
+end

--- a/test/unit/clusterers/test_linkage.rb
+++ b/test/unit/clusterers/test_linkage.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/clusterers/single_linkage'
+require 'ai4r/clusterers/complete_linkage'
+require 'ai4r/clusterers/average_linkage'
+require 'ai4r/clusterers/median_linkage'
+require 'ai4r/clusterers/centroid_linkage'
+require 'ai4r/clusterers/weighted_average_linkage'
+
+class TestLinkage < Minitest::Test
+  include Ai4r::Data
+  include Ai4r::Clusterers
+
+  DATA4 = [[0,0],[0,1],[5,0],[5,1]]
+  DATA_N = [[0],[1],[2],[3],[4]]
+
+  LINKAGE_CLASSES = [SingleLinkage, CompleteLinkage, AverageLinkage,
+                     MedianLinkage, CentroidLinkage, WeightedAverageLinkage]
+
+  def test_first_merge_shortest_pair
+    ds = DataSet.new(data_items: DATA4)
+    LINKAGE_CLASSES.each do |klass|
+      clusterer = klass.new.build(ds, 3)
+      clusters = clusterer.clusters.map(&:data_items).map { |c| c.sort }
+      assert clusters.include?([[0,0],[0,1]]) ||
+             clusters.include?([[5,0],[5,1]])
+    end
+  end
+
+  def test_merge_count
+    ds = DataSet.new(data_items: DATA_N)
+    LINKAGE_CLASSES.each do |klass|
+      mc = Class.new(klass) do
+        attr_reader :merge_count
+        def initialize
+          super()
+          @merge_count = 0
+        end
+        protected
+        def merge_clusters(a,b,ic)
+          @merge_count += 1
+          super
+        end
+      end
+      clusterer = mc.new.build(ds,1)
+      assert_equal DATA_N.length - 1, clusterer.merge_count
+    end
+  end
+end

--- a/test/unit/clusterers/test_ward.rb
+++ b/test/unit/clusterers/test_ward.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/clusterers/ward_linkage'
+
+class TestWard < Minitest::Test
+  include Ai4r::Data
+  include Ai4r::Clusterers
+
+  DATA = [[1,1],[1,2],[2,1],[2,2],[8,8],[8,9],[9,8],[9,9]]
+
+  class WardMonitor < WardLinkage
+    attr_reader :merge_count, :sse_history
+    def initialize
+      super()
+      @merge_count = 0
+      @sse_history = []
+    end
+    protected
+    def merge_clusters(a,b,ic)
+      super
+      clusters = build_clusters_from_index_clusters(ic)
+      sse = clusters.sum do |cl|
+        cen = cl.get_mean_or_mode
+        cl.data_items.sum { |it| Ai4r::Data::Proximity.squared_euclidean_distance(it, cen) }
+      end
+      @sse_history << sse
+      @merge_count += 1
+    end
+  end
+
+  def test_sse_non_decreasing
+    ds = DataSet.new(data_items: DATA)
+    w = WardMonitor.new.build(ds, 1)
+    assert w.sse_history.each_cons(2).all? { |a,b| b >= a }
+  end
+
+  def test_merge_count
+    ds = DataSet.new(data_items: DATA.first(5))
+    w = WardMonitor.new.build(ds, 1)
+    assert_equal ds.data_items.length - 1, w.merge_count
+  end
+end


### PR DESCRIPTION
## Summary
- add unit tests for kmeans, bisecting kmeans, diana, linkages and ward methods
- update kmeans to validate cluster count vs data size
- extend test helper with SSE and purity asserts

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68755b3df9948326a25e90bcbf351bd1