### PR TITLE
Implement BFS and DFS search algorithms

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ require 'ai4r'
 * [IB1 Classifier](ib1.md) – instance-based nearest neighbour algorithm.
 * [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
 * [Reinforcement Learning](reinforcement_learning.md) – Q-learning and policy iteration.
+* [Search Algorithms](search_algorithms.md) – breadth-first and depth-first search implementations.
 * [Transformer](transformer.md) – tiny encoder, decoder and seq2seq models.
 
 

--- a/docs/search_algorithms.md
+++ b/docs/search_algorithms.md
@@ -1,0 +1,20 @@
+# Search Algorithms
+
+The `Ai4r::Search` module provides minimal implementations of
+breadth-first search (BFS) and depth-first search (DFS). Both algorithms
+traverse a state space defined by a successor function until a goal is
+reached.
+
+```ruby
+require 'ai4r/search/bfs'
+require 'ai4r/search/dfs'
+
+bfs = Ai4r::Search::BFS.new
+path = bfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbors(n) })
+
+dfs = Ai4r::Search::DFS.new
+path = dfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbors(n) })
+```
+
+Both methods return the path from the start node to the first goal or
+`nil` when no goal is reachable.

--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -47,6 +47,10 @@ require_relative 'ai4r/genetic_algorithm/genetic_algorithm'
 require_relative 'ai4r/reinforcement/q_learning'
 require_relative 'ai4r/reinforcement/policy_iteration'
 
+# Search
+require_relative 'ai4r/search/bfs'
+require_relative 'ai4r/search/dfs'
+
 # Hidden Markov Models
 require_relative 'ai4r/hmm/hidden_markov_model'
 

--- a/lib/ai4r/search/bfs.rb
+++ b/lib/ai4r/search/bfs.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Author::    OpenAI Assistant
+# License::   MPL 1.1
+# Project::   ai4r
+#
+# Basic breadth-first search implementation.
+
+module Ai4r
+  module Search
+    # Explore nodes in breadth-first order until a goal is found.
+    class BFS
+      # Find a path from the start node to a goal.
+      #
+      # start::      initial node
+      # goal_test::  lambda returning true for a goal node
+      # neighbors::  lambda returning adjacent nodes for a given node
+      #
+      # Returns an array of nodes representing the path, or nil if no goal was found.
+      def search(start, goal_test, neighbors)
+        queue = [[start, [start]]]
+        visited = { start => true }
+        until queue.empty?
+          node, path = queue.shift
+          return path if goal_test.call(node)
+          neighbors.call(node).each do |n|
+            next if visited[n]
+            visited[n] = true
+            queue << [n, path + [n]]
+          end
+        end
+        nil
+      end
+    end
+  end
+end

--- a/lib/ai4r/search/dfs.rb
+++ b/lib/ai4r/search/dfs.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Author::    OpenAI Assistant
+# License::   MPL 1.1
+# Project::   ai4r
+#
+# Basic depth-first search implementation.
+
+module Ai4r
+  module Search
+    # Explore nodes in depth-first order until a goal is found.
+    class DFS
+      # Find a path from the start node to a goal.
+      #
+      # start::      initial node
+      # goal_test::  lambda returning true for a goal node
+      # neighbors::  lambda returning adjacent nodes for a given node
+      #
+      # Returns an array of nodes representing the path, or nil if no goal was found.
+      def search(start, goal_test, neighbors)
+        stack = [[start, [start]]]
+        visited = { start => true }
+        until stack.empty?
+          node, path = stack.pop
+          return path if goal_test.call(node)
+          neighbors.call(node).each do |n|
+            next if visited[n]
+            visited[n] = true
+            stack << [n, path + [n]]
+          end
+        end
+        nil
+      end
+    end
+  end
+end

--- a/test/unit/search/bfs_test.rb
+++ b/test/unit/search/bfs_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/search/bfs'
+
+class BFSTest < Minitest::Test
+  include Ai4r::Search
+
+  def setup
+    @graph = {
+      a: %i[b c],
+      b: %i[d],
+      c: %i[d],
+      d: []
+    }
+  end
+
+  def test_finds_shortest_path
+    bfs = BFS.new
+    path = bfs.search(:a, ->(n) { n == :d }, ->(n) { @graph[n] })
+    assert_equal %i[a b d], path
+  end
+
+  def test_returns_nil_when_unreachable
+    bfs = BFS.new
+    path = bfs.search(:a, ->(n) { n == :x }, ->(n) { @graph[n] || [] })
+    assert_nil path
+  end
+end

--- a/test/unit/search/dfs_test.rb
+++ b/test/unit/search/dfs_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+require 'ai4r/search/dfs'
+
+class DFSTest < Minitest::Test
+  include Ai4r::Search
+
+  def setup
+    @graph = {
+      a: %i[b c],
+      b: %i[d],
+      c: %i[e],
+      d: [],
+      e: []
+    }
+  end
+
+  def test_explores_depth_first
+    dfs = DFS.new
+    path = dfs.search(:a, ->(n) { n == :e }, ->(n) { @graph[n] })
+    assert_equal %i[a c e], path
+  end
+end


### PR DESCRIPTION
## Summary
- add BFS and DFS modules under `Ai4r::Search`
- document search algorithms
- list them in documentation index
- include unit tests for BFS and DFS
- require new modules in main library file

## Testing
- `bundle install` *(fails: Could not install all gems)*
- `bundle exec rake test` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_687580b266b48326bf9b84522bed208a