### PR TITLE
Fix CI by ignoring coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
 rdoc/
 site/build/
+coverage/
 


### PR DESCRIPTION
## Summary
- add `coverage/` to `.gitignore` to avoid committing coverage artifacts

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6875c990a510832680b93ac0e74d44d9