### PR TITLE
Add dataset summary and CSV option support

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -38,7 +38,8 @@ Running this script prints `"yes"`.
 
 ## Working with Data
 
-Datasets can be loaded from CSV files or created directly from arrays. Numeric attributes support normalization with either z-score or min-max scaling.
+Datasets can be loaded from CSV files or created directly from arrays. The CSV helpers accept the same options as Ruby's `CSV` class, so you can specify separators or encoding via `csv_options:`.
+Numeric attributes support normalization with either z-score or min-max scaling. Call `describe` on a dataset to obtain a quick statistical summary of each attribute.
 
 ## Algorithm Overview
 

--- a/test/data/data_set_semicolon.csv
+++ b/test/data/data_set_semicolon.csv
@@ -1,0 +1,3 @@
+zone;rooms;size;price
+A;1;10;Y
+B;2;20;N

--- a/test/data/data_set_test.rb
+++ b/test/data/data_set_test.rb
@@ -156,6 +156,25 @@ module Ai4r
         assert_equal labels, first.data_labels
         assert_equal labels, second.data_labels
       end
+
+      def test_load_csv_custom_separator
+        file = File.join(File.dirname(__FILE__), 'data_set_semicolon.csv')
+        set = DataSet.new.load_csv_with_labels(file, parse_numeric: true,
+                                               csv_options: { col_sep: ';' })
+        assert_equal %w[zone rooms size price], set.data_labels
+        assert_equal ['A', 1.0, 10.0, 'Y'], set.data_items.first
+      end
+
+      def test_describe
+        items = [['A', 1], ['B', 2], ['A', 3]]
+        labels = %w[name val]
+        set = DataSet.new(data_items: items, data_labels: labels)
+        expected = {
+          'name' => { type: :nominal, count: 3, unique: 2, top: 'A' },
+          'val' => { type: :numeric, count: 3, mean: 2.0, std: 1.0, min: 1, max: 3 }
+        }
+        assert_equal expected, set.describe
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- allow passing `csv_options` to `DataSet` CSV loaders
- add `DataSet#describe` to summarize numeric and nominal attributes
- document CSV options and describe in the user guide
- add tests and fixture for the new features

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875ae01eca083269cd6642fcaeffada