### PR TITLE
Simplify most_freq with tally

### DIFF
--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -274,17 +274,8 @@ module Ai4r
       # @param examples [Object]
       # @param domain [Object]
       # @return [Object]
-      def most_freq(examples, domain)
-        category_domain = domain.last
-        freqs = Array.new(category_domain.length, 0)
-        examples.each do |example|
-          example_category = example.last
-          cat_index = category_domain.index(example_category)
-          freqs[cat_index] += 1
-        end
-        max_freq = freqs.max
-        max_freq_index = freqs.index(max_freq)
-        category_domain[max_freq_index]
+      def most_freq(examples, _domain)
+        examples.map(&:last).tally.max_by { _2 }&.first
       end
 
       private


### PR DESCRIPTION
## Summary
- compute ID3 `most_freq` using Ruby's `tally`

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68755f020f0c83268c7a5265494030f6