### PR TITLE
Add DBSCAN support to cluster bench

### DIFF
--- a/bench/clusterer/README.md
+++ b/bench/clusterer/README.md
@@ -9,11 +9,14 @@ under `bench/clusterer` while shared helpers are in `bench/common`.
 $ ruby bench/clusterer/cluster_bench.rb \
     --dataset bench/clusterer/datasets/blobs.csv \
     --k 3 \
-    --algos kmeans,single_linkage,average_linkage,diana \
+    --epsilon 4 --min-points 3 \
+    --algos kmeans,single_linkage,average_linkage,diana,dbscan \
     --export out/cluster_results.csv
 ```
 
 This prints an ASCII table of metrics and saves a CSV with the same data.
+`--epsilon` and `--min-points` control DBSCAN when selected. They default to
+`4` and `3` respectively.
 
 ## Understanding the numbers
 

--- a/bench/clusterer/cluster_bench.rb
+++ b/bench/clusterer/cluster_bench.rb
@@ -2,11 +2,13 @@
 # frozen_string_literal: true
 
 require 'csv'
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
 require_relative '../common/cli'
 require_relative 'runners/kmeans_runner'
 require_relative 'runners/single_linkage_runner'
 require_relative 'runners/average_linkage_runner'
 require_relative 'runners/diana_runner'
+require_relative 'runners/dbscan_runner'
 
 module Bench
   module Clusterer
@@ -16,7 +18,8 @@ module Bench
       'kmeans' => Runners::KmeansRunner,
       'single_linkage' => Runners::SingleLinkageRunner,
       'average_linkage' => Runners::AverageLinkageRunner,
-      'diana' => Runners::DianaRunner
+      'diana' => Runners::DianaRunner,
+      'dbscan' => Runners::DbscanRunner
     }.freeze
 
     module_function
@@ -34,6 +37,8 @@ module Bench
       cli = Bench::Common::CLI.new('clusterer', RUNNERS.keys, CLUSTER_METRICS) do |opts, options|
         opts.on('--dataset FILE', 'CSV data file') { |v| options[:dataset] = v }
         opts.on('--k N', Integer, 'Number of clusters') { |v| options[:k] = v }
+        opts.on('--epsilon N', Float, 'DBSCAN squared radius') { |v| options[:epsilon] = v }
+        opts.on('--min-points N', Integer, 'DBSCAN minimum neighbours') { |v| options[:min_points] = v }
         opts.on('--with-ground-truth', 'Use labels column') { options[:with_gt] = true }
       end
       options = cli.parse(argv)
@@ -45,7 +50,14 @@ module Bench
       k = options[:k] || 3
 
       results = options[:algos].map do |name|
-        runner = RUNNERS[name].new(data_set, k)
+        runner = case name
+                 when 'dbscan'
+                   eps = options[:epsilon] || 4.0
+                   min_p = options[:min_points] || 3
+                   RUNNERS[name].new(data_set, eps, min_p)
+                 else
+                   RUNNERS[name].new(data_set, k)
+                 end
         runner.call
       end
       cli.report(results, options[:export])

--- a/bench/clusterer/runners/dbscan_runner.rb
+++ b/bench/clusterer/runners/dbscan_runner.rb
@@ -1,0 +1,37 @@
+require_relative '../../common/base_runner'
+require_relative '../../common/metrics'
+require 'ai4r/clusterers/dbscan'
+
+module Bench
+  module Clusterer
+    module Runners
+      class DbscanRunner < Bench::Common::BaseRunner
+        def initialize(data_set, epsilon, min_points)
+          @epsilon = epsilon
+          @min_points = min_points
+          super(data_set)
+        end
+
+        def call
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          clusterer = Ai4r::Clusterers::DBSCAN.new
+          clusterer.set_parameters(epsilon: @epsilon, min_points: @min_points)
+                   .build(problem)
+          duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+          clusters = clusterer.cluster_indices
+          metrics = {
+            clusters: clusters,
+            sse: nil,
+            silhouette: Bench::Common.silhouette(problem, clusters),
+            duration_ms: (duration * 1000).round(2),
+            iterations: nil,
+            memory_peaked: false,
+            notes: "eps=#{@epsilon}"
+          }
+          Bench::Common::Metrics.new(algo_name, metrics)
+        end
+      end
+    end
+  end
+end

--- a/docs/benches_overview.md
+++ b/docs/benches_overview.md
@@ -5,7 +5,8 @@ Benchmark scripts for selected algorithms live in the `bench/` directory. Each
 problems. Shared helpers such as the CLI, metrics and table reporter reside in
 `bench/common`.
 
-Currently the search lab is available under `bench/search`.
+Currently the search and clustering labs are available under `bench/search` and
+`bench/clusterer` respectively.
 
 ## Adding a new lab
 

--- a/docs/clusterer_bench.md
+++ b/docs/clusterer_bench.md
@@ -1,0 +1,15 @@
+# Clusterer Bench
+
+The clusterer bench compares algorithms such as KMeans, hierarchical linkages,
+DIANA and DBSCAN. It loads points from a CSV file and prints basic metrics
+for each run.
+
+```bash
+ruby bench/clusterer/cluster_bench.rb \
+    --dataset bench/clusterer/datasets/blobs.csv \
+    --k 3 --epsilon 4 --min-points 3 \
+    --algos kmeans,dbscan
+```
+
+`--epsilon` and `--min-points` only apply to DBSCAN. Results are shown in an
+ASCII table and can be exported to CSV.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ require 'ai4r'
 * [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
 * [Reinforcement Learning](reinforcement_learning.md) – Q-learning and policy iteration.
 * [Search Algorithms](search_algorithms.md) – breadth-first and depth-first search implementations.
+* [Clusterer Bench](clusterer_bench.md) – compare clustering algorithms on small datasets.
 * [Monte Carlo Tree Search](monte_carlo_tree_search.md) – generic UCT search.
 * [A* Search](a_star_search.md) – heuristic best-first path search.
 * [Transformer](transformer.md) – a minimal take on the attention-powered architecture that transformed modern AI.

--- a/examples/clusterers/dbscan_example.rb
+++ b/examples/clusterers/dbscan_example.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Example showcasing DBSCAN clustering with custom parameters.
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [
+  [1,1], [1,2], [1,3], [2,1], [2,2], [2,3],
+  [8,8], [8,9], [8,10], [9,8], [9,9], [9,10],
+  [5,5], [1,9], [10,0]
+]
+set = DataSet.new(data_items: points)
+
+clusterer = DBSCAN.new
+clusterer.set_parameters(epsilon: 10, min_points: 2).build(set)
+
+pp clusterer.labels
+pp clusterer.clusters.map(&:data_items)


### PR DESCRIPTION
## Summary
- extend cluster bench to load library path automatically
- add DBSCAN runner and CLI options
- update README and docs
- include new DBSCAN example

## Testing
- `bundle exec rake test`
- `ruby bench/clusterer/cluster_bench.rb --algos kmeans,dbscan --dataset bench/clusterer/datasets/blobs.csv --k 3 --epsilon 4 --min-points 3`

------
https://chatgpt.com/codex/tasks/task_e_6875afccb8b48326b955eeede0a9c7b0