### PR TITLE
Implement RandomForest and GradientBoosting

### DIFF
--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -31,6 +31,8 @@ require_relative 'ai4r/classifiers/zero_r'
 require_relative 'ai4r/classifiers/hyperpipes'
 require_relative 'ai4r/classifiers/naive_bayes'
 require_relative 'ai4r/classifiers/ib1'
+require_relative 'ai4r/classifiers/random_forest'
+require_relative 'ai4r/classifiers/gradient_boosting'
 
 # Neural networks
 require_relative 'ai4r/neural_network/backpropagation'

--- a/lib/ai4r/classifiers/gradient_boosting.rb
+++ b/lib/ai4r/classifiers/gradient_boosting.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# Author::    OpenAI ChatGPT
+# License::   MPL 1.1
+# Project::   ai4r
+#
+# Very small gradient boosting implementation for regression using
+# simple linear regression as base learner.
+
+require_relative 'simple_linear_regression'
+require_relative '../data/data_set'
+require_relative '../classifiers/classifier'
+
+module Ai4r
+  module Classifiers
+    class GradientBoosting < Classifier
+      parameters_info n_estimators: 'Number of boosting iterations. Default 10.',
+        learning_rate: 'Shrinkage parameter for each learner. Default 0.1.'
+
+      attr_reader :initial_value, :learners
+
+      def initialize
+        @n_estimators = 10
+        @learning_rate = 0.1
+      end
+
+      def build(data_set)
+        data_set.check_not_empty
+        @learners = []
+        targets = data_set.data_items.map(&:last)
+        @initial_value = targets.sum.to_f / targets.length
+        predictions = Array.new(targets.length, @initial_value)
+        @n_estimators.times do
+          residuals = targets.zip(predictions).map { |y, f| y - f }
+          items = data_set.data_items.each_with_index.map do |item, idx|
+            item[0...-1] + [residuals[idx]]
+          end
+          ds = Ai4r::Data::DataSet.new(data_items: items, data_labels: data_set.data_labels)
+          learner = SimpleLinearRegression.new.build(ds)
+          @learners << learner
+          pred = items.map { |it| learner.eval(it[0...-1]) }
+          predictions = predictions.zip(pred).map { |f, p| f + @learning_rate * p }
+        end
+        self
+      end
+
+      def eval(data)
+        value = @initial_value
+        @learners.each do |learner|
+          value += @learning_rate * learner.eval(data)
+        end
+        value
+      end
+
+      def get_rules
+        'GradientBoosting does not support rule extraction.'
+      end
+    end
+  end
+end

--- a/lib/ai4r/classifiers/random_forest.rb
+++ b/lib/ai4r/classifiers/random_forest.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+# Author::    OpenAI ChatGPT
+# License::   MPL 1.1
+# Project::   ai4r
+#
+# A simple Random Forest implementation using ID3 decision trees.
+
+require_relative 'id3'
+require_relative '../data/data_set'
+require_relative '../classifiers/classifier'
+require_relative 'votes'
+
+module Ai4r
+  module Classifiers
+    class RandomForest < Classifier
+      parameters_info n_trees: 'Number of trees to build. Default 10.',
+                      sample_size: 'Number of data items for each tree (with replacement). Default: data set size.',
+                      feature_fraction: 'Fraction of attributes sampled for each tree. Default: sqrt(num_attributes)/num_attributes.',
+                      random_seed: 'Seed for reproducible randomness.'
+
+      attr_reader :trees, :features
+
+      def initialize
+        @n_trees = 10
+        @sample_size = nil
+        @feature_fraction = nil
+        @random_seed = nil
+      end
+
+      def build(data_set)
+        data_set.check_not_empty
+        rng = @random_seed ? Random.new(@random_seed) : Random.new
+        num_attributes = data_set.data_labels.length - 1
+        frac = @feature_fraction || Math.sqrt(num_attributes) / num_attributes
+        feature_count = [1, (num_attributes * frac).round].max
+        @sample_size ||= data_set.data_items.length
+        @trees = []
+        @features = []
+        @n_trees.times do
+          sampled = Array.new(@sample_size) { data_set.data_items.sample(random: rng) }
+          feature_idx = (0...num_attributes).to_a.sample(feature_count, random: rng)
+          tree_items = sampled.map do |item|
+            values = feature_idx.map { |i| item[i] }
+            values + [item.last]
+          end
+          labels = feature_idx.map { |i| data_set.data_labels[i] } + [data_set.data_labels.last]
+          ds = Ai4r::Data::DataSet.new(data_items: tree_items, data_labels: labels)
+          @trees << ID3.new.build(ds)
+          @features << feature_idx
+        end
+        self
+      end
+
+      def eval(data)
+        votes = Votes.new
+        @trees.each_with_index do |tree, idx|
+          sub_data = @features[idx].map { |i| data[i] }
+          votes.increment_category(tree.eval(sub_data))
+        end
+        votes.get_winner
+      end
+
+      def get_rules
+        'RandomForest does not support rule extraction.'
+      end
+    end
+  end
+end

--- a/test/classifiers/gradient_boosting_test.rb
+++ b/test/classifiers/gradient_boosting_test.rb
@@ -1,0 +1,20 @@
+require 'ai4r/classifiers/gradient_boosting'
+require 'ai4r/data/data_set'
+require 'minitest/autorun'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+class GradientBoostingTest < Minitest::Test
+  DATA_LABELS = ['x', 'target']
+  DATA_ITEMS = [[1,2],[2,4],[3,6],[4,8]]
+
+  def setup
+    ds = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
+    @gb = GradientBoosting.new.set_parameters(n_estimators: 5, learning_rate: 0.5).build(ds)
+  end
+
+  def test_eval
+    assert_in_delta 10.0, @gb.eval([5]), 1.0
+  end
+end

--- a/test/classifiers/random_forest_test.rb
+++ b/test/classifiers/random_forest_test.rb
@@ -1,0 +1,37 @@
+require 'ai4r/classifiers/random_forest'
+require 'ai4r/data/data_set'
+require 'minitest/autorun'
+
+include Ai4r::Classifiers
+include Ai4r::Data
+
+class RandomForestTest < Minitest::Test
+  DATA_LABELS = ['city', 'age_range', 'gender', 'marketing_target']
+  DATA_ITEMS = [
+    ['New York', '<30', 'M', 'Y'],
+    ['Chicago', '<30', 'M', 'Y'],
+    ['Chicago', '<30', 'F', 'Y'],
+    ['New York', '<30', 'M', 'Y'],
+    ['New York', '<30', 'M', 'Y'],
+    ['Chicago', '[30-50)', 'M', 'Y'],
+    ['New York', '[30-50)', 'F', 'N'],
+    ['Chicago', '[30-50)', 'F', 'Y'],
+    ['New York', '[30-50)', 'F', 'N'],
+    ['Chicago', '[50-80]', 'M', 'N'],
+    ['New York', '[50-80]', 'F', 'N'],
+    ['New York', '[50-80]', 'M', 'N'],
+    ['Chicago', '[50-80]', 'M', 'N'],
+    ['New York', '[50-80]', 'F', 'N'],
+    ['Chicago', '>80', 'F', 'Y']
+  ]
+
+  def setup
+    ds = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
+    @forest = RandomForest.new.set_parameters(n_trees: 3, random_seed: 1).build(ds)
+  end
+
+  def test_eval
+    result = @forest.eval(['New York', '<30', 'F'])
+    assert_equal 'Y', result
+  end
+end


### PR DESCRIPTION
## Summary
- add RandomForest classifier based on ID3 trees
- add GradientBoosting regression classifier
- include new classifiers in library entrypoint
- test RandomForest and GradientBoosting

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687567a97cdc8326b546ef12c1c62f7a