### PR TITLE
Align search API parameter names

### DIFF
--- a/docs/a_star_search.md
+++ b/docs/a_star_search.md
@@ -10,10 +10,10 @@ require 'ai4r/search'
 
 start = 'A'
 goal_test = ->(n) { n == 'G' }
-neighbors = ->(n) { { 'G' => 1 } }
-heuristic = ->(n) { 0 }
+neighbor_fn = ->(n) { { 'G' => 1 } }
+heuristic_fn = ->(n) { 0 }
 
-path = Ai4r::Search::AStar.new(start, goal_test, neighbors, heuristic).search
+path = Ai4r::Search::AStar.new(start, goal_test, neighbor_fn, heuristic_fn).search
 ```
 
 The call returns the path as an array of nodes or `nil` when the goal cannot be

--- a/docs/monte_carlo_tree_search.md
+++ b/docs/monte_carlo_tree_search.md
@@ -6,10 +6,10 @@
 require 'ai4r/search'
 
 env = {
-  actions: ->(s) { s == :root ? %i[a b] : [] },
-  transition: ->(s, a) { a == :a ? :win : :lose },
-  terminal: ->(s) { %i[win lose].include?(s) },
-  reward: ->(s) { s == :win ? 1.0 : 0.0 }
+  actions_fn: ->(s) { s == :root ? %i[a b] : [] },
+  transition_fn: ->(s, a) { a == :a ? :win : :lose },
+  terminal_fn: ->(s) { %i[win lose].include?(s) },
+  reward_fn: ->(s) { s == :win ? 1.0 : 0.0 }
 }
 
 mcts = Ai4r::Search::MCTS.new(**env)
@@ -18,9 +18,9 @@ best = mcts.search(:root, 50)
 
 The callbacks are:
 
-* `actions.call(state)` – list available actions.
-* `transition.call(state, action)` – compute the next state.
-* `terminal.call(state)` – whether the state is terminal.
-* `reward.call(state)` – payoff for terminal states.
+* `actions_fn.call(state)` – list available actions.
+* `transition_fn.call(state, action)` – compute the next state.
+* `terminal_fn.call(state)` – whether the state is terminal.
+* `reward_fn.call(state)` – payoff for terminal states.
 
 Only a few dozen iterations are often enough to obtain a good action in small games.

--- a/docs/search_algorithms.md
+++ b/docs/search_algorithms.md
@@ -8,10 +8,10 @@ reached.
 ```ruby
 require 'ai4r/search'
 
-bfs = Ai4r::Search::BFS.new(->(n) { goal?(n) }, ->(n) { neighbors(n) })
+bfs = Ai4r::Search::BFS.new(goal_test, neighbor_fn)
 path = bfs.search(start)
 
-dfs = Ai4r::Search::DFS.new(->(n) { goal?(n) }, ->(n) { neighbors(n) })
+dfs = Ai4r::Search::DFS.new(goal_test, neighbor_fn)
 path = dfs.search(start)
 ```
 

--- a/lib/ai4r/search/bfs.rb
+++ b/lib/ai4r/search/bfs.rb
@@ -13,11 +13,11 @@ module Ai4r
       # Create a new BFS searcher.
       #
       # goal_test::  lambda returning true for a goal node
-      # neighbors::  lambda returning adjacent nodes for a given node
-      # start::      optional starting node
-      def initialize(goal_test, neighbors, start = nil)
+      # neighbor_fn:: lambda returning adjacent nodes for a given node
+      # start::       optional starting node
+      def initialize(goal_test, neighbor_fn, start = nil)
         @goal_test = goal_test
-        @neighbors = neighbors
+        @neighbor_fn = neighbor_fn
         @start = start
       end
 
@@ -35,7 +35,7 @@ module Ai4r
         until queue.empty?
           node, path = queue.shift
           return path if @goal_test.call(node)
-          @neighbors.call(node).each do |n|
+          @neighbor_fn.call(node).each do |n|
             next if visited[n]
             visited[n] = true
             queue << [n, path + [n]]

--- a/lib/ai4r/search/dfs.rb
+++ b/lib/ai4r/search/dfs.rb
@@ -13,11 +13,11 @@ module Ai4r
       # Create a new DFS searcher.
       #
       # goal_test::  lambda returning true for a goal node
-      # neighbors::  lambda returning adjacent nodes for a given node
-      # start::      optional starting node
-      def initialize(goal_test, neighbors, start = nil)
+      # neighbor_fn:: lambda returning adjacent nodes for a given node
+      # start::       optional starting node
+      def initialize(goal_test, neighbor_fn, start = nil)
         @goal_test = goal_test
-        @neighbors = neighbors
+        @neighbor_fn = neighbor_fn
         @start = start
       end
 
@@ -35,7 +35,7 @@ module Ai4r
         until stack.empty?
           node, path = stack.pop
           return path if @goal_test.call(node)
-          @neighbors.call(node).each do |n|
+          @neighbor_fn.call(node).each do |n|
             next if visited[n]
             visited[n] = true
             stack << [n, path + [n]]

--- a/test/unit/search/bfs_test.rb
+++ b/test/unit/search/bfs_test.rb
@@ -14,14 +14,30 @@ class BFSTest < Minitest::Test
     }
   end
 
+  def goal_test(node)
+    node == :d
+  end
+
+  def neighbor_fn(node)
+    @graph[node]
+  end
+
   def test_finds_shortest_path
-    bfs = BFS.new(->(n) { n == :d }, ->(n) { @graph[n] })
+    bfs = BFS.new(method(:goal_test), method(:neighbor_fn))
     path = bfs.search(:a)
     assert_equal %i[a b d], path
   end
 
+  def goal_test_unreach(node)
+    node == :x
+  end
+
+  def neighbor_fn_unreach(node)
+    @graph[node] || []
+  end
+
   def test_returns_nil_when_unreachable
-    bfs = BFS.new(->(n) { n == :x }, ->(n) { @graph[n] || [] })
+    bfs = BFS.new(method(:goal_test_unreach), method(:neighbor_fn_unreach))
     path = bfs.search(:a)
     assert_nil path
   end

--- a/test/unit/search/dfs_test.rb
+++ b/test/unit/search/dfs_test.rb
@@ -15,8 +15,16 @@ class DFSTest < Minitest::Test
     }
   end
 
+  def goal_test(node)
+    node == :e
+  end
+
+  def neighbor_fn(node)
+    @graph[node]
+  end
+
   def test_explores_depth_first
-    dfs = DFS.new(->(n) { n == :e }, ->(n) { @graph[n] })
+    dfs = DFS.new(method(:goal_test), method(:neighbor_fn))
     path = dfs.search(:a)
     assert_equal %i[a c e], path
   end

--- a/test/unit/search/mcts_test.rb
+++ b/test/unit/search/mcts_test.rb
@@ -7,10 +7,10 @@ class MCTSTest < Minitest::Test
 
   def setup
     @env = {
-      actions: ->(s) { s == :root ? %i[a b] : [] },
-      transition: ->(s, a) { a == :a ? :win : :lose },
-      terminal: ->(s) { %i[win lose].include?(s) },
-      reward: ->(s) { s == :win ? 1.0 : 0.0 }
+      actions_fn: ->(s) { s == :root ? %i[a b] : [] },
+      transition_fn: ->(s, a) { a == :a ? :win : :lose },
+      terminal_fn: ->(s) { %i[win lose].include?(s) },
+      reward_fn: ->(s) { s == :win ? 1.0 : 0.0 }
     }
     @mcts = MCTS.new(**@env)
   end


### PR DESCRIPTION
## Summary
- synchronize parameter names across BFS, DFS, AStar and MCTS
- update docs to use `goal_test`, `neighbor_fn` and `*_fn` callbacks
- adjust unit tests for new constructor keywords

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68759586e1948326a78915b157d657ea