### PR TITLE
Improve search algorithm docs

### DIFF
--- a/docs/a_star_search.md
+++ b/docs/a_star_search.md
@@ -6,6 +6,8 @@ function returning adjacent nodes with their transition costs, and a
 heuristic estimating the remaining distance. A good heuristic dramatically
 reduces the number of explored states.
 
+See [Search Algorithms](search_algorithms.md) for BFS and DFS.
+
 ```ruby
 require 'ai4r/search'
 
@@ -34,4 +36,5 @@ $ ruby bench/search/search_bench.rb \
 
 Observe how `nodes_expanded` drops compared to BFS or DFS while the
 solution path remains the same. Encourage students to tweak the heuristic
-or design their own problems.
+or design their own problems. For probabilistic search consider
+[Monte Carlo Tree Search](monte_carlo_tree_search.md).

--- a/docs/monte_carlo_tree_search.md
+++ b/docs/monte_carlo_tree_search.md
@@ -2,6 +2,9 @@
 
 `Ai4r::Search::MCTS` implements the Monte Carlo Tree Search strategy used in many modern game agents. It works anywhere you can programmatically enumerate actions, transitions and rewards. The algorithm repeatedly selects a promising node, expands one child, performs a random simulation and backpropagates the reward.
 
+See [Search Algorithms](search_algorithms.md) for BFS and DFS or
+[A* Search](a_star_search.md) for heuristic search.
+
 ```ruby
 require 'ai4r/search'
 
@@ -26,4 +29,6 @@ The callbacks are:
 Only a few dozen iterations are often enough to obtain a good action in small games.
 
 Experiment with the parameters or plug in your own environment to see how the algorithm balances exploration and exploitation. MCTS shines when the search space is enormous but simulations are cheap.
-You can run the search benchmark under `bench/search` to compare MCTS with other search strategies.
+You can run the search benchmark under
+[`bench/search`](../bench/search) to compare MCTS with other
+search strategies.

--- a/docs/search_algorithms.md
+++ b/docs/search_algorithms.md
@@ -1,13 +1,14 @@
 # Search Algorithms
 
 `Ai4r::Search` collects a handful of classical techniques for exploring
-state spaces. The goal predicates and successor functions are tiny Ruby
-procs so you can prototype ideas in a few lines of code. Breadth-first
-search (BFS) expands the frontier level by level, whereas depth-first
-search (DFS) follows one branch as deep as it can. They both expect a
-`goal_test` and a `neighbor_fn` describing your problem space. For large
-graphs you can also try iterative deepening search (IDDFS) which mixes the
-two approaches.
+state spaces. Each algorithm only needs a `goal_test` and a `neighbor_fn`,
+so you can describe new problems in a few lines of Ruby.
+
+*Breadth-first search* (BFS) expands the frontier level by level, while
+*depth-first search* (DFS) follows one branch as deep as it can. Both
+return the path to the first goal node or `nil` when no goal is reachable.
+The search bench also provides an **iterative deepening** variant (IDDFS)
+for comparison.
 
 ```ruby
 require 'ai4r/search'
@@ -18,9 +19,6 @@ path = bfs.search(start)
 dfs = Ai4r::Search::DFS.new(goal_test, neighbor_fn)
 path = dfs.search(start)
 ```
-
-Both methods return the path from the start node to the first goal or
-`nil` when no goal is reachable.
 
 ## A tiny grid example
 
@@ -50,3 +48,9 @@ $ ruby bench/search/search_bench.rb \
 You will see an ASCII table summarizing nodes expanded and duration for
 each algorithm. The CSV export can be loaded into a spreadsheet for
 discussion.
+
+## More search strategies
+
+For heuristic path finding see [A* Search](a_star_search.md).
+For probabilistic exploration check
+[Monte Carlo Tree Search](monte_carlo_tree_search.md).


### PR DESCRIPTION
## Summary
- clarify BFS/DFS intro in Search Algorithms guide
- mention IDDFS benchmark and link to A* and MCTS docs
- cross-link docs between A* Search, Monte Carlo Tree Search and the Search Algorithms page

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687653c347b08326b5d5cde18918be2e