### PR TITLE
Add Support Vector Machine classifier

### DIFF
--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -31,6 +31,7 @@ require_relative 'ai4r/classifiers/zero_r'
 require_relative 'ai4r/classifiers/hyperpipes'
 require_relative 'ai4r/classifiers/naive_bayes'
 require_relative 'ai4r/classifiers/ib1'
+require_relative 'ai4r/classifiers/support_vector_machine'
 
 # Neural networks
 require_relative 'ai4r/neural_network/backpropagation'

--- a/lib/ai4r/classifiers/support_vector_machine.rb
+++ b/lib/ai4r/classifiers/support_vector_machine.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+# Author::    OpenAI Assistant
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       https://github.com/SergioFierens/ai4r
+#
+# A minimal linear Support Vector Machine implementation using
+# stochastic gradient descent. This implementation is intentionally
+# simple and only supports binary classification with numeric
+# attributes.
+
+require_relative '../data/data_set'
+require_relative 'classifier'
+
+module Ai4r
+  module Classifiers
+    # A lightweight linear SVM classifier trained via gradient descent.
+    # Only two classes are supported. Predictions return the same class
+    # labels used in the training data.
+    class SupportVectorMachine < Classifier
+      attr_reader :weights, :bias, :classes
+
+      parameters_info learning_rate: 'Learning rate for gradient descent.',
+                      iterations: 'Training iterations.',
+                      c: 'Regularization strength.'
+
+      def initialize
+        @learning_rate = 0.01
+        @iterations = 1000
+        @c = 1.0
+        @weights = []
+        @bias = 0.0
+        @classes = []
+      end
+
+      # Train the SVM using the provided DataSet. Only numeric attributes and
+      # exactly two classes are supported.
+      def build(data_set)
+        data_set.check_not_empty
+        @classes = data_set.build_domains.last.to_a
+        raise ArgumentError, 'SVM only supports two classes' unless @classes.size == 2
+
+        num_features = data_set.data_labels.length - 1
+        @weights = Array.new(num_features, 0.0)
+        @bias = 0.0
+
+        samples = data_set.data_items.map do |row|
+          [row[0...-1].map(&:to_f), row.last]
+        end
+
+        @iterations.times do
+          samples.each do |features, label|
+            y = label == @classes[0] ? 1.0 : -1.0
+            prediction = dot(@weights, features) + @bias
+            if y * prediction < 1
+              @weights.map!.with_index do |w, i|
+                w + @learning_rate * (@c * y * features[i] - 2 * w)
+              end
+              @bias += @learning_rate * @c * y
+            else
+              @weights.map!.with_index { |w, _i| w - @learning_rate * 2 * w }
+            end
+          end
+        end
+        self
+      end
+
+      # Predict the class for the given numeric feature vector.
+      def eval(data)
+        score = dot(@weights, data.map(&:to_f)) + @bias
+        score >= 0 ? @classes[0] : @classes[1]
+      end
+
+      private
+
+      def dot(a, b)
+        sum = 0.0
+        a.each_index { |i| sum += a[i] * b[i] }
+        sum
+      end
+    end
+  end
+end

--- a/test/classifiers/support_vector_machine_test.rb
+++ b/test/classifiers/support_vector_machine_test.rb
@@ -1,0 +1,35 @@
+require 'ai4r/classifiers/support_vector_machine'
+require 'ai4r/data/data_set'
+require 'minitest/autorun'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+class SupportVectorMachineTest < Minitest::Test
+  def setup
+    labels = %w(x1 x2 class)
+    items = [
+      [1.0, 2.0, 'pos'],
+      [2.0, 3.0, 'pos'],
+      [2.0, 0.0, 'pos'],
+      [-1.0, -1.0, 'neg'],
+      [-2.0, -1.0, 'neg'],
+      [-2.0, -3.0, 'neg']
+    ]
+    @data_set = DataSet.new(data_items: items, data_labels: labels)
+  end
+
+  def test_build_and_eval
+    svm = SupportVectorMachine.new.set_parameters(iterations: 50, learning_rate: 0.1)
+    svm.build(@data_set)
+    assert_equal 'pos', svm.eval([2, 2])
+    assert_equal 'neg', svm.eval([-1, -2])
+  end
+
+  def test_invalid_class_count
+    labels = %w(x1 x2 class)
+    items = [[0, 0, 'a'], [1, 1, 'b'], [2, 2, 'c']]
+    ds = DataSet.new(data_items: items, data_labels: labels)
+    assert_raises(ArgumentError) { SupportVectorMachine.new.build(ds) }
+  end
+end


### PR DESCRIPTION
## Summary
- implement a simple linear Support Vector Machine classifier
- load it automatically through `ai4r.rb`
- cover functionality with unit tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687566eb8c1c8326b7d2473363bb515e