### PR TITLE
Add GA e2e tests

### DIFF
--- a/examples/genetic_algorithm/kmeans_seed_tuning.rb
+++ b/examples/genetic_algorithm/kmeans_seed_tuning.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../lib/ai4r/genetic_algorithm/genetic_algorithm'
+require_relative '../../lib/ai4r/clusterers/k_means'
+require_relative '../som/som_data'
+
+include Ai4r::GeneticAlgorithm
+include Ai4r::Clusterers
+include Ai4r::Data
+
+class SeedChromosome < ChromosomeBase
+  RANGE = (0..10)
+  DATA = DataSet.new(data_items: SOM_DATA.first(30))
+
+  def fitness
+    return @fitness if @fitness
+
+    kmeans = KMeans.new.set_parameters(random_seed: @data).build(DATA, 3)
+    @fitness = -kmeans.sse
+  end
+
+  def self.seed
+    new(RANGE.to_a.sample)
+  end
+
+  def self.reproduce(a, b, _rate = 0.7)
+    new([a.data, b.data].sample)
+  end
+
+  def self.mutate(chrom, rate = 0.3)
+    return unless rand < rate
+
+    chrom.data = RANGE.to_a.sample
+    chrom.instance_variable_set(:@fitness, nil)
+  end
+end
+
+search = GeneticSearch.new(6, 5, SeedChromosome, 0.1, 0.7)
+best = search.run
+puts(-best.fitness)

--- a/test/e2e/ga_function_opt_test.rb
+++ b/test/e2e/ga_function_opt_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'ai4r/genetic_algorithm/genetic_algorithm'
+
+class GaFunctionOptTest < Minitest::Test
+  include Ai4r::GeneticAlgorithm
+
+  class IntChromosome < ChromosomeBase
+    RANGE = (0..31)
+
+    def fitness
+      @data**2
+    end
+
+    def self.seed
+      new(RANGE.to_a.sample)
+    end
+
+    def self.reproduce(a, b, _rate = 0.7)
+      new(rand < _rate ? b.data : a.data)
+    end
+
+    def self.mutate(chrom, rate = 0.1)
+      chrom.data = RANGE.to_a.sample if rand < rate
+    end
+  end
+
+  def test_finds_max_value
+    srand(1234)
+    search = GeneticSearch.new(10, 20, IntChromosome, 0.2, 0.7)
+    best = search.run
+    assert_equal 31, best.data
+  end
+end

--- a/test/e2e/ga_kmeans_tuning_test.rb
+++ b/test/e2e/ga_kmeans_tuning_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'ai4r/clusterers/k_means'
+require 'ai4r/data/data_set'
+
+class GaKmeansTuningTest < Minitest::Test
+  include Ai4r::Clusterers
+  include Ai4r::Data
+
+  SCRIPT = File.expand_path('../../examples/genetic_algorithm/kmeans_seed_tuning.rb', __dir__)
+
+  def test_cli_improves_sse
+    load File.expand_path('../../examples/som/som_data.rb', __dir__)
+    data = DataSet.new(data_items: SOM_DATA.first(30))
+    baseline = KMeans.new.set_parameters(random_seed: 10).build(data, 3).sse
+    improved = `ruby #{SCRIPT}`.to_f
+    assert improved < baseline * 0.8
+  end
+end


### PR DESCRIPTION
## Summary
- add script to run GA tuning for kmeans
- implement ga_function_opt and ga_kmeans_tuning end-to-end tests

## Testing
- `bundle exec rake e2e`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875871fe130832692c75eeaf658a8ad