### PR TITLE
Improve search algorithms and bench

### DIFF
--- a/bench/common/base_runner.rb
+++ b/bench/common/base_runner.rb
@@ -1,3 +1,5 @@
+require_relative 'metrics'
+
 module Bench
   module Common
     # Base class for algorithm runners collecting simple metrics.

--- a/bench/search/README.md
+++ b/bench/search/README.md
@@ -17,6 +17,9 @@ Console output shows a table of metrics and the CSV can be loaded into a
 spreadsheet. Swap the problem or algorithm names to try DFS, IDDFS or the
 classic eight puzzle.
 
+Use `--max-depth` to limit how far BFS and DFS explore. This is handy when
+demonstrating incomplete searches or examining progressively deeper levels.
+
 ## Metrics
 
 * `solution_depth` – length of the returned path minus one

--- a/bench/search/runners/a_star_runner.rb
+++ b/bench/search/runners/a_star_runner.rb
@@ -6,6 +6,10 @@ module Bench
     module Runners
       # A* search runner.
       class AStarRunner < Bench::Common::BaseRunner
+        def initialize(problem, _max_depth = nil)
+          super(problem)
+        end
+
         private
 
         def run

--- a/bench/search/runners/bfs_runner.rb
+++ b/bench/search/runners/bfs_runner.rb
@@ -5,21 +5,27 @@ module Bench
     module Runners
       # Breadth-first search runner.
       class BfsRunner < Bench::Common::BaseRunner
+        def initialize(problem, max_depth = nil)
+          super(problem)
+          @max_depth = max_depth
+        end
+
         private
 
         def run
           start = problem.start_state
-          queue = [[start, [start]]]
+          queue = [[start, [start], 0]]
           visited = { start => true }
           until queue.empty?
             frontier_size(queue.size)
-            node, path = queue.shift
+            node, path, depth = queue.shift
             return path if problem.goal?(node)
+            next if @max_depth && depth >= @max_depth
             expand
             problem.neighbors(node).each_key do |nbr|
               next if visited[nbr]
               visited[nbr] = true
-              queue << [nbr, path + [nbr]]
+              queue << [nbr, path + [nbr], depth + 1]
             end
           end
           nil

--- a/bench/search/runners/dfs_runner.rb
+++ b/bench/search/runners/dfs_runner.rb
@@ -5,21 +5,27 @@ module Bench
     module Runners
       # Depth-first search runner.
       class DfsRunner < Bench::Common::BaseRunner
+        def initialize(problem, max_depth = nil)
+          super(problem)
+          @max_depth = max_depth
+        end
+
         private
 
         def run
           start = problem.start_state
-          stack = [[start, [start]]]
+          stack = [[start, [start], 0]]
           visited = { start => true }
           until stack.empty?
             frontier_size(stack.size)
-            node, path = stack.pop
+            node, path, depth = stack.pop
             return path if problem.goal?(node)
+            next if @max_depth && depth >= @max_depth
             expand
             problem.neighbors(node).each_key do |nbr|
               next if visited[nbr]
               visited[nbr] = true
-              stack << [nbr, path + [nbr]]
+              stack << [nbr, path + [nbr], depth + 1]
             end
           end
           nil

--- a/bench/search/runners/iddfs_runner.rb
+++ b/bench/search/runners/iddfs_runner.rb
@@ -5,6 +5,10 @@ module Bench
     module Runners
       # Iterative deepening depth-first search runner.
       class IddfsRunner < Bench::Common::BaseRunner
+        def initialize(problem, _max_depth = nil)
+          super(problem)
+        end
+
         private
 
         def run

--- a/bench/search/search_bench.rb
+++ b/bench/search/search_bench.rb
@@ -32,6 +32,9 @@ module Bench
         opts.on('--problem NAME', PROBLEMS.keys, 'Problem name') { |v| options[:problem] = v }
         opts.on('--map FILE', 'Grid map file for grid problem') { |v| options[:map] = v }
         opts.on('--start STATE', 'Initial state for eight puzzle') { |v| options[:start] = v }
+        opts.on('--max-depth N', Integer, 'Depth limit for BFS/DFS algorithms') do |v|
+          options[:max_depth] = v
+        end
       end
       options = cli.parse(argv)
 
@@ -46,7 +49,7 @@ module Bench
                  end
 
       results = options[:algos].map do |name|
-        runner = RUNNERS[name].new(problem)
+        runner = RUNNERS[name].new(problem, options[:max_depth])
         runner.call
       end
       cli.report(results, options[:export])

--- a/docs/search_algorithms.md
+++ b/docs/search_algorithms.md
@@ -5,17 +5,18 @@ state spaces. The goal predicates and successor functions are tiny Ruby
 procs so you can prototype ideas in a few lines of code. Breadth-first
 search (BFS) expands the frontier level by level, whereas depth-first
 search (DFS) follows one branch as deep as it can. They both expect a
-`goal_test` and a `neighbor_fn` describing your problem space. For large
-graphs you can also try iterative deepening search (IDDFS) which mixes the
+`goal_test` and a `neighbor_fn` describing your problem space. Both accept a
+`max_depth` parameter if you want to limit exploration.
+For large graphs you can also try iterative deepening search (IDDFS) which mixes the
 two approaches.
 
 ```ruby
 require 'ai4r/search'
 
-bfs = Ai4r::Search::BFS.new(goal_test, neighbor_fn)
+bfs = Ai4r::Search::BFS.new(goal_test, neighbor_fn, nil, max_depth: 5)
 path = bfs.search(start)
 
-dfs = Ai4r::Search::DFS.new(goal_test, neighbor_fn)
+dfs = Ai4r::Search::DFS.new(goal_test, neighbor_fn, nil, max_depth: 5)
 path = dfs.search(start)
 ```
 

--- a/lib/ai4r/search/bfs.rb
+++ b/lib/ai4r/search/bfs.rb
@@ -6,19 +6,26 @@
 #
 # Basic breadth-first search implementation.
 
+require_relative '../data/parameterizable'
+
 module Ai4r
   module Search
     # Explore nodes in breadth-first order until a goal is found.
     class BFS
+      include Ai4r::Data::Parameterizable
+
+      parameters_info max_depth: 'Limit search depth. Nil means unlimited.'
       # Create a new BFS searcher.
       #
       # goal_test::  lambda returning true for a goal node
       # neighbor_fn:: lambda returning adjacent nodes for a given node
       # start::       optional starting node
-      def initialize(goal_test, neighbor_fn, start = nil)
+      # max_depth::   optional depth limit
+      def initialize(goal_test, neighbor_fn, start = nil, max_depth: nil)
         @goal_test = goal_test
         @neighbor_fn = neighbor_fn
         @start = start
+        @max_depth = max_depth
       end
 
       # Find a path from the start node to a goal.
@@ -35,6 +42,8 @@ module Ai4r
         until queue.empty?
           node, path = queue.shift
           return path if @goal_test.call(node)
+          depth = path.length - 1
+          next if @max_depth && depth >= @max_depth
           @neighbor_fn.call(node).each do |n|
             next if visited[n]
             visited[n] = true

--- a/lib/ai4r/search/dfs.rb
+++ b/lib/ai4r/search/dfs.rb
@@ -6,19 +6,27 @@
 #
 # Basic depth-first search implementation.
 
+require_relative '../data/parameterizable'
+
 module Ai4r
   module Search
     # Explore nodes in depth-first order until a goal is found.
     class DFS
+      include Ai4r::Data::Parameterizable
+
+      parameters_info max_depth: 'Limit search depth. Nil means unlimited.'
       # Create a new DFS searcher.
       #
       # goal_test::  lambda returning true for a goal node
       # neighbor_fn:: lambda returning adjacent nodes for a given node
       # start::       optional starting node
-      def initialize(goal_test, neighbor_fn, start = nil)
+      # start::       optional starting node
+      # max_depth::   optional depth limit
+      def initialize(goal_test, neighbor_fn, start = nil, max_depth: nil)
         @goal_test = goal_test
         @neighbor_fn = neighbor_fn
         @start = start
+        @max_depth = max_depth
       end
 
       # Find a path from the start node to a goal.
@@ -35,6 +43,8 @@ module Ai4r
         until stack.empty?
           node, path = stack.pop
           return path if @goal_test.call(node)
+          depth = path.length - 1
+          next if @max_depth && depth >= @max_depth
           @neighbor_fn.call(node).each do |n|
             next if visited[n]
             visited[n] = true

--- a/test/unit/search/bfs_test.rb
+++ b/test/unit/search/bfs_test.rb
@@ -41,4 +41,9 @@ class BFSTest < Minitest::Test
     path = bfs.search(:a)
     assert_nil path
   end
+
+  def test_respects_max_depth
+    bfs = BFS.new(method(:goal_test), method(:neighbor_fn), nil, max_depth: 1)
+    assert_nil bfs.search(:a)
+  end
 end

--- a/test/unit/search/dfs_test.rb
+++ b/test/unit/search/dfs_test.rb
@@ -28,4 +28,9 @@ class DFSTest < Minitest::Test
     path = dfs.search(:a)
     assert_equal %i[a c e], path
   end
+
+  def test_respects_max_depth
+    dfs = DFS.new(method(:goal_test), method(:neighbor_fn), nil, max_depth: 1)
+    assert_nil dfs.search(:a)
+  end
 end


### PR DESCRIPTION
## Summary
- fix search bench requiring metrics so it runs
- add max-depth parameter to BFS & DFS and expose via bench CLI
- update bench runners to use depth limit
- document new option and search algorithm usage
- add tests for depth limit

## Testing
- `bundle exec rake test`
- `ruby bench/search/search_bench.rb --problem grid --map bench/search/maps/small.txt --algos bfs --max-depth 1`
- `ruby bench/search/search_bench.rb --problem grid --map bench/search/maps/small.txt --algos bfs`

------
https://chatgpt.com/codex/tasks/task_e_6875afc3d35c83269301868ddf8a2ac1