### PR TITLE
Fix top RuboCop issues

### DIFF
--- a/ai4r.gemspec
+++ b/ai4r.gemspec
@@ -14,7 +14,7 @@ SPEC = Gem::Specification.new do |s|
 
     With no external dependencies, no GPU support, and no production overhead, AI4R serves as a practical and transparent way to explore the foundations of AI in Ruby. It is a long-maintained open-source effort to bring accessible, hands-on machine learning to the Ruby community.
   DESC
-  s.required_ruby_version = '>= 3.2'
+  s.required_ruby_version = '>= 3.1'
   s.license = 'Unlicense'
   s.files = FileList['{examples,lib}/**/*'].to_a
   s.require_path = 'lib'

--- a/bench/classifier/classifier_bench.rb
+++ b/bench/classifier/classifier_bench.rb
@@ -9,6 +9,7 @@ require_relative 'runners/ib1_runner'
 require_relative 'runners/hyperpipes_runner'
 
 module Bench
+  # Entry point for running classifier benchmarks.
   module Classifier
     CLASS_METRICS = %i[accuracy f1 training_ms predict_ms model_size_kb].freeze
 

--- a/bench/classifier/runners/hyperpipes_runner.rb
+++ b/bench/classifier/runners/hyperpipes_runner.rb
@@ -7,6 +7,7 @@ require 'ai4r/classifiers/hyperpipes'
 module Bench
   module Classifier
     module Runners
+      # Benchmark runner for the Hyperpipes classifier.
       class HyperpipesRunner < Bench::Common::BaseRunner
         def initialize(train_set, test_set)
           @test_set = test_set

--- a/bench/classifier/runners/ib1_runner.rb
+++ b/bench/classifier/runners/ib1_runner.rb
@@ -7,6 +7,7 @@ require 'ai4r/classifiers/ib1'
 module Bench
   module Classifier
     module Runners
+      # Benchmark runner for the IB1 classifier.
       class Ib1Runner < Bench::Common::BaseRunner
         def initialize(train_set, test_set)
           @test_set = test_set

--- a/bench/classifier/runners/id3_runner.rb
+++ b/bench/classifier/runners/id3_runner.rb
@@ -7,6 +7,7 @@ require 'ai4r/classifiers/id3'
 module Bench
   module Classifier
     module Runners
+      # Benchmark runner for the ID3 classifier.
       class Id3Runner < Bench::Common::BaseRunner
         def initialize(train_set, test_set)
           @test_set = test_set

--- a/bench/classifier/runners/naive_bayes_runner.rb
+++ b/bench/classifier/runners/naive_bayes_runner.rb
@@ -7,6 +7,7 @@ require 'ai4r/classifiers/naive_bayes'
 module Bench
   module Classifier
     module Runners
+      # Benchmark runner for the Naive Bayes classifier.
       class NaiveBayesRunner < Bench::Common::BaseRunner
         def initialize(train_set, test_set)
           @test_set = test_set

--- a/bench/clusterer/cluster_bench.rb
+++ b/bench/clusterer/cluster_bench.rb
@@ -44,7 +44,9 @@ module Bench
         opts.on('--dataset FILE', 'CSV data file') { |v| options[:dataset] = v }
         opts.on('--k N', Integer, 'Number of clusters') { |v| options[:k] = v }
         opts.on('--epsilon N', Float, 'DBSCAN squared radius') { |v| options[:epsilon] = v }
-        opts.on('--min-points N', Integer, 'DBSCAN minimum neighbours') { |v| options[:min_points] = v }
+        opts.on('--min-points N', Integer, 'DBSCAN minimum neighbours') do |v|
+          options[:min_points] = v
+        end
         opts.on('--with-ground-truth', 'Use labels column') { options[:with_gt] = true }
       end
       options = cli.parse(argv)

--- a/bench/clusterer/runners/average_linkage_runner.rb
+++ b/bench/clusterer/runners/average_linkage_runner.rb
@@ -7,9 +7,10 @@ require 'ai4r/clusterers/average_linkage'
 module Bench
   module Clusterer
     module Runners
+      # Benchmark runner for Average Linkage clustering.
       class AverageLinkageRunner < Bench::Common::BaseRunner
-        def initialize(data_set, k)
-          @k = k
+        def initialize(data_set, k_value)
+          @k = k_value
           super(data_set)
         end
 

--- a/bench/clusterer/runners/dbscan_runner.rb
+++ b/bench/clusterer/runners/dbscan_runner.rb
@@ -7,6 +7,7 @@ require 'ai4r/clusterers/dbscan'
 module Bench
   module Clusterer
     module Runners
+      # Benchmark runner for DBSCAN clustering.
       class DbscanRunner < Bench::Common::BaseRunner
         def initialize(data_set, epsilon, min_points)
           @epsilon = epsilon

--- a/bench/clusterer/runners/diana_runner.rb
+++ b/bench/clusterer/runners/diana_runner.rb
@@ -7,9 +7,10 @@ require 'ai4r/clusterers/diana'
 module Bench
   module Clusterer
     module Runners
+      # Benchmark runner for DIANA clustering.
       class DianaRunner < Bench::Common::BaseRunner
-        def initialize(data_set, k)
-          @k = k
+        def initialize(data_set, k_value)
+          @k = k_value
           super(data_set)
         end
 

--- a/bench/clusterer/runners/kmeans_runner.rb
+++ b/bench/clusterer/runners/kmeans_runner.rb
@@ -5,9 +5,10 @@ require 'ai4r/clusterers/k_means'
 module Bench
   module Clusterer
     module Runners
+      # Benchmark runner for K-Means clustering.
       class KmeansRunner < Bench::Common::BaseRunner
-        def initialize(data_set, k)
-          @k = k
+        def initialize(data_set, k_value)
+          @k = k_value
           super(data_set)
         end
 

--- a/bench/clusterer/runners/single_linkage_runner.rb
+++ b/bench/clusterer/runners/single_linkage_runner.rb
@@ -5,9 +5,10 @@ require 'ai4r/clusterers/single_linkage'
 module Bench
   module Clusterer
     module Runners
+      # Benchmark runner for Single Linkage clustering.
       class SingleLinkageRunner < Bench::Common::BaseRunner
-        def initialize(data_set, k)
-          @k = k
+        def initialize(data_set, k_value)
+          @k = k_value
           super(data_set)
         end
 

--- a/bench/common/base_runner.rb
+++ b/bench/common/base_runner.rb
@@ -17,7 +17,7 @@ module Bench
         path = run
         duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
         @metrics[:duration_ms] = (duration * 1000).round(2)
-        @metrics[:solution_depth] = path ? path.length - 1 : nil
+        @metrics[:solution_depth] = path&.length&.-(1)
         @metrics[:completed] = !path.nil?
         Metrics.new(algo_name, @metrics)
       end

--- a/lib/ai4r/classifiers/hyperpipes.rb
+++ b/lib/ai4r/classifiers/hyperpipes.rb
@@ -16,6 +16,7 @@ require_relative '../classifiers/votes'
 
 module Ai4r
   module Classifiers
+    # Collection of classifier algorithms.
     include Ai4r::Data
 
     # = Introduction

--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -658,6 +658,7 @@ module Ai4r
       end
     end
 
+    # Raised when the training data is insufficient to build a model.
     class ModelFailureError < StandardError
       'There was not enough information during training to do a proper induction for this data element.'
     end

--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -55,6 +55,7 @@ module Ai4r
     #   b.eval(["Red", "SUV", "Domestic"])
     #
 
+    # Probabilistic classifier based on Bayes' theorem.
     class NaiveBayes < Classifier
       attr_reader :class_prob, :pcc, :pcp
 

--- a/lib/ai4r/data/parameterizable.rb
+++ b/lib/ai4r/data/parameterizable.rb
@@ -11,7 +11,9 @@
 
 module Ai4r
   module Data
+    # Mix-in to declare configurable parameters for algorithms.
     module Parameterizable
+      # Class-level helpers for Parameterizable.
       module ClassMethods
         # Get info on what can be parameterized on this algorithm.
         # It returns a hash with the following format:


### PR DESCRIPTION
## Summary
- bump gemspec to allow Ruby 3.1
- document benchmark modules and runners
- rename clusterer runner args for clarity
- simplify solution depth calculation
- add missing docs in library modules
- clean up CLI block formatting

## Testing
- `bundle exec rubocop`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_687652953b7083269fb9b6d54442630a