### PR TITLE
Add flexible Transformer architectures

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ require 'ai4r'
 * [IB1 Classifier](ib1.md) – instance-based nearest neighbour algorithm.
 * [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
 * [Reinforcement Learning](reinforcement_learning.md) – Q-learning and policy iteration.
-* [Transformer](transformer.md) – minimal self-attention encoder.
+* [Transformer](transformer.md) – tiny encoder, decoder and seq2seq models.
 
 
 ## Contributing

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -1,6 +1,6 @@
 # Minimal Transformer
 
-`Ai4r::NeuralNetwork::Transformer` implements a small self‑attention encoder. It includes token embeddings, sinusoidal positional encoding, multi‑head attention and a two‑layer feed‑forward network. Weights are initialized randomly and the model is not trainable.
+`Ai4r::NeuralNetwork::Transformer` implements a tiny transformer architecture. It can operate as an encoder, a decoder or a full encoder‑decoder (sequence‑to‑sequence) model. Token embeddings, sinusoidal positional encodings, multi‑head attention and a two‑layer feed‑forward network are provided. Weights are initialized randomly and the model is not trainable.
 
 ## Usage
 
@@ -12,9 +12,26 @@ model = Ai4r::NeuralNetwork::Transformer.new(
   max_len: 10,
   embed_dim: 8,
   num_heads: 2,
-  ff_dim: 16
+  ff_dim: 16,
+  architecture: :encoder
 )
 
 output = model.eval([1, 2, 3, 4])
 # => array of 4 vectors of length 8
+
+decoder = Ai4r::NeuralNetwork::Transformer.new(
+  vocab_size: 50,
+  max_len: 10,
+  architecture: :decoder
+)
+
+decoder_output = decoder.eval([4, 5, 6])
+
+seq2seq = Ai4r::NeuralNetwork::Transformer.new(
+  vocab_size: 50,
+  max_len: 10,
+  architecture: :seq2seq
+)
+
+seq2seq_output = seq2seq.eval([1, 2, 3], [4, 5])
 ```

--- a/test/neural_network/transformer_test.rb
+++ b/test/neural_network/transformer_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require 'ai4r/neural_network/transformer'
 
 class TransformerTest < Minitest::Test
-  def test_eval_shape
+  def test_encoder_eval_shape
     srand 1
     model = Ai4r::NeuralNetwork::Transformer.new(
       vocab_size: 20,
@@ -14,6 +14,20 @@ class TransformerTest < Minitest::Test
     out = model.eval([1, 2, 3])
     assert_equal 3, out.length
     out.each { |vec| assert_equal 8, vec.length }
+  end
+
+  def test_decoder_eval_shape
+    model = Ai4r::NeuralNetwork::Transformer.new(vocab_size: 10, max_len: 4, architecture: :decoder)
+    out = model.eval([1, 2, 3])
+    assert_equal 3, out.length
+    out.each { |vec| assert_equal model.embed_dim, vec.length }
+  end
+
+  def test_seq2seq_eval_shape
+    model = Ai4r::NeuralNetwork::Transformer.new(vocab_size: 10, max_len: 4, architecture: :seq2seq)
+    out = model.eval([1, 2], [3, 4, 5])
+    assert_equal 3, out.length
+    out.each { |vec| assert_equal model.embed_dim, vec.length }
   end
 
   def test_sequence_too_long


### PR DESCRIPTION
## Summary
- allow Transformer to work as encoder-only, decoder-only or seq2seq
- describe architecture options in docs
- expand usage guide
- update index entry
- test encoder, decoder and seq2seq modes

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68756dc2470483269f09133d3d57866d