### PR TITLE
Harmonize clusterer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ require 'ai4r'
 
 The `docs/` directory contains tutorials on using specific algorithms such as genetic algorithms, neural networks, clustering, and others. Examples under `examples/` showcase how to run several algorithms.
 
+All clustering algorithms expose a uniform interface:
+
+```ruby
+clusterer.build(data_set, number_of_clusters = nil)
+```
+
+`number_of_clusters` is ignored by algorithms such as DBSCAN that determine the
+count from the data.  Clusters are returned as `Ai4r::Data::DataSet` objects for
+consistency across implementations.
+
 See `README.rdoc` for additional usage notes and examples.
 
 ## Running Tests

--- a/docs/dbscan.md
+++ b/docs/dbscan.md
@@ -12,6 +12,10 @@ DBSCAN groups together densely packed points and labels isolated points as noise
 
 For example, a radius of `3` units corresponds to `epsilon: 9`.
 
+Unlike KMeans, DBSCAN cannot classify new items once built.  Calling
+`supports_eval?` returns `false` and attempting to use `eval` will raise
+`NotImplementedError`.
+
 ## Example
 
 ```ruby
@@ -23,7 +27,8 @@ points = [[1,1], [1,2], [8,8], [9,8]]
 set = DataSet.new(data_items: points)
 clusterer = DBSCAN.new
 clusterer.set_parameters(epsilon: 4, min_points: 1).build(set)
-pp clusterer.clusters
+# Clusters are returned as DataSet objects
+pp clusterer.clusters.map(&:data_items)
 ```
 
 ## Illustrative Example
@@ -46,7 +51,8 @@ set = DataSet.new(data_items: points)
 clusterer = DBSCAN.new
 clusterer.set_parameters(epsilon: 10, min_points: 2).build(set)
 pp clusterer.labels
-pp clusterer.clusters
+# Convert resulting DataSet clusters to plain arrays for printing
+pp clusterer.clusters.map(&:data_items)
 ```
 
 The output shows two clusters and three points labelled as noise:

--- a/docs/hierarchical_clustering.md
+++ b/docs/hierarchical_clustering.md
@@ -21,6 +21,10 @@ The first element of the array contains the final cluster and the last
 captures the initial individual points. You can limit the depth by
 passing a value to the constructor.
 
+Hierarchical clusterers only build a dendrogram and do not support
+evaluating new items afterwards. `supports_eval?` will return `false`
+for these classes.
+
 ## Plotting a dendrogram
 
 The example `examples/clusterers/dendrogram_example.rb` shows how to

--- a/lib/ai4r/clusterers/bisecting_k_means.rb
+++ b/lib/ai4r/clusterers/bisecting_k_means.rb
@@ -22,7 +22,6 @@ module Ai4r
     # http://en.wikipedia.org/wiki/K-means_algorithm
     class BisectingKMeans < KMeans
       attr_reader :data_set, :number_of_clusters, :clusters, :centroids
-      attr_accessor :max_iterations, :distance_function, :refine
 
       parameters_info max_iterations: 'Maximum number of iterations to ' \
                                       'build the clusterer. By default it is uncapped.',

--- a/lib/ai4r/clusterers/dbscan.rb
+++ b/lib/ai4r/clusterers/dbscan.rb
@@ -28,7 +28,14 @@ module Ai4r
         @cluster_indices = []
       end
 
-      def build(data_set)
+      # Build a new clusterer using data from +data_set+.
+      # An optional +number_of_clusters+ argument is ignored and present only to
+      # keep a consistent interface with other clusterers.
+      #
+      # @param data_set [Ai4r::Data::DataSet]
+      # @param number_of_clusters [Integer, nil]
+      # @return [DBSCAN]
+      def build(data_set, number_of_clusters = nil)
         @data_set = data_set
         @clusters = []
         @cluster_indices = []
@@ -48,13 +55,14 @@ module Ai4r
           else
             @number_of_clusters += 1
             @labels[data_index] = @number_of_clusters
-            @clusters.push([data_item])
+            ds = Ai4r::Data::DataSet.new(data_labels: @data_set.data_labels)
+            ds << data_item
+            @clusters.push(ds)
             @cluster_indices.push([data_index])
             extend_cluster(neighbors, @number_of_clusters)
           end
         end
 
-        @number_of_clusters = number_of_clusters
         raise 'number_of_clusters must be positive' if !@clusters.empty? && @number_of_clusters <= 0
 
         valid_labels = (1..@number_of_clusters).to_a << :noise

--- a/test/clusterers/dbscan_test.rb
+++ b/test/clusterers/dbscan_test.rb
@@ -24,12 +24,12 @@ class DBSCANTest < Minitest::Test
     assert_equal 3, clusterer.clusters.length
     total_length = 0
     clusterer.clusters.each do |cluster|
-      total_length += cluster.length
+      total_length += cluster.data_items.length
     end
     assert @@data.length >= total_length
     # Data inside clusters must be the same as original data
     clusterer.clusters.each do |cluster|
-      cluster.each do |data_item|
+      cluster.data_items.each do |data_item|
         assert @@data.include?(data_item)
       end
     end
@@ -110,7 +110,7 @@ class DBSCANTest < Minitest::Test
   def draw_map(clusterer)
     map = Array.new(11) { Array.new(11, 0) }
     clusterer.clusters.each_index do |i|
-      clusterer.clusters[i].each do |point|
+      clusterer.clusters[i].data_items.each do |point|
         map[point.first][point.last] = (i + 1)
       end
     end


### PR DESCRIPTION
## Summary
- standardize DBSCAN `build` signature and return `DataSet` clusters
- rely on `Parameterizable` in BisectingKMeans
- document that hierarchical clusterers and DBSCAN do not support `eval`
- explain unified clusterer API in README
- adjust DBSCAN tests for new DataSet clusters

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875922cdf0c8326bb9034947bced1ec