### PR TITLE
Remove RSpec parameterized tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,5 @@ end
 
 group :test do
   gem 'minitest', '~> 5.22'
-  gem 'rspec-parameterized', '~> 1.0'
   gem 'simplecov', '~> 0.22', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    binding_of_caller (1.0.1)
-      debug_inspector (>= 1.2.0)
     csv (3.3.5)
     date (3.4.1)
-    debug_inspector (1.2.0)
-    diff-lcs (1.6.2)
     docile (1.4.1)
     erb (5.0.1)
     json (2.12.2)
@@ -19,10 +15,6 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    proc_to_ast (0.2.0)
-      parser
-      rouge
-      unparser
     psych (5.2.6)
       date
       stringio
@@ -33,31 +25,6 @@ GEM
       erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
-    rouge (4.5.2)
-    rspec (3.13.1)
-      rspec-core (~> 3.13.0)
-      rspec-expectations (~> 3.13.0)
-      rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.5)
-      rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.5)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.5)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-parameterized (1.0.2)
-      rspec-parameterized-core (< 2)
-      rspec-parameterized-table_syntax (< 2)
-    rspec-parameterized-core (1.0.1)
-      parser
-      proc_to_ast (>= 0.2.0)
-      rspec (>= 2.13, < 4)
-      unparser
-    rspec-parameterized-table_syntax (1.0.1)
-      binding_of_caller
-      rspec-parameterized-core (< 2)
-    rspec-support (3.13.4)
     rubocop (1.78.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -83,10 +50,6 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    unparser (0.8.0)
-      diff-lcs (~> 1.6)
-      parser (>= 3.3.0)
-      prism (>= 1.4)
 
 PLATFORMS
   ruby
@@ -97,7 +60,6 @@ DEPENDENCIES
   minitest (~> 5.22)
   rake (~> 13)
   rdoc (~> 6)
-  rspec-parameterized (~> 1.0)
   rubocop (~> 1.78)
   simplecov (~> 0.22)
 

--- a/test/neural_network/backpropagation_test.rb
+++ b/test/neural_network/backpropagation_test.rb
@@ -18,8 +18,6 @@
 
 require 'ai4r/neural_network/backpropagation'
 require 'minitest/autorun'
-require 'rspec/autorun'
-require 'rspec/parameterized'
 require_relative '../test_helper'
 
 module Ai4r
@@ -219,25 +217,16 @@ module Ai4r
       end
     end
   end
-end
-
-RSpec.describe Ai4r::NeuralNetwork::Backpropagation do
-  include RSpec::Parameterized::TableSyntax
-
-  where(:structure, :expected_nodes, :disable_bias) do
+  def test_initializes_networks_with_given_structure
     [
       [[4, 2], [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0]], false],
       [[2, 2, 1], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0]], false],
       [[2, 2, 1], [[1.0, 1.0], [1.0, 1.0], [1.0]], true]
-    ]
-  end
-
-  with_them do
-    it 'initializes networks with given structure' do
-      net = described_class.new(structure)
+    ].each do |structure, expected_nodes, disable_bias|
+      net = Backpropagation.new(structure)
       net.disable_bias = true if disable_bias
       net.init_network
-      expect(net.activation_nodes).to eq(expected_nodes)
+      assert_equal expected_nodes, net.activation_nodes
     end
   end
 end


### PR DESCRIPTION
## Summary
- drop rspec-parameterized gem
- replace RSpec blocks with Minitest loops
- clean up requires in tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68758f7d58fc83268f1b7b1453fb6c38