### PR TITLE
Add minimal Transformer encoder

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ require 'ai4r'
 * [Hyperpipes](hyperpipes.md) – baseline classifier using value ranges.
 * [IB1 Classifier](ib1.md) – instance-based nearest neighbour algorithm.
 * [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
+* [Transformer](transformer.md) – minimal self-attention encoder.
 
 ## Contributing
 

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -1,0 +1,20 @@
+# Minimal Transformer
+
+`Ai4r::NeuralNetwork::Transformer` implements a small self‑attention encoder. It includes token embeddings, sinusoidal positional encoding, multi‑head attention and a two‑layer feed‑forward network. Weights are initialized randomly and the model is not trainable.
+
+## Usage
+
+```ruby
+require 'ai4r/neural_network/transformer'
+
+model = Ai4r::NeuralNetwork::Transformer.new(
+  vocab_size: 50,
+  max_len: 10,
+  embed_dim: 8,
+  num_heads: 2,
+  ff_dim: 16
+)
+
+output = model.eval([1, 2, 3, 4])
+# => array of 4 vectors of length 8
+```

--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -38,6 +38,7 @@ require_relative 'ai4r/classifiers/support_vector_machine'
 # Neural networks
 require_relative 'ai4r/neural_network/backpropagation'
 require_relative 'ai4r/neural_network/hopfield'
+require_relative 'ai4r/neural_network/transformer'
 
 # Genetic Algorithms
 require_relative 'ai4r/genetic_algorithm/genetic_algorithm'

--- a/lib/ai4r/neural_network/transformer.rb
+++ b/lib/ai4r/neural_network/transformer.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+# Minimal Transformer implementation
+# Author::    OpenAI Assistant
+# License::   MPL 1.1
+# Project::   ai4r
+# Url::       https://github.com/SergioFierens/ai4r
+
+require_relative '../data/parameterizable'
+require_relative 'activation_functions'
+
+module Ai4r
+  module NeuralNetwork
+    # A tiny Transformer encoder with embeddings, positional encoding,
+    # multi-head self-attention and a feed-forward layer.
+    # Weights are initialized randomly and the model is not trainable.
+    class Transformer
+      include Ai4r::Data::Parameterizable
+
+      parameters_info embed_dim: 'Embedding dimension.',
+                      num_heads: 'Number of attention heads.',
+                      ff_dim: 'Feed-forward hidden size.',
+                      vocab_size: 'Vocabulary size.',
+                      max_len: 'Maximum sequence length.'
+
+      attr_accessor :embed_dim, :num_heads, :ff_dim, :vocab_size, :max_len
+
+      # Initialize the Transformer with given hyperparameters.
+      def initialize(vocab_size:, max_len:, embed_dim: 8, num_heads: 2, ff_dim: 32)
+        @vocab_size = vocab_size
+        @max_len = max_len
+        @embed_dim = embed_dim
+        @num_heads = num_heads
+        @ff_dim = ff_dim
+        raise ArgumentError, 'embed_dim must be divisible by num_heads' if embed_dim % num_heads != 0
+        init_weights
+        build_positional_encoding
+      end
+
+      # Evaluate a sequence of integer token ids. Returns an array of
+      # length seq_len with embed_dim sized vectors.
+      def eval(tokens)
+        raise ArgumentError, 'sequence too long' if tokens.length > @max_len
+        x = tokens.map.with_index { |t, i| add(@token_embeddings[t], @positional[i]) }
+        x = multi_head_attention(x)
+        feed_forward(x)
+      end
+
+      private
+
+      def head_dim
+        @embed_dim / @num_heads
+      end
+
+      def init_weights
+        @token_embeddings = Array.new(@vocab_size) { Array.new(@embed_dim) { rand * 2 - 1 } }
+        hd = head_dim
+        @heads = Array.new(@num_heads) do
+          {
+            q: Array.new(@embed_dim) { Array.new(hd) { rand * 2 - 1 } },
+            k: Array.new(@embed_dim) { Array.new(hd) { rand * 2 - 1 } },
+            v: Array.new(@embed_dim) { Array.new(hd) { rand * 2 - 1 } }
+          }
+        end
+        @wo = Array.new(@num_heads * hd) { Array.new(@embed_dim) { rand * 2 - 1 } }
+        @w1 = Array.new(@embed_dim) { Array.new(@ff_dim) { rand * 2 - 1 } }
+        @b1 = Array.new(@ff_dim, 0.0)
+        @w2 = Array.new(@ff_dim) { Array.new(@embed_dim) { rand * 2 - 1 } }
+        @b2 = Array.new(@embed_dim, 0.0)
+      end
+
+      def build_positional_encoding
+        @positional = Array.new(@max_len) do |pos|
+          Array.new(@embed_dim) do |i|
+            angle = pos / (10000.0 ** ((2 * (i / 2)) / @embed_dim.to_f))
+            i.even? ? Math.sin(angle) : Math.cos(angle)
+          end
+        end
+      end
+
+      def add(a, b)
+        a.each_index.map { |i| a[i] + b[i] }
+      end
+
+      def dot(a, b)
+        sum = 0.0
+        a.each_index { |i| sum += a[i] * b[i] }
+        sum
+      end
+
+      def matmul(mat, weights)
+        mat.map do |row|
+          weights.transpose.map { |w| dot(row, w) }
+        end
+      end
+
+      def softmax(vec)
+        m = vec.max
+        exps = vec.map { |v| Math.exp(v - m) }
+        sum = exps.inject(:+)
+        exps.map { |e| e / sum }
+      end
+
+      def multi_head_attention(x)
+        hd = head_dim
+        heads_out = @heads.map do |h|
+          q = matmul(x, h[:q])
+          k = matmul(x, h[:k])
+          v = matmul(x, h[:v])
+          scores = matmul(q, k.transpose)
+          scale = Math.sqrt(hd.to_f)
+          scores.map! { |row| softmax(row.map { |v| v / scale }) }
+          matmul(scores, v)
+        end
+        concat = Array.new(x.length) { [] }
+        heads_out.each do |head|
+          head.each_index do |i|
+            concat[i].concat(head[i])
+          end
+        end
+        matmul(concat, @wo)
+      end
+
+      def relu(x)
+        x > 0 ? x : 0
+      end
+
+      def affine(mat, weights, bias)
+        mat.map do |row|
+          weights.transpose.map.with_index { |w, j| dot(row, w) + bias[j] }
+        end
+      end
+
+      def feed_forward(x)
+        h = affine(x, @w1, @b1)
+        h.map! { |row| row.map { |v| relu(v) } }
+        affine(h, @w2, @b2)
+      end
+    end
+  end
+end
+

--- a/test/neural_network/transformer_test.rb
+++ b/test/neural_network/transformer_test.rb
@@ -1,0 +1,23 @@
+require 'minitest/autorun'
+require 'ai4r/neural_network/transformer'
+
+class TransformerTest < Minitest::Test
+  def test_eval_shape
+    srand 1
+    model = Ai4r::NeuralNetwork::Transformer.new(
+      vocab_size: 20,
+      max_len: 5,
+      embed_dim: 8,
+      num_heads: 2,
+      ff_dim: 16
+    )
+    out = model.eval([1, 2, 3])
+    assert_equal 3, out.length
+    out.each { |vec| assert_equal 8, vec.length }
+  end
+
+  def test_sequence_too_long
+    model = Ai4r::NeuralNetwork::Transformer.new(vocab_size: 10, max_len: 2)
+    assert_raises(ArgumentError) { model.eval([1, 2, 3]) }
+  end
+end


### PR DESCRIPTION
## Summary
- introduce `Ai4r::NeuralNetwork::Transformer` implementing a small self‑attention encoder
- document Transformer usage
- list Transformer in docs index
- require the new component in the main library
- add basic unit tests

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68756b6eb8d08326beb7ab986ca130af