### PR TITLE
Improve transformer docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ require 'ai4r'
 * [A* Search](a_star_search.md) – heuristic best-first path search.
 * [Transformer](transformer.md) – tiny encoder, decoder and seq2seq models.
 * [Decode-only Classification Example](../examples/transformer/decode_classifier_example.rb)
+* [Encoder Text Classification Example](../examples/neural_network/transformer_text_classification.rb)
 
 ## Contributing
 

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -1,39 +1,44 @@
 # Minimal Transformer
 
-`Ai4r::NeuralNetwork::Transformer` implements a tiny transformer architecture. It can operate as an encoder, a decoder or a full encoder‑decoder (sequence‑to‑sequence) model. Token embeddings, sinusoidal positional encodings, multi‑head attention and a two‑layer feed‑forward network are provided. Weights are initialized randomly and the model is not trainable.
+`Ai4r::NeuralNetwork::Transformer` is a bite‑sized implementation of the Transformer architecture. It keeps the core ideas—token embeddings, sinusoidal positional encodings, multi‑head attention and a two‑layer feed‑forward network—while discarding the heavy training machinery. Everything is initialized at random, so you can focus on understanding the flow of data rather than achieving state‑of‑the‑art results.
+
+## Architecture options
+
+When creating a Transformer you pick one of three modes:
+
+* **Encoder** – processes a single sequence and returns its contextualized token vectors. Useful for classification or as the first half of a sequence‑to‑sequence model.
+* **Decoder** – predicts a sequence given its own past tokens. It uses causal attention so each position only attends to previous ones. Great for toy language models or decode‑only classifiers.
+* **Seq2seq** – combines an encoder and a decoder. The decoder attends both to its own history and to the encoder output, mimicking translation or summarization setups.
 
 ## Usage
 
 ```ruby
 require 'ai4r/neural_network/transformer'
 
-model = Ai4r::NeuralNetwork::Transformer.new(
+encoder = Ai4r::NeuralNetwork::Transformer.new(
   vocab_size: 50,
   max_len: 10,
-  embed_dim: 8,
-  num_heads: 2,
-  ff_dim: 16,
   architecture: :encoder
 )
-
-output = model.eval([1, 2, 3, 4])
-# => array of 4 vectors of length 8
+enc_output = encoder.eval([1, 2, 3, 4])
+# => array of 4 vectors of length encoder.embed_dim
 
 decoder = Ai4r::NeuralNetwork::Transformer.new(
   vocab_size: 50,
   max_len: 10,
   architecture: :decoder
 )
-
-decoder_output = decoder.eval([4, 5, 6])
+dec_output = decoder.eval([4, 5, 6])
 
 seq2seq = Ai4r::NeuralNetwork::Transformer.new(
   vocab_size: 50,
   max_len: 10,
   architecture: :seq2seq
 )
-
 seq2seq_output = seq2seq.eval([1, 2, 3], [4, 5])
 ```
 
-For a full toy classification demo using the decode-only configuration, see `examples/transformer/decode_classifier_example.rb`.
+## Examples
+
+* **Decode‑only text classification** – [`examples/transformer/decode_classifier_example.rb`](../examples/transformer/decode_classifier_example.rb) shows how to build embeddings with a decoder and train logistic regression on top.
+* **Encoder sentiment demo** – [`examples/neural_network/transformer_text_classification.rb`](../examples/neural_network/transformer_text_classification.rb) uses the encoder to create sentence vectors for a tiny sentiment dataset.


### PR DESCRIPTION
## Summary
- document encoder, decoder and seq2seq modes
- add examples section with links to transformer examples
- list encoder demo in docs index

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875ab87ad508326a0ec755c84fc0a80