### PR TITLE
Rename tie_strategy parameter to tie_break

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,10 +30,10 @@ strategies.  You can list available parameters by calling
 
   data = Ai4r::Data::DataSet.new.load_csv_with_labels 'examples/classifiers/zero_one_r_data.csv'
 
-  # ZeroR will return the most frequent class.  The ``tie_strategy'' parameter
+  # ZeroR will return the most frequent class.  The ``tie_break'' parameter
   # controls what happens when more than one class has the same frequency.
   zero_r = Ai4r::Classifiers::ZeroR.new
-  zero_r.set_parameters(:tie_strategy => :random)
+  zero_r.set_parameters(:tie_break => :random)
   zero_r.build(data)
 
   # OneR selects the single attribute with the lowest prediction error.  You

--- a/docs/hyperpipes.md
+++ b/docs/hyperpipes.md
@@ -12,7 +12,7 @@ file = 'examples/classifiers/hyperpipes_data.csv'
 data = DataSet.new.parse_csv_with_labels(file)
 
 classifier = Hyperpipes.new
-classifier.set_parameters(:tie_strategy => :random).build(data)
+classifier.set_parameters(:tie_break => :random).build(data)
 
 pp classifier.pipes    # inspect pipes_summary
 puts classifier.eval(['Chicago', 85, 'F'])
@@ -27,7 +27,7 @@ attributes match each pipe.
 
 ## Parameters
 
-`tie_strategy` – determines how to break ties when several classes receive the
+`tie_break` – determines how to break ties when several classes receive the
 same number of votes. Options are `:first`, `:last` or `:random`.
 
 `margin` – expands numeric boundaries by this amount when building the pipes.
@@ -46,7 +46,7 @@ items = [
 
 set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
 classifier = Ai4r::Classifiers::Hyperpipes.new
-classifier.set_parameters(tie_strategy: :last, margin: 0.5)
+classifier.set_parameters(tie_break: :last, margin: 0.5)
 classifier.build(set)
 classifier.eval(['New York', 30, 'M'])
 ```

--- a/examples/classifiers/hyperpipes_example.rb
+++ b/examples/classifiers/hyperpipes_example.rb
@@ -11,7 +11,7 @@ file = "#{File.dirname(__FILE__)}/hyperpipes_data.csv"
 data = DataSet.new.parse_csv_with_labels(file)
 
 # Build the classifier using custom parameters
-classifier = Hyperpipes.new.set_parameters(tie_strategy: :random).build(data)
+classifier = Hyperpipes.new.set_parameters(tie_break: :random).build(data)
 
 # Inspect the generated pipes
 pipes_summary = classifier.pipes

--- a/examples/classifiers/parameter_tutorial.rb
+++ b/examples/classifiers/parameter_tutorial.rb
@@ -18,8 +18,8 @@ puts '== ZeroR with default parameters =='
 zero_default = ZeroR.new.build(set)
 puts zero_default.get_rules
 
-puts "\n== ZeroR with :tie_strategy => :random =="
-zero_rand = ZeroR.new.set_parameters(tie_strategy: :random).build(set)
+puts "\n== ZeroR with :tie_break => :random =="
+zero_rand = ZeroR.new.set_parameters(tie_break: :random).build(set)
 puts zero_rand.get_rules
 
 puts "\n== OneR default behaviour =="

--- a/examples/classifiers/zero_and_one_r_example.rb
+++ b/examples/classifiers/zero_and_one_r_example.rb
@@ -20,7 +20,7 @@ puts "ZeroR default prediction: #{zero_default.eval(data.data_items.first)}"
 puts "Generated rule: #{zero_default.get_rules}"
 
 # Build ZeroR with custom tie strategy
-zero_random = ZeroR.new.set_parameters(tie_strategy: :random).build(data)
+zero_random = ZeroR.new.set_parameters(tie_break: :random).build(data)
 puts "ZeroR random tie strategy prediction: #{zero_random.eval(data.data_items.first)}"
 
 puts

--- a/lib/ai4r/classifiers/hyperpipes.rb
+++ b/lib/ai4r/classifiers/hyperpipes.rb
@@ -25,14 +25,14 @@ module Ai4r
     class Hyperpipes < Classifier
       attr_reader :data_set, :pipes
 
-      parameters_info tie_strategy: 'Strategy used when more than one class has the same maximal vote. ' \
-                                    'Valid values are :last (default) and :random.',
+      parameters_info tie_break: 'Strategy used when more than one class has the same maximal vote. ' \
+                                  'Valid values are :last (default) and :random.',
                       margin: 'Numeric margin added to the bounds of numeric attributes.',
-                      random_seed: 'Seed for random tie-breaking when tie_strategy is :random.'
+                      random_seed: 'Seed for random tie-breaking when tie_break is :random.'
 
       # @return [Object]
       def initialize
-        @tie_strategy = :last
+        @tie_break = :last
         @margin = 0
         @random_seed = nil
         @rng = nil
@@ -58,7 +58,7 @@ module Ai4r
       # You can evaluate new data, predicting its class.
       # e.g.
       #   classifier.eval(['New York',  '<30', 'F'])  # => 'Y'
-      # Tie resolution is controlled by +tie_strategy+ parameter.
+      # Tie resolution is controlled by +tie_break+ parameter.
       # @param data [Object]
       # @return [Object]
       def eval(data)
@@ -73,7 +73,7 @@ module Ai4r
           end
         end
         rng = @rng || (@random_seed.nil? ? Random.new : Random.new(@random_seed))
-        votes.get_winner(@tie_strategy, rng: rng)
+        votes.get_winner(@tie_break, rng: rng)
       end
 
       # This method returns the generated rules in ruby code.
@@ -107,7 +107,7 @@ module Ai4r
             rules << rule
           end
         end
-        rules << "#{labels.last} = votes.get_winner(:#{@tie_strategy})"
+        rules << "#{labels.last} = votes.get_winner(:#{@tie_break})"
         rules.join("\n")
       end
 

--- a/lib/ai4r/classifiers/votes.rb
+++ b/lib/ai4r/classifiers/votes.rb
@@ -29,9 +29,9 @@ module Ai4r
         tally_sheet[category]
       end
 
-      # @param tie_strategy [Object]
+      # @param tie_break [Object]
       # @return [Object]
-      def get_winner(tie_strategy = :last, rng: Random.new)
+      def get_winner(tie_break = :last, rng: Random.new)
         n = 0 # used to create a stable sort of the tallys
         sorted_sheet = tally_sheet.sort_by do |_, score|
           n += 1
@@ -39,7 +39,7 @@ module Ai4r
         end
         return nil if sorted_sheet.empty?
 
-        if tie_strategy == :random
+        if tie_break == :random
           max_score = sorted_sheet.last[1]
           tied = sorted_sheet.select { |_, score| score == max_score }.map(&:first)
           tied.sample(random: rng)

--- a/lib/ai4r/classifiers/zero_r.rb
+++ b/lib/ai4r/classifiers/zero_r.rb
@@ -26,15 +26,15 @@ module Ai4r
 
       parameters_info default_class: 'Return this value when the provided ' \
                                      'dataset is empty.',
-                      tie_strategy: 'Strategy used when more than one class has the ' \
-                                    'same maximal frequency. Valid values are :first (default) ' \
-                                    'and :random.',
+                      tie_break: 'Strategy used when more than one class has the ' \
+                                 'same maximal frequency. Valid values are :first (default) ' \
+                                 'and :random.',
                       random_seed: 'Seed for tie resolution when using :random strategy.'
 
       # @return [Object]
       def initialize
         @default_class = nil
-        @tie_strategy = :first
+        @tie_break = :first
         @random_seed = nil
         @rng = nil
       end
@@ -73,7 +73,7 @@ module Ai4r
         @class_value = if tied_classes.length == 1
                          tied_classes.first
                        else
-                         case @tie_strategy
+                         case @tie_break
                          when :random
                            tied_classes.sample(random: rng)
                          else

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -80,10 +80,10 @@ class HyperpipesTest < Minitest::Test
     assert_equal(expected, summary)
   end
 
-  def test_tie_strategy
-    classifier = Hyperpipes.new.set_parameters(tie_strategy: :last).build(@data_set)
+  def test_tie_break
+    classifier = Hyperpipes.new.set_parameters(tie_break: :last).build(@data_set)
     assert_equal 'N', classifier.eval(['Chicago', 40, 'F'])
-    classifier = Hyperpipes.new.set_parameters(tie_strategy: :random,
+    classifier = Hyperpipes.new.set_parameters(tie_break: :random,
                                                random_seed: 2).build(@data_set)
     assert_equal 'Y', classifier.eval(['Chicago', 40, 'F'])
   end

--- a/test/classifiers/zero_r_test.rb
+++ b/test/classifiers/zero_r_test.rb
@@ -53,12 +53,12 @@ class ZeroRTest < Minitest::Test
     assert_equal('N', classifier.class_value)
   end
 
-  def test_tie_strategy
+  def test_tie_break
     data = [%w[a Y], %w[b N], %w[c Y], %w[d N]]
     data_set = DataSet.new(data_items: data)
-    classifier = ZeroR.new.set_parameters({ tie_strategy: :first }).build(data_set)
+    classifier = ZeroR.new.set_parameters({ tie_break: :first }).build(data_set)
     assert_equal('Y', classifier.class_value)
-    classifier = ZeroR.new.set_parameters(tie_strategy: :random, random_seed: 1).build(data_set)
+    classifier = ZeroR.new.set_parameters(tie_break: :random, random_seed: 1).build(data_set)
     assert_equal('N', classifier.class_value)
   end
 end


### PR DESCRIPTION
## Summary
- rename the `tie_strategy` parameter and internal variable to `tie_break`
- update classifiers Hyperpipes and ZeroR
- update Votes helper parameter name
- adjust examples, tests and documentation

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687598dec4448326858ebbac23572ec4