### PR TITLE
Align search API parameter names

### DIFF
--- a/docs/a_star_search.md
+++ b/docs/a_star_search.md
@@ -10,10 +10,10 @@ require 'ai4r/search'
 
 start = 'A'
 goal_test = ->(n) { n == 'G' }
-neighbors = ->(n) { { 'G' => 1 } }
+neighbor_fn = ->(n) { { 'G' => 1 } }
 heuristic = ->(n) { 0 }
 
-path = Ai4r::Search::AStar.new(start, goal_test, neighbors, heuristic).search
+path = Ai4r::Search::AStar.new(start, goal_test, neighbor_fn, heuristic).search
 ```
 
 The call returns the path as an array of nodes or `nil` when the goal cannot be

--- a/docs/search_algorithms.md
+++ b/docs/search_algorithms.md
@@ -10,10 +10,10 @@ require 'ai4r/search/bfs'
 require 'ai4r/search/dfs'
 
 bfs = Ai4r::Search::BFS.new
-path = bfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbors(n) })
+path = bfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbor_fn(n) })
 
 dfs = Ai4r::Search::DFS.new
-path = dfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbors(n) })
+path = dfs.search(start, ->(n) { goal?(n) }, ->(n) { neighbor_fn(n) })
 ```
 
 Both methods return the path from the start node to the first goal or

--- a/lib/ai4r/search/bfs.rb
+++ b/lib/ai4r/search/bfs.rb
@@ -13,17 +13,17 @@ module Ai4r
       # Find a path from the start node to a goal.
       #
       # start::      initial node
-      # goal_test::  lambda returning true for a goal node
-      # neighbors::  lambda returning adjacent nodes for a given node
+      # goal_test::   lambda returning true for a goal node
+      # neighbor_fn:: lambda returning adjacent nodes for a given node
       #
       # Returns an array of nodes representing the path, or nil if no goal was found.
-      def search(start, goal_test, neighbors)
+      def search(start, goal_test, neighbor_fn)
         queue = [[start, [start]]]
         visited = { start => true }
         until queue.empty?
           node, path = queue.shift
           return path if goal_test.call(node)
-          neighbors.call(node).each do |n|
+          neighbor_fn.call(node).each do |n|
             next if visited[n]
             visited[n] = true
             queue << [n, path + [n]]

--- a/lib/ai4r/search/dfs.rb
+++ b/lib/ai4r/search/dfs.rb
@@ -13,17 +13,17 @@ module Ai4r
       # Find a path from the start node to a goal.
       #
       # start::      initial node
-      # goal_test::  lambda returning true for a goal node
-      # neighbors::  lambda returning adjacent nodes for a given node
+      # goal_test::   lambda returning true for a goal node
+      # neighbor_fn:: lambda returning adjacent nodes for a given node
       #
       # Returns an array of nodes representing the path, or nil if no goal was found.
-      def search(start, goal_test, neighbors)
+      def search(start, goal_test, neighbor_fn)
         stack = [[start, [start]]]
         visited = { start => true }
         until stack.empty?
           node, path = stack.pop
           return path if goal_test.call(node)
-          neighbors.call(node).each do |n|
+          neighbor_fn.call(node).each do |n|
             next if visited[n]
             visited[n] = true
             stack << [n, path + [n]]


### PR DESCRIPTION
## Summary
- unify parameter names across BFS, DFS, AStar
- update docs to use `neighbor_fn`
- run tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687593a504208326b735ff921aed86b2