### PR TITLE
Describe unsupported rule extraction

### DIFF
--- a/lib/ai4r/classifiers/logistic_regression.rb
+++ b/lib/ai4r/classifiers/logistic_regression.rb
@@ -73,6 +73,13 @@ module Ai4r
         prob = 1.0 / (1.0 + Math.exp(-z))
         prob >= 0.5 ? 1 : 0
       end
+
+      # Logistic regression models do not easily translate to rule based
+      # representations. This method provides a short explanation instead of
+      # raising a `NotImplementedError` like the base class.
+      def get_rules
+        'LogisticRegression does not support rule extraction.'
+      end
     end
   end
 end

--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -125,6 +125,12 @@ module Ai4r
         self
       end
 
+      # Naive Bayes uses probabilistic models that cannot be easily represented
+      # as deterministic rules. Provide a descriptive message instead.
+      def get_rules
+        'NaiveBayes does not support rule extraction.'
+      end
+
       private
 
       # @param data [Object]

--- a/lib/ai4r/classifiers/simple_linear_regression.rb
+++ b/lib/ai4r/classifiers/simple_linear_regression.rb
@@ -55,6 +55,13 @@ module Ai4r
         @intercept + (@slope * data[@attribute_index])
       end
 
+      # This regression algorithm only produces numeric coefficients. Returning
+      # them as rules would be misleading, so a descriptive string is provided
+      # instead.
+      def get_rules
+        'SimpleLinearRegression does not support rule extraction.'
+      end
+
       # Gets the best attribute and does Linear Regression using it to find out the
       # slope and intercept.
       # Parameter data has to be an instance of DataSet

--- a/lib/ai4r/classifiers/support_vector_machine.rb
+++ b/lib/ai4r/classifiers/support_vector_machine.rb
@@ -72,6 +72,13 @@ module Ai4r
         score >= 0 ? @classes[0] : @classes[1]
       end
 
+      # Linear SVMs are represented by a hyperplane rather than discrete rules.
+      # This method returns an explanatory string for consistency with the
+      # classifier API.
+      def get_rules
+        'SupportVectorMachine does not support rule extraction.'
+      end
+
       private
 
       def dot(a, b)

--- a/test/classifiers/logistic_regression_test.rb
+++ b/test/classifiers/logistic_regression_test.rb
@@ -33,4 +33,9 @@ class LogisticRegressionTest < Minitest::Test
   def test_weights_present
     assert_equal 3, @classifier.weights.length
   end
+
+  def test_get_rules
+    assert_equal 'LogisticRegression does not support rule extraction.',
+                 LogisticRegression.new.get_rules
+  end
 end

--- a/test/classifiers/naive_bayes_test.rb
+++ b/test/classifiers/naive_bayes_test.rb
@@ -62,4 +62,8 @@ class NaiveBayesTest < Minitest::Test
                                                                                           ])
     end
   end
+  def test_get_rules
+    assert_equal 'NaiveBayes does not support rule extraction.',
+                 NaiveBayes.new.get_rules
+  end
 end

--- a/test/classifiers/simple_linear_regression_test.rb
+++ b/test/classifiers/simple_linear_regression_test.rb
@@ -45,4 +45,9 @@ class SimpleLinearRegressionTest < Minitest::Test
     result = classifier.eval(@data_set.data_items.first[0...-1])
     assert_in_delta expected, result, 0.0001
   end
+
+  def test_get_rules
+    assert_equal 'SimpleLinearRegression does not support rule extraction.',
+                 SimpleLinearRegression.new.get_rules
+  end
 end

--- a/test/classifiers/support_vector_machine_test.rb
+++ b/test/classifiers/support_vector_machine_test.rb
@@ -34,4 +34,9 @@ class SupportVectorMachineTest < Minitest::Test
     ds = DataSet.new(data_items: items, data_labels: labels)
     assert_raises(ArgumentError) { SupportVectorMachine.new.build(ds) }
   end
+
+  def test_get_rules
+    assert_equal 'SupportVectorMachine does not support rule extraction.',
+                 SupportVectorMachine.new.get_rules
+  end
 end


### PR DESCRIPTION
## Summary
- implement `get_rules` for algorithms without rule extraction
- add simple tests verifying these descriptive messages

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68759551e42c83268a699c87b044dcd4