### PR TITLE
Synchronize README and development guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,14 @@ This repository contains the AI4R Ruby gem. Follow these guidelines to speed up 
 
 ## Setup
 
-1. Install dependencies using Bundler:
+1. Ensure Ruby 3.2 or later is installed.
+2. Install dependencies using Bundler:
 
    ```bash
    bundle install
    ```
 
-2. Run the test suite before submitting changes:
+3. Run the test suite before submitting changes:
 
    ```bash
    bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Over time the project has stretched beyond classical techniques. A bite-sized Tr
 
 ## AI4R
 
-AI4R is distributed as a gem and works with modern versions of Ruby.
+AI4R is distributed as a gem and requires Ruby 3.2 or later.
 
 ### Installation
 
@@ -123,6 +123,12 @@ Install development dependencies with Bundler and run the test suite:
 bundle install
 bundle exec rake test
 ```
+
+### Limitations
+
+- Not optimized for performance
+- No support for GPU, parallelism, or distributed training
+- Not intended for production deployment
 
 ### Disclaimer
 


### PR DESCRIPTION
## Summary
- document Ruby 3.2 requirement in README and AGENTS
- add limitations section to README
- clarify setup steps in AGENTS

## Testing
- `bundle install`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_687656639b0c8326a996ce19e60aaba1