### PR TITLE
Add get_rules strings for ML classifiers

### DIFF
--- a/lib/ai4r/classifiers/logistic_regression.rb
+++ b/lib/ai4r/classifiers/logistic_regression.rb
@@ -73,6 +73,14 @@ module Ai4r
         prob = 1.0 / (1.0 + Math.exp(-z))
         prob >= 0.5 ? 1 : 0
       end
+
+      # Logistic Regression classifiers cannot generate human readable rules.
+      #
+      # This method returns a string explaining that rule extraction is not
+      # supported for this algorithm.
+      def get_rules
+        'LogisticRegression does not support rule extraction.'
+      end
     end
   end
 end

--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -125,6 +125,13 @@ module Ai4r
         self
       end
 
+      # Naive Bayes classifiers cannot generate human readable rules.
+      # This method returns a descriptive string explaining that rule
+      # extraction is not supported for this algorithm.
+      def get_rules
+        'NaiveBayes does not support rule extraction.'
+      end
+
       private
 
       # @param data [Object]

--- a/lib/ai4r/classifiers/simple_linear_regression.rb
+++ b/lib/ai4r/classifiers/simple_linear_regression.rb
@@ -142,6 +142,13 @@ module Ai4r
         end
         self
       end
+
+      # Simple Linear Regression classifiers cannot generate human readable
+      # rules. This method returns a descriptive string indicating that rule
+      # extraction is not supported.
+      def get_rules
+        'SimpleLinearRegression does not support rule extraction.'
+      end
     end
   end
 end

--- a/lib/ai4r/classifiers/support_vector_machine.rb
+++ b/lib/ai4r/classifiers/support_vector_machine.rb
@@ -72,6 +72,12 @@ module Ai4r
         score >= 0 ? @classes[0] : @classes[1]
       end
 
+      # Support Vector Machine classifiers cannot generate human readable rules.
+      # This method returns a string indicating rule extraction is unsupported.
+      def get_rules
+        'SupportVectorMachine does not support rule extraction.'
+      end
+
       private
 
       def dot(a, b)

--- a/test/classifiers/logistic_regression_test.rb
+++ b/test/classifiers/logistic_regression_test.rb
@@ -33,4 +33,10 @@ class LogisticRegressionTest < Minitest::Test
   def test_weights_present
     assert_equal 3, @classifier.weights.length
   end
-end
+
+  def test_get_rules
+    classifier = LogisticRegression.new
+    assert_equal 'LogisticRegression does not support rule extraction.',
+                 classifier.get_rules
+  end
+  end

--- a/test/classifiers/naive_bayes_test.rb
+++ b/test/classifiers/naive_bayes_test.rb
@@ -58,8 +58,16 @@ class NaiveBayesTest < Minitest::Test
   def test_unknown_value_error
     assert_raises RuntimeError do
       NaiveBayes.new.set_parameters(unknown_value_strategy: :error).build(@data_set).eval(%w[
-                                                                                            Blue SUV Domestic
-                                                                                          ])
+
+            Blue SUV Domestic
+
+          ])
     end
+  end
+
+  def test_get_rules
+    classifier = NaiveBayes.new
+    assert_equal 'NaiveBayes does not support rule extraction.',
+                 classifier.get_rules
   end
 end

--- a/test/classifiers/simple_linear_regression_test.rb
+++ b/test/classifiers/simple_linear_regression_test.rb
@@ -45,4 +45,10 @@ class SimpleLinearRegressionTest < Minitest::Test
     result = classifier.eval(@data_set.data_items.first[0...-1])
     assert_in_delta expected, result, 0.0001
   end
-end
+
+  def test_get_rules
+    classifier = SimpleLinearRegression.new
+    assert_equal 'SimpleLinearRegression does not support rule extraction.',
+                 classifier.get_rules
+  end
+  end

--- a/test/classifiers/support_vector_machine_test.rb
+++ b/test/classifiers/support_vector_machine_test.rb
@@ -34,4 +34,10 @@ class SupportVectorMachineTest < Minitest::Test
     ds = DataSet.new(data_items: items, data_labels: labels)
     assert_raises(ArgumentError) { SupportVectorMachine.new.build(ds) }
   end
-end
+
+  def test_get_rules
+    svm = SupportVectorMachine.new
+    assert_equal 'SupportVectorMachine does not support rule extraction.',
+                 svm.get_rules
+  end
+  end


### PR DESCRIPTION
## Summary
- implement `get_rules` for classifiers that previously lacked it
- test rule string for each classifier

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68759abec4488326bf9ed63a048b644d