### PR TITLE
Improve neural network docs

### DIFF
--- a/docs/hopfield_network.md
+++ b/docs/hopfield_network.md
@@ -1,6 +1,6 @@
 # Hopfield Networks
 
-A Hopfield network is a recurrent neural network that stores patterns as stable states. It can remove noise from an input pattern by iteratively updating the neurons until it converges to the closest memorized pattern.
+A Hopfield network is a classical recurrent neural network that stores patterns as stable states. It can remove noise from an input pattern by iteratively updating the neurons until it converges to the closest memorized pattern. While newer models like Transformers excel at sequence learning, Hopfield networks showcase associative memory in its simplest form.
 
 ## Input Format
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ require 'ai4r'
 
 * [User Guide](user_guide.md) – start with the basics and explore the library in depth.
 * **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
-* **Neural Networks** – simple OCR recognition of visual patterns.
+* **Neural Networks** – simple OCR recognition with a classic feed‑forward model.
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
 * [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * [DBSCAN](dbscan.md) – density-based clustering using a squared distance threshold.
@@ -40,7 +40,7 @@ require 'ai4r'
 * [Search Algorithms](search_algorithms.md) – breadth-first and depth-first search implementations.
 * [Monte Carlo Tree Search](monte_carlo_tree_search.md) – generic UCT search.
 * [A* Search](a_star_search.md) – heuristic best-first path search.
-* [Transformer](transformer.md) – tiny encoder, decoder and seq2seq models.
+* [Transformer](transformer.md) – a minimal take on the attention-powered architecture that transformed modern AI.
 * [Decode-only Classification Example](../examples/transformer/decode_classifier_example.rb)
 
 ## Contributing

--- a/docs/neural_networks.md
+++ b/docs/neural_networks.md
@@ -1,6 +1,8 @@
 # Neural Networks: Backpropagation OCR
 
-AI4R includes a backpropagation neural network implementation. Neural networks infer functions from observations and are useful when business rules are hard to define.
+AI4R includes a classic backpropagation neural network implementation. While decision trees or logistic regression rely on explicit rules and formulas, neural networks learn directly from examples. They map inputs to outputs through layers of weighted connections, paving the way for modern deep‑learning techniques.
+
+If you are curious about how today's world‑changing Transformer models extend these ideas with attention mechanisms, see the [Transformer](transformer.md) document. The rest of this page focuses on the traditional feed‑forward network used throughout the library.
 
 ## OCR Example
 
@@ -90,5 +92,13 @@ g.write('loss.png')
 ```
 
 For a recurrent associative network that can recall patterns from noisy inputs see the [Hopfield network](hopfield_network.md) document.
+
+### Additional Examples
+
+Example scripts under `examples/neural_network` demonstrate other uses:
+
+* `xor_example.rb` – trains a tiny network to learn the XOR logic gate.
+* `patterns_with_noise.rb` – shows how the OCR network copes with noisy data.
+* `transformer_text_classification.rb` – pairs a Transformer encoder with logistic regression for text sentiment.
 
 See the [Artificial Neural Network](http://en.wikipedia.org/wiki/Artificial_neural_network) and [Backpropagation](http://en.wikipedia.org/wiki/Backpropagation) articles for more information.

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -1,6 +1,8 @@
 # Minimal Transformer
 
-`Ai4r::NeuralNetwork::Transformer` implements a tiny transformer architecture. It can operate as an encoder, a decoder or a full encoder‑decoder (sequence‑to‑sequence) model. Token embeddings, sinusoidal positional encodings, multi‑head attention and a two‑layer feed‑forward network are provided. Weights are initialized randomly and the model is not trainable.
+`Ai4r::NeuralNetwork::Transformer` implements a tiny transformer architecture. Classical feed‑forward networks process each input independently, but transformers use self‑attention to relate every token in a sequence to every other token. This idea sparked a revolution in natural language processing and beyond.
+
+The implementation here is intentionally minimal. It can operate as an encoder, a decoder or a full encoder‑decoder (sequence‑to‑sequence) model. Token embeddings, sinusoidal positional encodings, multi‑head attention and a two‑layer feed‑forward network are provided. Weights are initialized randomly and the model is not trainable.
 
 ## Usage
 
@@ -37,3 +39,5 @@ seq2seq_output = seq2seq.eval([1, 2, 3], [4, 5])
 ```
 
 For a full toy classification demo using the decode-only configuration, see `examples/transformer/decode_classifier_example.rb`.
+
+Transformers build on the same fundamentals as the backpropagation network described in [Neural Networks](neural_networks.md), but attention lets them capture long-range dependencies. Even this toy implementation highlights how sequences can be processed as a whole rather than token by token.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -44,11 +44,12 @@ Datasets can be loaded from CSV files or created directly from arrays. Numeric a
 
 AI4R includes several algorithms:
 
-- Decision trees such as ID3
-- Neural networks with backpropagation
-- Genetic algorithms for optimization
-- Clustering methods including KMeans and hierarchical clustering
-- Baseline classifiers like OneR, ZeroR and Hyperpipes
+* Decision trees such as ID3
+* Neural networks with backpropagation
+* A minimal Transformer for sequence processing
+* Genetic algorithms for optimization
+* Clustering methods including KMeans and hierarchical clustering
+* Baseline classifiers like OneR, ZeroR and Hyperpipes
 
 See the documents in this directory for detailed tutorials on each topic.
 


### PR DESCRIPTION
## Summary
- expand neural network tutorial with context and examples
- highlight the minimal Transformer and relate it to classical networks
- mention Transformers in the user guide and index
- clarify Hopfield docs and reference Transformers

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875ac5c1a548326bfba84f7240fc430