### PR TITLE
Fix neural network testing docs

### DIFF
--- a/TESTING_NN.md
+++ b/TESTING_NN.md
@@ -6,8 +6,7 @@ This document describes how to run the neural network test suite.
 
 ```
 bundle install
-bundle exec rake test:nn
-bundle exec rake e2e
+bundle exec rake test
 ```
 
 ## Fixtures


### PR DESCRIPTION
## Summary
- update instructions in `TESTING_NN.md`
- drop stale references to `test:nn` and `rake e2e`

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68758f7f16ec8326a7fbd230be9b608b