### PR TITLE
Implement logistic regression classifier

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -55,6 +55,16 @@ inspect these coefficients:
   puts r.slope          # regression slope
   puts r.intercept      # regression intercept
 
+== LogisticRegression
+
+Binary logistic regression is available as ``LogisticRegression''.  Training
+data must have numeric attributes with the last column containing ``0'' or ``1''
+labels.  Parameters ``lr'' and ``iterations'' control gradient descent.
+
+  reg = Ai4r::Classifiers::LogisticRegression.new
+  reg.set_parameters(lr: 0.5, iterations: 2000).build(data)
+  reg.eval([1, 0])  # => 1
+
 == DataSet normalization
 
 Numeric attributes can be normalized with `normalize!`. By default it applies

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ require 'ai4r'
 * [Naive Bayes Classifier](naive_bayes.md) – probabilistic classification for categorical data.
 * [Hyperpipes](hyperpipes.md) – baseline classifier using value ranges.
 * [IB1 Classifier](ib1.md) – instance-based nearest neighbour algorithm.
+* [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
 
 ## Contributing
 

--- a/docs/logistic_regression.md
+++ b/docs/logistic_regression.md
@@ -1,0 +1,24 @@
+# Logistic Regression
+
+`Ai4r::Classifiers::LogisticRegression` implements binary logistic regression using gradient descent. Training data must contain numeric attributes with the last column representing the class label `0` or `1`.
+
+## Parameters
+
+* `lr` – Learning rate used during gradient descent. Default is `0.1`.
+* `iterations` – Number of training iterations. Default is `1000`.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/logistic_regression'
+require 'ai4r/data/data_set'
+
+items = [[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]]
+labels = %w(x1 x2 class)
+set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
+
+reg = Ai4r::Classifiers::LogisticRegression.new
+reg.set_parameters(lr: 0.5, iterations: 2000).build(set)
+
+reg.eval([1, 0]) # => 1
+```

--- a/lib/ai4r/classifiers/logistic_regression.rb
+++ b/lib/ai4r/classifiers/logistic_regression.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+# Author::    OpenAI Assistant
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       https://github.com/SergioFierens/ai4r
+#
+# You can redistribute it and/or modify it under the terms of
+# the Mozilla Public License version 1.1  as published by the
+# Mozilla Foundation at http://www.mozilla.org/MPL/MPL-1.1.txt
+
+require_relative '../data/data_set'
+require_relative 'classifier'
+
+module Ai4r
+  module Classifiers
+    # Implementation of binary Logistic Regression using gradient descent.
+    #
+    # Training data must have numeric attributes with the last attribute being
+    # the class label (0 or 1). Parameters can be adjusted with
+    # {Parameterizable#set_parameters}.
+    #
+    # Example:
+    #   data = Ai4r::Data::DataSet.new(:data_items => [[0.2, 1], [0.4, 0]])
+    #   classifier = LogisticRegression.new.build(data)
+    #   classifier.eval([0.3])
+    class LogisticRegression < Classifier
+
+      attr_reader :weights
+
+      parameters_info lr: 'Learning rate for gradient descent.',
+                      iterations: 'Number of iterations to train.'
+
+      def initialize
+        @lr = 0.1
+        @iterations = 1000
+        @weights = nil
+      end
+
+      # Train the logistic regression classifier using the provided dataset.
+      def build(data_set)
+        raise 'Error instance must be passed' unless data_set.is_a?(Ai4r::Data::DataSet)
+        data_set.check_not_empty
+
+        x = data_set.data_items.map { |item| item[0...-1].map(&:to_f) }
+        y = data_set.data_items.map { |item| item.last.to_f }
+        m = x.length
+        n = x.first.length
+        @weights = Array.new(n + 1, 0.0) # last value is bias
+
+        @iterations.times do
+          predictions = x.map do |row|
+            z = row.each_with_index.inject(@weights.last) { |s, (v, j)| s + v * @weights[j] }
+            1.0 / (1.0 + Math.exp(-z))
+          end
+          errors = predictions.zip(y).map { |p, label| p - label }
+
+          n.times do |j|
+            grad = (0...m).inject(0.0) { |sum, i| sum + errors[i] * x[i][j] } / m
+            @weights[j] -= @lr * grad
+          end
+          bias_grad = errors.sum / m
+          @weights[n] -= @lr * bias_grad
+        end
+        self
+      end
+
+      # Predict the class (0 or 1) for the given data array.
+      def eval(data)
+        raise 'Model not trained' unless @weights
+
+        z = data.each_with_index.inject(@weights.last) { |s, (v, j)| s + v.to_f * @weights[j] }
+        prob = 1.0 / (1.0 + Math.exp(-z))
+        prob >= 0.5 ? 1 : 0
+      end
+    end
+  end
+end

--- a/test/classifiers/logistic_regression_test.rb
+++ b/test/classifiers/logistic_regression_test.rb
@@ -1,0 +1,34 @@
+require 'ai4r/classifiers/logistic_regression'
+require 'ai4r/data/data_set'
+require 'minitest/autorun'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+class LogisticRegressionTest < Minitest::Test
+  DATA_LABELS = %w(x1 x2 class)
+  DATA_ITEMS = [
+    [0, 0, 0],
+    [0, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1]
+  ]
+
+  def setup
+    @data_set = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
+    @classifier = LogisticRegression.new
+    @classifier.set_parameters(lr: 0.5, iterations: 2000)
+    @classifier.build(@data_set)
+  end
+
+  def test_eval
+    assert_equal 0, @classifier.eval([0, 0])
+    assert_equal 1, @classifier.eval([1, 0])
+    assert_equal 1, @classifier.eval([0, 1])
+    assert_equal 1, @classifier.eval([1, 1])
+  end
+
+  def test_weights_present
+    assert_equal 3, @classifier.weights.length
+  end
+end


### PR DESCRIPTION
## Summary
- add binary LogisticRegression classifier
- document logistic regression usage
- list logistic regression in docs index
- add LogisticRegression example to README
- test LogisticRegression classifier

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687566c0b03c83268315c6ffbd55560c