### PR TITLE
Improve classifier docs

### DIFF
--- a/docs/gradient_boosting.md
+++ b/docs/gradient_boosting.md
@@ -1,0 +1,21 @@
+# Gradient Boosting
+
+`Ai4r::Classifiers::GradientBoosting` performs regression by fitting many simple linear models to the residuals of previous ones. The predictions of all learners are combined using a learning rate.
+
+## Parameters
+
+* `n_estimators` – number of boosting iterations. Default is `10`.
+* `learning_rate` – shrinkage factor applied to each learner. Default is `0.1`.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/gradient_boosting'
+require 'ai4r/data/data_set'
+
+set = Ai4r::Data::DataSet.new.parse_csv_with_labels('examples/classifiers/simple_linear_regression_example.csv')
+boost = Ai4r::Classifiers::GradientBoosting.new.build(set)
+puts boost.eval(set.data_items.first[0...-1])
+```
+
+This algorithm does not produce interpretable rules.

--- a/docs/hyperpipes.md
+++ b/docs/hyperpipes.md
@@ -20,11 +20,6 @@ puts classifier.eval(['Chicago', 85, 'F'])
 
 See `examples/classifiers/hyperpipes_example.rb` for a runnable sample.
 
-Hyperpipes is a fast baseline algorithm that creates one "pipe" per class.
-A pipe records value ranges for numeric attributes and sets of observed values
-for nominal attributes. New records are classified by counting how many
-attributes match each pipe.
-
 ## Parameters
 
 `tie_break` – determines how to break ties when several classes receive the
@@ -51,4 +46,4 @@ classifier.build(set)
 classifier.eval(['New York', 30, 'M'])
 ```
 
-Check [Classifier Bench](classifier_bench.md) to compare Hyperpipes with other classifiers.
+Compare results in the [Classifier Bench](classifier_bench.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,13 @@ require 'ai4r'
 * [Hyperpipes](hyperpipes.md) – baseline classifier using value ranges.
 * [IB1 Classifier](ib1.md) – instance-based nearest neighbour algorithm.
 * [Logistic Regression](logistic_regression.md) – binary classifier trained with gradient descent.
+* [OneR](one_r.md) – single attribute rules.
+* [ZeroR](zero_r.md) – majority class baseline.
+* [Random Forest](random_forest.md) – ensemble of decision trees.
+* [Support Vector Machine](support_vector_machine.md) – linear SVM with SGD.
+* [Gradient Boosting](gradient_boosting.md) – boosted regressors.
+* [Simple Linear Regression](simple_linear_regression.md) – fit a line to one attribute.
+* [Multilayer Perceptron](multilayer_perceptron.md) – neural network classifier.
 * [Reinforcement Learning](reinforcement_learning.md) – Q-learning and policy iteration.
 * [Search Algorithms](search_algorithms.md) – breadth-first and depth-first search implementations.
 * [Clusterer Bench](clusterer_bench.md) – compare clustering algorithms on small datasets.

--- a/docs/multilayer_perceptron.md
+++ b/docs/multilayer_perceptron.md
@@ -1,0 +1,25 @@
+# Multilayer Perceptron
+
+This wrapper trains a backpropagation neural network for classification. Inputs are one‑hot encoded and the last column of the dataset holds the class label.
+
+## Parameters
+
+* `network_class` – underlying network implementation. Default uses `Ai4r::NeuralNetwork::Backpropagation`.
+* `network_parameters` – options forwarded to the neural network constructor.
+* `hidden_layers` – array describing the hidden layer sizes. Default is an empty array.
+* `training_iterations` – number of training epochs. Default is `500`.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/multilayer_perceptron'
+require 'ai4r/data/data_set'
+
+items = [['New York', '<30', 'Y'], ['Chicago', '<30', 'N']]
+labels = %w[city age class]
+set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
+mlp = Ai4r::Classifiers::MultilayerPerceptron.new.set_parameters(hidden_layers: [5]).build(set)
+puts mlp.eval(['Chicago', '<30'])
+```
+
+For more background on neural networks see the [Neural Networks](neural_networks.md) page.

--- a/docs/naive_bayes.md
+++ b/docs/naive_bayes.md
@@ -27,16 +27,13 @@ puts classifier.get_probability_map(['Red', 'SUV', 'Domestic'])
 
 The last line prints a hash with the probability for each class.
 
-# Naive Bayes
-
-`Ai4r::Classifiers::NaiveBayes` computes several probability tables when built. These attributes are exposed as read-only accessors:
+`Ai4r::Classifiers::NaiveBayes` computes several probability tables you can inspect:
 
 * `class_prob` – Probability of each class in the training set.
-* `pcc` – Count of occurrences for every attribute value and class. Layout is `[attribute][value][class]`.
-* `pcp` – Conditional probability of an attribute value given a class. Shares the same layout as `pcc` and is derived from it using the `:m` parameter.
+* `pcc` – Count of attribute value and class occurrences.
+* `pcp` – Conditional probability of an attribute value given a class.
 
-Inspecting these arrays helps you understand the learned model.
-
+Inspect these arrays to understand the learned model.
 Run [Classifier Bench](classifier_bench.md) to see how Naive Bayes performs alongside other classifiers.
 
 

--- a/docs/one_r.md
+++ b/docs/one_r.md
@@ -1,0 +1,22 @@
+# OneR Classifier
+
+OneR selects the single attribute that yields the fewest classification errors and creates a rule for each of its values. Numeric attributes are discretized into a given number of bins (default: 10).
+
+## Parameters
+
+* `selected_attribute` – index of the attribute to force, otherwise the best attribute is chosen.
+* `tie_break` – strategy when two attributes have the same error rate, `:first` or `:last`.
+* `bin_count` – number of bins for numeric attributes.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/one_r'
+require 'ai4r/data/data_set'
+
+set = Ai4r::Data::DataSet.new.load_csv_with_labels('examples/classifiers/zero_one_r_data.csv')
+classifier = Ai4r::Classifiers::OneR.new.build(set)
+puts classifier.get_rules
+```
+
+See `examples/classifiers/zero_and_one_r_example.rb` for an interactive demo.

--- a/docs/prism.md
+++ b/docs/prism.md
@@ -45,3 +45,5 @@ classifier = Ai4r::Classifiers::Prism.new.build(data)
 puts classifier.eval([30, 70])
 ```
 
+Compare PRISM with other models in the [Classifier Bench](classifier_bench.md).
+

--- a/docs/random_forest.md
+++ b/docs/random_forest.md
@@ -1,0 +1,23 @@
+# Random Forest
+
+`Ai4r::Classifiers::RandomForest` builds an ensemble of ID3 decision trees from random samples of the data and feature set. Predictions are made by majority vote across all trees.
+
+## Parameters
+
+* `n_trees` – number of trees to build. Default is `10`.
+* `sample_size` – number of data items sampled for each tree.
+* `feature_fraction` – fraction of attributes sampled for each tree.
+* `random_seed` – seed to make the randomness reproducible.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/random_forest'
+require 'ai4r/data/data_set'
+
+set = Ai4r::Data::DataSet.new.load_csv_with_labels('examples/classifiers/id3_data.csv')
+forest = Ai4r::Classifiers::RandomForest.new.set_parameters(n_trees: 5).build(set)
+puts forest.eval(set.data_items.first[0...-1])
+```
+
+Random forests do not currently export human‑readable rules.

--- a/docs/simple_linear_regression.md
+++ b/docs/simple_linear_regression.md
@@ -1,0 +1,20 @@
+# Simple Linear Regression
+
+`Ai4r::Classifiers::SimpleLinearRegression` fits a straight line to predict a numeric output from a single attribute. When multiple attributes are present, the algorithm chooses the one that minimises mean squared error.
+
+## Parameters
+
+* `selected_attribute` – force the attribute index used for regression; otherwise the best attribute is selected automatically.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/simple_linear_regression'
+require 'ai4r/data/data_set'
+
+set = Ai4r::Data::DataSet.new.parse_csv_with_labels('examples/classifiers/simple_linear_regression_example.csv')
+model = Ai4r::Classifiers::SimpleLinearRegression.new.build(set)
+puts "Slope: #{model.slope}, Intercept: #{model.intercept}"
+```
+
+See `examples/classifiers/simple_linear_regression_example.rb` for a full script.

--- a/docs/support_vector_machine.md
+++ b/docs/support_vector_machine.md
@@ -1,0 +1,24 @@
+# Support Vector Machine
+
+`Ai4r::Classifiers::SupportVectorMachine` is a minimal linear SVM trained with stochastic gradient descent. Only numeric attributes and two classes are supported.
+
+## Parameters
+
+* `learning_rate` – gradient descent step size. Default is `0.01`.
+* `iterations` – number of training iterations. Default is `1000`.
+* `c` – regularisation strength. Default is `1.0`.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/support_vector_machine'
+require 'ai4r/data/data_set'
+
+items = [[0,0,'N'], [1,0,'N'], [0,1,'Y'], [1,1,'Y']]
+labels = %w[x1 x2 class]
+set = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
+svm = Ai4r::Classifiers::SupportVectorMachine.new.build(set)
+puts svm.eval([1,0])
+```
+
+SVM models do not generate human-readable rules.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -49,7 +49,7 @@ AI4R includes several algorithms:
 * [Transformer](transformer.md) for sequence processing
 * [Genetic Algorithms](genetic_algorithms.md) for optimization
 * Clustering with [KMeans](kmeans.md) and [Hierarchical Clustering](hierarchical_clustering.md)
-* Baseline classifiers like OneR, ZeroR and [Hyperpipes](hyperpipes.md)
+* Baseline classifiers like [OneR](one_r.md), [ZeroR](zero_r.md) and [Hyperpipes](hyperpipes.md)
 
 See the documents in this directory for detailed tutorials on each topic.
 

--- a/docs/zero_r.md
+++ b/docs/zero_r.md
@@ -1,0 +1,22 @@
+# ZeroR Classifier
+
+ZeroR picks the most frequent class in the training data and predicts that value for every new example. It is a sanity check often used to compare more elaborate algorithms against a trivial baseline.
+
+## Parameters
+
+* `default_class` – value returned when the dataset is empty.
+* `tie_break` – how to choose among classes with equal frequency. Options are `:first` or `:random`.
+* `random_seed` – seed for reproducible tie resolution.
+
+## Example
+
+```ruby
+require 'ai4r/classifiers/zero_r'
+require 'ai4r/data/data_set'
+
+set = Ai4r::Data::DataSet.new.load_csv_with_labels('examples/classifiers/zero_one_r_data.csv')
+classifier = Ai4r::Classifiers::ZeroR.new.build(set)
+puts classifier.eval(set.data_items.first)
+```
+
+See `examples/classifiers/zero_and_one_r_example.rb` for a longer walkthrough.


### PR DESCRIPTION
## Summary
- add documentation for ZeroR, OneR, Random Forest, SVM, Gradient Boosting, Simple Linear Regression and Multilayer Perceptron
- link new docs from the index and user guide
- simplify Hyperpipes, Prism and Naive Bayes docs
- keep docs consistent and cross-linked

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6876541d597883269091c2442fdf2747