### PR TITLE
Add clusterer integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,14 @@ jobs:
       - run: bundle exec rake e2e
       - run: |
           echo "Coverage $(grep -A1 '^COVERAGE' coverage/.last_run.json)"
+
+  cluster-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - run: bundle exec rake test:cl
+      - run: bundle exec rake e2e

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -17,6 +17,14 @@ namespace :test do
     script = 'ARGV.each { |f| require File.expand_path(f) }'
     ruby '-Ilib:test', '-e', script, *files
   end
+
+  desc 'Run clusterer unit and integration tests'
+  task :cl do
+    files = Dir['test/unit/clusterers/test_*.rb'] +
+            Dir['test/integration/test_cl_flow.rb']
+    script = 'ARGV.each { |f| require File.expand_path(f) }'
+    ruby '-Ilib:test', '-e', script, *files
+  end
 end
 
 task :e2e do

--- a/test/integration/test_cl_flow.rb
+++ b/test/integration/test_cl_flow.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'ai4r/clusterers/k_means'
+require 'ai4r/clusterers/ward_linkage_hierarchical'
+require 'ai4r/data/data_set'
+
+class ClustererFlowTest < Minitest::Test
+  include Ai4r::Data
+  include Ai4r::Clusterers
+
+  DATA = [[1, 1], [1, 2], [2, 1], [2, 2],
+          [8, 8], [8, 9], [9, 8], [9, 9]].freeze
+
+  def test_normalization_improves_sse
+    ds = DataSet.new(data_items: DATA)
+    raw_sse = KMeans.new.set_parameters(random_seed: 1).build(ds, 2).sse
+
+    norm = DataSet.normalized(ds, method: :minmax)
+    norm_sse = KMeans.new.set_parameters(random_seed: 1).build(norm, 2).sse
+    assert norm_sse < raw_sse
+  end
+
+  def test_export_labels_to_dataset
+    ds = DataSet.new(data_items: DATA, data_labels: %w[x y])
+    km = KMeans.new.set_parameters(random_seed: 1).build(ds, 2)
+    labeled_items = ds.data_items.map { |row| row + [km.eval(row)] }
+    labeled = DataSet.new(data_items: labeled_items,
+                          data_labels: ds.data_labels + ['cluster'])
+    assert_equal ds.data_items.length, labeled.data_items.length
+    assert labeled.data_items.all? { |r| r.last.is_a?(Integer) }
+  end
+
+  def test_dendrogram_cut_to_three_clusters
+    ds = DataSet.new(data_items: DATA.first(5))
+    dendro = WardLinkageHierarchical.new.build(ds, 1)
+    level = dendro.cluster_tree[2]
+    assert_equal 3, level.length
+  end
+end

--- a/test/unit/clusterers/test_diana.rb
+++ b/test/unit/clusterers/test_diana.rb
@@ -31,13 +31,13 @@ class TestDiana < Minitest::Test
   end
 
   def test_dendrogram_height
-    ds = DataSet.new(data_items: DATA)
+    ds = DataSet.new(data_items: DATA.map(&:dup))
     d = CountingDiana.new.build(ds, DATA.length)
     assert_equal DATA.length - 1, d.splits
   end
 
   def test_first_cluster_has_all_points
-    ds = DataSet.new(data_items: DATA)
+    ds = DataSet.new(data_items: DATA.map(&:dup))
     d = CountingDiana.new.build(ds, 3)
     assert_equal DATA, d.first_cluster
   end


### PR DESCRIPTION
## Summary
- add flow tests for clusterers
- enable running cluster tests via rake
- run new job `cluster-tests` in CI
- fix Diana tests with frozen data

## Testing
- `bundle exec rake test:cl`
- `bundle exec rake e2e`


------
https://chatgpt.com/codex/tasks/task_e_687588d680d883269528d807306ff93f