### PR TITLE
Simplify row duplication with symbol form

### DIFF
--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -32,7 +32,7 @@ module Ai4r
       # @return [Object]
       def self.normalized(data_set, method: :zscore)
         new_set = DataSet.new(
-          data_items: data_set.data_items.map { |row| row.dup },
+          data_items: data_set.data_items.map(&:dup),
           data_labels: data_set.data_labels.dup
         )
         new_set.normalize!(method)
@@ -327,8 +327,8 @@ module Ai4r
         raise ArgumentError, 'ratio must be between 0 and 1' unless ratio.positive? && ratio < 1
 
         pivot = (ratio * @data_items.length).round
-        first_items = @data_items[0...pivot].map { |row| row.dup }
-        second_items = @data_items[pivot..-1].map { |row| row.dup }
+        first_items = @data_items[0...pivot].map(&:dup)
+        second_items = @data_items[pivot..-1].map(&:dup)
 
         [
           DataSet.new(data_items: first_items, data_labels: @data_labels.dup),


### PR DESCRIPTION
## Summary
- use `map(&:dup)` for copying rows

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68755f0c09cc832694174e2b1abb678f