### PR TITLE
Load BFS/DFS/MCTS via ai4r/search

### DIFF
--- a/docs/monte_carlo_tree_search.md
+++ b/docs/monte_carlo_tree_search.md
@@ -3,7 +3,7 @@
 `Ai4r::Search::MCTS` provides a generic implementation of the popular Monte Carlo Tree Search algorithm. It can be used for game playing or any domain where the available actions, state transitions and rewards can be described programmatically.
 
 ```ruby
-require 'ai4r/search/mcts'
+require 'ai4r/search'
 
 env = {
   actions: ->(s) { s == :root ? %i[a b] : [] },

--- a/docs/search_algorithms.md
+++ b/docs/search_algorithms.md
@@ -6,8 +6,7 @@ traverse a state space defined by a successor function until a goal is
 reached.
 
 ```ruby
-require 'ai4r/search/bfs'
-require 'ai4r/search/dfs'
+require 'ai4r/search'
 
 bfs = Ai4r::Search::BFS.new
 path = bfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbors(n) })

--- a/lib/ai4r/search.rb
+++ b/lib/ai4r/search.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require_relative 'search/a_star'
+require_relative 'search/bfs'
+require_relative 'search/dfs'
+require_relative 'search/mcts'
 
 module Ai4r
   # Namespace for search algorithms like A*.


### PR DESCRIPTION
## Summary
- add BFS, DFS, and MCTS requires in `lib/ai4r/search.rb`
- update docs to recommend loading via `require 'ai4r/search'`

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68759390c3d08326b0f7c1940dc77d67