### PR TITLE
Add A* search algorithm with tests

### DIFF
--- a/docs/a_star_search.md
+++ b/docs/a_star_search.md
@@ -1,0 +1,20 @@
+# A* Search
+
+`Ai4r::Search::AStar` performs best-first search using heuristics to guide
+expansion. Provide a starting node, a goal predicate, a neighbor function that
+returns reachable nodes and their costs, and a heuristic estimating remaining
+cost.
+
+```ruby
+require 'ai4r/search'
+
+start = 'A'
+goal_test = ->(n) { n == 'G' }
+neighbors = ->(n) { { 'G' => 1 } }
+heuristic = ->(n) { 0 }
+
+path = Ai4r::Search::AStar.new(start, goal_test, neighbors, heuristic).search
+```
+
+The call returns the path as an array of nodes or `nil` when the goal cannot be
+reached.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ require 'ai4r'
 * [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
 * [Reinforcement Learning](reinforcement_learning.md) – Q-learning and policy iteration.
 * [Transformer](transformer.md) – tiny encoder, decoder and seq2seq models.
+* [A* Search](a_star_search.md) – heuristic best-first path search.
 
 
 ## Contributing

--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -52,3 +52,6 @@ require_relative 'ai4r/hmm/hidden_markov_model'
 
 # SOM
 require_relative 'ai4r/som/som'
+
+# Search Algorithms
+require_relative 'ai4r/search'

--- a/lib/ai4r/search.rb
+++ b/lib/ai4r/search.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative 'search/a_star'
+
+module Ai4r
+  # Namespace for search algorithms like A*.
+  module Search
+  end
+end

--- a/lib/ai4r/search/a_star.rb
+++ b/lib/ai4r/search/a_star.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Author::    OpenAI Assistant
+# License::   MPL 1.1
+# Project::   ai4r
+#
+# Generic A* search algorithm.
+
+require 'set'
+
+module Ai4r
+  module Search
+    # Generic A* search implementation operating on arbitrary graph
+    # representations.
+    #
+    # Initialize with start node, a goal predicate, a neighbor function and a
+    # heuristic.
+    #
+    # The neighbor function must return a hash mapping neighbor nodes to edge
+    # costs. The heuristic receives a node and returns the estimated remaining
+    # cost to reach the goal.
+    class AStar
+      # @param start [Object] initial node
+      # @param goal_test [Proc] predicate returning true when node is goal
+      # @param neighbor_fn [Proc] -> node { neighbor => cost, ... }
+      # @param heuristic_fn [Proc] -> node => estimated remaining cost
+      def initialize(start, goal_test, neighbor_fn, heuristic_fn)
+        @start = start
+        @goal_test = goal_test
+        @neighbor_fn = neighbor_fn
+        @heuristic_fn = heuristic_fn
+      end
+
+      # Execute the search and return the path as an array of nodes or nil
+      # if the goal cannot be reached.
+      def search
+        open_set = [@start]
+        came_from = {}
+        g = { @start => 0 }
+        f = { @start => @heuristic_fn.call(@start) }
+        closed = Set.new
+
+        until open_set.empty?
+          current = open_set.min_by { |n| f[n] }
+          return reconstruct_path(came_from, current) if @goal_test.call(current)
+
+          open_set.delete(current)
+          closed << current
+          @neighbor_fn.call(current).each do |neighbor, cost|
+            next if closed.include?(neighbor)
+
+            tentative_g = g[current] + cost
+            if g[neighbor].nil? || tentative_g < g[neighbor]
+              came_from[neighbor] = current
+              g[neighbor] = tentative_g
+              f[neighbor] = tentative_g + @heuristic_fn.call(neighbor)
+              open_set << neighbor unless open_set.include?(neighbor)
+            end
+          end
+        end
+        nil
+      end
+
+      private
+
+      def reconstruct_path(came_from, node)
+        path = [node]
+        while came_from.key?(node)
+          node = came_from[node]
+          path.unshift(node)
+        end
+        path
+      end
+    end
+  end
+end

--- a/test/unit/search/a_star_test.rb
+++ b/test/unit/search/a_star_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/search'
+
+class AStarUnitTest < Minitest::Test
+  include Ai4r::Search
+
+  GRAPH = {
+    'A' => { 'B' => 1, 'C' => 4 },
+    'B' => { 'C' => 2, 'D' => 5, 'E' => 12 },
+    'C' => { 'D' => 2, 'F' => 3 },
+    'D' => { 'G' => 1 },
+    'E' => { 'G' => 5 },
+    'F' => { 'G' => 7 }
+  }
+
+  HEURISTIC = {
+    'A' => 6, 'B' => 5, 'C' => 3,
+    'D' => 1, 'E' => 5, 'F' => 7, 'G' => 0
+  }
+
+  def neighbor_fn(node)
+    GRAPH[node] || {}
+  end
+
+  def heuristic_fn(node)
+    HEURISTIC[node] || 0
+  end
+
+  def goal_test(node)
+    node == 'G'
+  end
+
+  def test_finds_shortest_path
+    astar = AStar.new('A', method(:goal_test), method(:neighbor_fn), method(:heuristic_fn))
+    path = astar.search
+    assert_equal %w[A B C D G], path
+  end
+
+  def test_returns_nil_when_unreachable
+    bad_graph = lambda { |n| n == 'A' ? { 'B' => 1 } : {} }
+    astar = AStar.new('A', method(:goal_test), bad_graph, method(:heuristic_fn))
+    assert_nil astar.search
+  end
+end


### PR DESCRIPTION
## Summary
- implement generic A* search
- load search module from ai4r.rb
- document A* usage and link from index
- add unit tests for A*

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68758027a9d08326a81f1a8aa664b1dc