### PR TITLE
Improve parameter handling with test coverage

### DIFF
--- a/lib/ai4r/data/parameterizable.rb
+++ b/lib/ai4r/data/parameterizable.rb
@@ -41,12 +41,10 @@ module Ai4r
       # @param params [Object]
       # @return [Object]
       def set_parameters(params)
-        self.class.get_parameters_info.keys.each do | key |
-          if self.respond_to?("#{key}=".to_sym)
-            send("#{key}=".to_sym, params[key]) if params.has_key? key
-          end
+        params.each do |key, val|
+          public_send("#{key}=", val) if respond_to?("#{key}=")
         end
-        return self
+        self
       end
       
       # Get parameter values on this algorithm instance.

--- a/test/data/parameterizable_test.rb
+++ b/test/data/parameterizable_test.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+require 'ai4r/data/parameterizable'
+
+class DummyParamClass
+  include Ai4r::Data::Parameterizable
+  parameters_info(max_iterations: 'desc')
+end
+
+module Ai4r
+  module Data
+    class ParameterizableTest < Minitest::Test
+      def test_unknown_keys_are_ignored
+        dummy = DummyParamClass.new
+        dummy.set_parameters(max_iterations: 10, unknown: 'foo')
+        assert_equal 10, dummy.max_iterations
+        refute dummy.respond_to?(:unknown)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- refactor `set_parameters` to use a succinct iteration
- ignore unknown keys using `respond_to?` with `public_send`
- add unit test for handling unknown parameters

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68755f180ff48326a545c95c4facc926