### PR TITLE
Improve SOM docs and bench setup

### DIFF
--- a/bench/clusterer/README.md
+++ b/bench/clusterer/README.md
@@ -15,6 +15,9 @@ $ ruby bench/clusterer/cluster_bench.rb \
 
 This prints an ASCII table of metrics and saves a CSV with the same data.
 
+Run the command from the project root. The script automatically adds the
+`lib/` directory to Ruby's load path so no gem installation is required.
+
 ## Understanding the numbers
 
 * `silhouette` – average silhouette coefficient (-1..1), higher is better.

--- a/bench/clusterer/cluster_bench.rb
+++ b/bench/clusterer/cluster_bench.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+require 'ai4r'
 require 'csv'
 require_relative '../common/cli'
 require_relative 'runners/kmeans_runner'

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ require 'ai4r'
 * **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
 * **Neural Networks** – simple OCR recognition with a classic feed‑forward model.
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
+* [Self-Organizing Maps](som.md) – unsupervised mapping from high dimensions into a grid.
 * [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * [DBSCAN](dbscan.md) – density-based clustering using a squared distance threshold.
 * **Automatic Classifiers** – identify relevant marketing targets using decision trees.

--- a/docs/som.md
+++ b/docs/som.md
@@ -1,0 +1,56 @@
+# Self-Organizing Maps
+
+AI4R provides a lightweight implementation of Kohonen's Self-Organizing
+Map (SOM) under `Ai4r::Som`. A SOM maps high dimensional data into a
+lower dimensional grid where nearby nodes respond to similar patterns.
+
+## Quick Example
+
+```ruby
+require 'ai4r/som/som'
+
+layer = Ai4r::Som::TwoPhaseLayer.new(10, distance_metric: :euclidean)
+som = Ai4r::Som::Som.new(4, 8, 8, layer)
+som.initiate_map
+
+# `data` is an array of numeric vectors. The iris dataset from
+# `examples/som/som_data.rb` works well.
+10.times do
+  som.train_step(data)
+end
+```
+
+`train_step` updates the map for a single epoch and returns the global
+error. You can call `train` to run until the configured epoch count or
+an optional `error_threshold` is reached.
+
+```ruby
+errors = som.train(data, error_threshold: 1000) do |err|
+  puts "epoch #{som.epoch} error=#{err}"
+end
+```
+
+## Customizing Parameters
+
+Both layers and nodes accept a `distance_metric` parameter
+(`:chebyshev`, `:euclidean` or `:manhattan`). The `TwoPhaseLayer`
+additionally lets you tune the number of epochs for each phase and the
+learning rates:
+
+```ruby
+layer = Ai4r::Som::TwoPhaseLayer.new(
+  10,                 # nodes per side
+  0.9,                # initial learning rate
+  150,                # phase one epochs
+  100,                # phase two epochs
+  0.1,                # phase one learning rate
+  0.01,               # phase two learning rate
+  distance_metric: :euclidean
+)
+```
+
+Weights are initialized randomly in `[0, 1)` by default. Pass
+`random_seed:` to `Som#initiate_map` for reproducible runs.
+
+See `examples/som` for complete scripts exploring early stopping and map
+size effects.


### PR DESCRIPTION
## Summary
- add SOM tutorial documentation
- require ai4r in clusterer bench so it works from repo
- document bench usage from project root
- mention SOM docs in index

## Testing
- `bundle exec rake test`
- `ruby bench/clusterer/cluster_bench.rb --dataset bench/clusterer/datasets/blobs.csv --k 2 --algos kmeans,single_linkage`

------
https://chatgpt.com/codex/tasks/task_e_6875afe1941c8326bf7e1d5a02f3b9da