### PR TITLE
Improve Clusterer docs and bench guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ require 'ai4r'
 
 The `docs/` directory contains tutorials on using specific algorithms such as genetic algorithms, neural networks, clustering, and others. Examples under `examples/` showcase how to run several algorithms.
 
+For performance comparisons the project includes a small bench suite. See
+[Bench Suite Overview](docs/benches_overview.md) for instructions on running the
+search and clustering benches.
+
 All clustering algorithms expose a uniform interface:
 
 ```ruby

--- a/docs/benches_overview.md
+++ b/docs/benches_overview.md
@@ -5,7 +5,12 @@ Benchmark scripts for selected algorithms live in the `bench/` directory. Each
 problems. Shared helpers such as the CLI, metrics and table reporter reside in
 `bench/common`.
 
-Currently the search lab is available under `bench/search`.
+Two labs ship with the library:
+
+* `bench/search` – compares graph search algorithms.
+* `bench/clusterer` – evaluates clustering methods such as k-means and hierarchical approaches.
+
+Each lab folder contains a README with quick-start examples and a description of the reported metrics.
 
 ## Adding a new lab
 

--- a/docs/dbscan.md
+++ b/docs/dbscan.md
@@ -1,70 +1,48 @@
 # DBSCAN Clustering
 
-DBSCAN groups together densely packed points and labels isolated points as noise. The implementation operates on numeric attributes and uses squared Euclidean distance by default. Squaring the distance avoids an expensive square root for every comparison.
+`DBSCAN` groups together densely packed points and labels sparse points as noise.
+The implementation in AI4R works on numeric attributes and uses a squared
+Euclidean distance by default (avoiding a square root per comparison).
 
 ## Parameters
 
-`Ai4r::Clusterers::DBSCAN` exposes parameters via `set_parameters`:
+Set parameters with `set_parameters`:
 
-* `epsilon` – squared radius for the neighbourhood. The squared distance between two points must be `<= epsilon` to be considered neighbours. If you want a real radius `r`, pass `epsilon: r**2`.
-* `min_points` – minimum number of neighbouring points **excluding the point itself** required to create or expand a cluster.
-* `distance_function` – optional custom distance measure. Provide a closure receiving two items and returning a distance. When omitted, squared Euclidean distance is used.
+* `epsilon` – squared neighbourhood radius. For a real radius `r`, pass
+  `epsilon: r**2`.
+* `min_points` – number of neighbours **excluding the point itself** required to
+  create or expand a cluster.
+* `distance_function` – optional lambda to override the distance metric.
 
-For example, a radius of `3` units corresponds to `epsilon: 9`.
+Unlike `KMeans`, DBSCAN does not support `eval` once built. Calling
+`supports_eval?` returns `false`.
 
-Unlike KMeans, DBSCAN cannot classify new items once built.  Calling
-`supports_eval?` returns `false` and attempting to use `eval` will raise
-`NotImplementedError`.
-
-## Example
+## Minimal Example
 
 ```ruby
 require 'ai4r'
 include Ai4r::Clusterers
 include Ai4r::Data
 
-points = [[1,1], [1,2], [8,8], [9,8]]
-set = DataSet.new(data_items: points)
+set = DataSet.new(data_items: [[1,1], [1,2], [8,8], [9,8]])
 clusterer = DBSCAN.new
 clusterer.set_parameters(epsilon: 4, min_points: 1).build(set)
-# Clusters are returned as DataSet objects
 pp clusterer.clusters.map(&:data_items)
 ```
 
-## Illustrative Example
+## Parameter Exploration
 
-The minimal dataset above shows the mechanics of the algorithm.  To gain
-intuition about parameter tuning, try running DBSCAN on a slightly larger
-synthetic set:
+To see how `epsilon` and `min_points` influence the results, run the script in
+the "Illustrative Example" section or adapt it to your own datasets.
 
-```ruby
-require 'ai4r'
-include Ai4r::Clusterers
-include Ai4r::Data
+## Benchmarks
 
-points = [
-  [1,1], [1,2], [1,3], [2,1], [2,2], [2,3],
-  [8,8], [8,9], [8,10], [9,8], [9,9], [9,10],
-  [5,5], [1,9], [10,0]
-]
-set = DataSet.new(data_items: points)
-clusterer = DBSCAN.new
-clusterer.set_parameters(epsilon: 10, min_points: 2).build(set)
-pp clusterer.labels
-# Convert resulting DataSet clusters to plain arrays for printing
-pp clusterer.clusters.map(&:data_items)
+DBSCAN can also be benchmarked using the clusterer bench just like other
+algorithms. Simply add `dbscan` to the `--algos` list:
+
+```bash
+ruby bench/clusterer/cluster_bench.rb --algos dbscan,kmeans \
+    --dataset bench/clusterer/datasets/blobs.csv --k 3
 ```
 
-The output shows two clusters and three points labelled as noise:
-
-```
-[1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, :noise, :noise, :noise]
-[
-  [[1,1], [1,2], [1,3], [2,1], [2,2], [2,3]],
-  [[8,8], [8,9], [8,10], [9,8], [9,9], [9,10]]
-]
-```
-
-With `epsilon` set to `10` (squared radius) and `min_points` set to `2`,
-DBSCAN groups points within each dense region while ignoring the scattered
-items.
+Check `bench/clusterer/README.md` for the available metrics and usage tips.

--- a/docs/hierarchical_clustering.md
+++ b/docs/hierarchical_clustering.md
@@ -1,9 +1,24 @@
 # Hierarchical Clustering
 
-AI4R includes several agglomerative algorithms such as SingleLinkage,
-CompleteLinkage and WardLinkage.  All hierarchical clusterers expose a
-`cluster_tree` array storing the clusters at each merge step when the
-clusterer is built.
+AI4R provides several algorithms to build dendrograms from your data. Most are
+**agglomerative** – they start with individual points and merge the closest
+clusters. `Diana` implements a **divisive** strategy by repeatedly splitting a
+cluster.
+
+Available linkage methods include:
+
+* `SingleLinkage`
+* `CompleteLinkage`
+* `AverageLinkage`
+* `WeightedAverageLinkage`
+* `CentroidLinkage`
+* `MedianLinkage`
+* `WardLinkage` and `WardLinkageHierarchical`
+* `Diana` (divisive)
+
+Every hierarchical clusterer records the merge tree in a `cluster_tree` array.
+The first element contains the final cluster, while the last holds the original
+points.
 
 ```ruby
 require 'ai4r'
@@ -17,15 +32,26 @@ puts clusterer.cluster_tree.size       # => 4
 puts clusterer.cluster_tree.last.size  # => 4
 ```
 
-The first element of the array contains the final cluster and the last
-captures the initial individual points. You can limit the depth by
-passing a value to the constructor.
+These algorithms only build the dendrogram. `supports_eval?` therefore returns
+`false` except for the divisive `Diana` class, which can classify unseen points.
 
-Hierarchical clusterers only build a dendrogram and do not support
-evaluating new items afterwards. `supports_eval?` will return `false`
-for these classes.
+## Example Scripts
 
-## Plotting a dendrogram
+* `examples/clusterers/dendrogram_example.rb` – save a dendrogram image using
+  `WardLinkage`.
+* `examples/clusterers/hierarchical_dendrogram_example.rb` – print the levels
+  stored by `WardLinkageHierarchical`.
+* `examples/clusterers/clusterer_example.rb` – try different algorithms (e.g.,
+  `Diana`, `KMeans`) on survey data.
 
-The example `examples/clusterers/dendrogram_example.rb` shows how to
-plot the recorded tree using the `dendrogram` gem.
+## Benchmarks
+
+Compare linkage methods with k-means using the clusterer bench:
+
+```bash
+ruby bench/clusterer/cluster_bench.rb --algos kmeans,single_linkage,diana \
+    --dataset bench/clusterer/datasets/blobs.csv --k 3
+```
+
+The resulting table shows silhouette scores, SSE when available and runtime.
+See `bench/clusterer/README.md` for more information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ require 'ai4r'
 * **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
 * **Neural Networks** – simple OCR recognition of visual patterns.
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
+* [K-Means](k_means.md) – classic partitioning approach with customizable distance functions.
 * [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * [DBSCAN](dbscan.md) – density-based clustering using a squared distance threshold.
 * **Automatic Classifiers** – identify relevant marketing targets using decision trees.
@@ -42,6 +43,7 @@ require 'ai4r'
 * [A* Search](a_star_search.md) – heuristic best-first path search.
 * [Transformer](transformer.md) – tiny encoder, decoder and seq2seq models.
 * [Decode-only Classification Example](../examples/transformer/decode_classifier_example.rb)
+* [Bench Suite Overview](benches_overview.md) – run benchmarks for search and clustering algorithms.
 
 ## Contributing
 

--- a/docs/k_means.md
+++ b/docs/k_means.md
@@ -1,0 +1,54 @@
+# K-Means Clustering
+
+The `Ai4r::Clusterers::KMeans` class implements the classic k-means algorithm.
+It partitions numeric data points into `k` clusters by iteratively assigning
+points to the nearest centroid and then updating the centroids.
+
+## Basic Usage
+
+```ruby
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [[1, 1], [1, 2], [2, 1], [2, 2], [8, 8], [9, 8]]
+set = DataSet.new(data_items: points)
+clusterer = KMeans.new.build(set, 2)
+
+clusterer.clusters.each_with_index do |cluster, i|
+  puts "Cluster #{i}: #{cluster.data_items.inspect}"
+end
+```
+
+Centroids are picked at random by default. Provide `random_seed` in
+`set_parameters` for deterministic results or `init_centroids` to choose your
+own starting points.
+
+To change the distance measure supply a lambda via `distance_function`.
+See `examples/clusterers/kmeans_custom_example.rb` for a full script.
+
+## After Building
+
+* `clusters` returns an array of `DataSet` clusters.
+* `sse` gives the sum of squared errors for the current centroids.
+* `iterations` reports how many refinement steps were required.
+
+K-means supports evaluating new items:
+
+```ruby
+index = clusterer.eval([1.5, 1.5])
+```
+
+## Benchmarks
+
+The project ships with a small benchmarking harness under
+`bench/clusterer`. Run it to compare k-means against hierarchical
+approaches:
+
+```bash
+ruby bench/clusterer/cluster_bench.rb --algos kmeans,single_linkage \
+    --dataset bench/clusterer/datasets/blobs.csv --k 3
+```
+
+The resulting table reports silhouette score, SSE, runtime and other
+useful notes. Consult `bench/clusterer/README.md` for details.


### PR DESCRIPTION
## Summary
- document k-means clustering
- expand hierarchical clustering guide
- update DBSCAN overview
- link to the bench suite
- mention bench suite in README

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875ad9f1ea08326800658577ed72380