### PR TITLE
Improve docs with cross-links and KMeans page

### DIFF
--- a/docs/benches_overview.md
+++ b/docs/benches_overview.md
@@ -6,9 +6,9 @@ problems. Shared helpers such as the CLI, metrics and table reporter reside in
 `bench/common`.
 
 Labs exist for search algorithms, clustering algorithms and classifiers:
-- `bench/search`
-- `bench/clusterer`
-- `bench/classifier`
+- [`bench/search`](../bench/search)
+- [`bench/clusterer`](../bench/clusterer)
+- [`bench/classifier`](../bench/classifier)
 
 ## Adding a new lab
 

--- a/docs/classifier_bench.md
+++ b/docs/classifier_bench.md
@@ -15,3 +15,7 @@ Results appear in an ASCII table and can be exported to CSV with `--export`.
 Metrics include accuracy, F1 score, training time, prediction speed and model
 size. An additional table highlights advantages such as interpretability or
 speed.
+
+The bench is a quick way to compare [ID3](machine_learning.md),
+[Naive Bayes](naive_bayes.md), [IB1](ib1.md) and
+[Hyperpipes](hyperpipes.md) on the same dataset.

--- a/docs/clusterer_bench.md
+++ b/docs/clusterer_bench.md
@@ -1,7 +1,8 @@
 # Clusterer Bench
 
-The clusterer bench compares algorithms such as KMeans, hierarchical linkages,
-DIANA and DBSCAN. It loads points from a CSV file and prints basic metrics
+The clusterer bench compares algorithms such as [KMeans](kmeans.md),
+[hierarchical clustering](hierarchical_clustering.md), DIANA and
+[DBSCAN](dbscan.md). It loads points from a CSV file and prints basic metrics
 for each run.
 
 ```bash

--- a/docs/dbscan.md
+++ b/docs/dbscan.md
@@ -12,7 +12,7 @@ DBSCAN groups together densely packed points and labels isolated points as noise
 
 For example, a radius of `3` units corresponds to `epsilon: 9`.
 
-Unlike KMeans, DBSCAN cannot classify new items once built.  Calling
+Unlike [KMeans](kmeans.md), DBSCAN cannot classify new items once built.  Calling
 `supports_eval?` returns `false` and attempting to use `eval` will raise
 `NotImplementedError`.
 
@@ -68,3 +68,5 @@ The output shows two clusters and three points labelled as noise:
 With `epsilon` set to `10` (squared radius) and `min_points` set to `2`,
 DBSCAN groups points within each dense region while ignoring the scattered
 items.
+
+See [Clusterer Bench](clusterer_bench.md) to compare DBSCAN with other clusterers.

--- a/docs/hierarchical_clustering.md
+++ b/docs/hierarchical_clustering.md
@@ -29,3 +29,6 @@ for these classes.
 
 The example `examples/clusterers/dendrogram_example.rb` shows how to
 plot the recorded tree using the `dendrogram` gem.
+
+You can benchmark hierarchical clustering against other methods in the
+[Clusterer Bench](clusterer_bench.md).

--- a/docs/hyperpipes.md
+++ b/docs/hyperpipes.md
@@ -50,3 +50,5 @@ classifier.set_parameters(tie_break: :last, margin: 0.5)
 classifier.build(set)
 classifier.eval(['New York', 30, 'M'])
 ```
+
+Check [Classifier Bench](classifier_bench.md) to compare Hyperpipes with other classifiers.

--- a/docs/ib1.md
+++ b/docs/ib1.md
@@ -25,4 +25,6 @@ puts "Prediction for #{sample.inspect}: #{classifier.eval(sample)}"
 
 The classifier automatically updates attribute ranges as new examples are seen and returns the class of the closest training instance.
 
+See [Classifier Bench](classifier_bench.md) for a comparison with other classifiers.
+
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,13 +25,14 @@ require 'ai4r'
 ## Practical Examples
 
 * [User Guide](user_guide.md) – start with the basics and explore the library in depth.
-* **Genetic Algorithms** – optimization of the Travelling Salesman Problem.
-* **Neural Networks** – simple OCR recognition with a classic feed‑forward model.
+* [Genetic Algorithms](genetic_algorithms.md) – optimization of the Travelling Salesman Problem.
+* [Neural Networks](neural_networks.md) – simple OCR recognition with a classic feed‑forward model.
 * [Hopfield Networks](hopfield_network.md) – memory based recognition of noisy patterns.
 * [Self-Organizing Maps](som.md) – unsupervised mapping from high dimensions into a grid.
 * [Hierarchical Clustering](hierarchical_clustering.md) – build dendrograms from merge steps.
 * [DBSCAN](dbscan.md) – density-based clustering using a squared distance threshold.
-* **Automatic Classifiers** – identify relevant marketing targets using decision trees.
+* [KMeans](kmeans.md) – partition data into k clusters with iterative centroid updates.
+* [ID3 Decision Trees](machine_learning.md) – interpretable rules for marketing targets.
 * [PRISM](prism.md) – rule induction algorithm for discrete attributes.
 * [Naive Bayes Classifier](naive_bayes.md) – probabilistic classification for categorical data.
 * [Hyperpipes](hyperpipes.md) – baseline classifier using value ranges.

--- a/docs/kmeans.md
+++ b/docs/kmeans.md
@@ -1,0 +1,25 @@
+# KMeans Clustering
+
+`Ai4r::Clusterers::KMeans` partitions data into K clusters by minimizing the
+within-cluster variance. Points are assigned to the nearest centroid and the
+centroids move to the mean of their assigned points until convergence.
+
+## Example
+
+```ruby
+require 'ai4r'
+include Ai4r::Clusterers
+include Ai4r::Data
+
+points = [[1,1],[1,2],[9,8],[9,9]]
+set = DataSet.new(data_items: points)
+clusterer = KMeans.new
+clusterer.build(set, 2)
+pp clusterer.clusters.map(&:data_items)
+```
+
+`build` returns the clusterer itself so you can inspect `clusters`,
+`iterations`, and the sum of squared errors via `sse`.
+
+See `examples/clusterers/kmeans_custom_example.rb` for a variant using
+Manhattan distance.

--- a/docs/logistic_regression.md
+++ b/docs/logistic_regression.md
@@ -24,3 +24,4 @@ reg.eval([1, 0]) # => 1
 ```
 
 See `examples/classifiers/logistic_regression_example.rb` for a runnable script.
+You can benchmark it with other models in the [Classifier Bench](classifier_bench.md).

--- a/docs/machine_learning.md
+++ b/docs/machine_learning.md
@@ -89,3 +89,5 @@ File.write('tree.dot', dot)
 
 Running `dot -Tpng tree.dot -o tree.png` will generate an image of the decision
 tree.
+
+For performance metrics against other models see the [Classifier Bench](classifier_bench.md).

--- a/docs/monte_carlo_tree_search.md
+++ b/docs/monte_carlo_tree_search.md
@@ -26,3 +26,4 @@ The callbacks are:
 Only a few dozen iterations are often enough to obtain a good action in small games.
 
 Experiment with the parameters or plug in your own environment to see how the algorithm balances exploration and exploitation. MCTS shines when the search space is enormous but simulations are cheap.
+You can run the search benchmark under `bench/search` to compare MCTS with other search strategies.

--- a/docs/naive_bayes.md
+++ b/docs/naive_bayes.md
@@ -37,4 +37,6 @@ The last line prints a hash with the probability for each class.
 
 Inspecting these arrays helps you understand the learned model.
 
+Run [Classifier Bench](classifier_bench.md) to see how Naive Bayes performs alongside other classifiers.
+
 

--- a/docs/reinforcement_learning.md
+++ b/docs/reinforcement_learning.md
@@ -25,3 +25,5 @@ require 'ai4r/reinforcement/policy_iteration'
 pi = Ai4r::Reinforcement::PolicyIteration.new
 policy = pi.policy_iteration(states, actions, transition, reward)
 ```
+
+For classical graph search techniques see [Search Algorithms](search_algorithms.md).

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -44,12 +44,12 @@ Datasets can be loaded from CSV files or created directly from arrays. Numeric a
 
 AI4R includes several algorithms:
 
-* Decision trees such as ID3
-* Neural networks with backpropagation
-* A minimal Transformer for sequence processing
-* Genetic algorithms for optimization
-* Clustering methods including KMeans and hierarchical clustering
-* Baseline classifiers like OneR, ZeroR and Hyperpipes
+* [ID3 Decision Trees](machine_learning.md)
+* [Neural Networks](neural_networks.md) with backpropagation
+* [Transformer](transformer.md) for sequence processing
+* [Genetic Algorithms](genetic_algorithms.md) for optimization
+* Clustering with [KMeans](kmeans.md) and [Hierarchical Clustering](hierarchical_clustering.md)
+* Baseline classifiers like OneR, ZeroR and [Hyperpipes](hyperpipes.md)
 
 See the documents in this directory for detailed tutorials on each topic.
 


### PR DESCRIPTION
## Summary
- add missing documentation page for KMeans clustering
- cross-link major docs and highlight key algorithms
- mention classifier and clusterer benches where appropriate
- simplify bullet lists in index and user guide

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68762f9cb0f883268a6bb3f5c1c9aa74