### PR TITLE
Rename LogisticRegression lr parameter

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,10 +59,10 @@ inspect these coefficients:
 
 Binary logistic regression is available as ``LogisticRegression''.  Training
 data must have numeric attributes with the last column containing ``0'' or ``1''
-labels.  Parameters ``lr'' and ``iterations'' control gradient descent.
+labels.  Parameters ``learning_rate'' and ``iterations'' control gradient descent.
 
   reg = Ai4r::Classifiers::LogisticRegression.new
-  reg.set_parameters(lr: 0.5, iterations: 2000).build(data)
+  reg.set_parameters(learning_rate: 0.5, iterations: 2000).build(data)
   reg.eval([1, 0])  # => 1
 
 == DataSet normalization

--- a/docs/logistic_regression.md
+++ b/docs/logistic_regression.md
@@ -4,7 +4,7 @@
 
 ## Parameters
 
-* `lr` – Learning rate used during gradient descent. Default is `0.1`.
+* `learning_rate` – Learning rate used during gradient descent. Default is `0.1`.
 * `iterations` – Number of training iterations. Default is `1000`.
 
 ## Example
@@ -18,7 +18,7 @@ labels = %w(x1 x2 class)
 set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
 
 reg = Ai4r::Classifiers::LogisticRegression.new
-reg.set_parameters(lr: 0.5, iterations: 2000).build(set)
+reg.set_parameters(learning_rate: 0.5, iterations: 2000).build(set)
 
 reg.eval([1, 0]) # => 1
 ```

--- a/lib/ai4r/classifiers/logistic_regression.rb
+++ b/lib/ai4r/classifiers/logistic_regression.rb
@@ -27,11 +27,11 @@ module Ai4r
     class LogisticRegression < Classifier
       attr_reader :weights
 
-      parameters_info lr: 'Learning rate for gradient descent.',
+      parameters_info learning_rate: 'Learning rate for gradient descent.',
                       iterations: 'Number of iterations to train.'
 
       def initialize
-        @lr = 0.1
+        @learning_rate = 0.1
         @iterations = 1000
         @weights = nil
       end
@@ -57,10 +57,10 @@ module Ai4r
 
           n.times do |j|
             grad = (0...m).inject(0.0) { |sum, i| sum + (errors[i] * x[i][j]) } / m
-            @weights[j] -= @lr * grad
+            @weights[j] -= @learning_rate * grad
           end
           bias_grad = errors.sum / m
-          @weights[n] -= @lr * bias_grad
+          @weights[n] -= @learning_rate * bias_grad
         end
         self
       end

--- a/test/classifiers/logistic_regression_test.rb
+++ b/test/classifiers/logistic_regression_test.rb
@@ -19,7 +19,7 @@ class LogisticRegressionTest < Minitest::Test
   def setup
     @data_set = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
     @classifier = LogisticRegression.new
-    @classifier.set_parameters(lr: 0.5, iterations: 2000)
+    @classifier.set_parameters(learning_rate: 0.5, iterations: 2000)
     @classifier.build(@data_set)
   end
 


### PR DESCRIPTION
## Summary
- rename `lr` parameter to `learning_rate`
- update logistic regression docs and README
- adjust logistic regression tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875954fa3e883269491db76b6b31c11