### PR TITLE
Reduce RuboCop offenses in examples

### DIFF
--- a/examples/classifiers/hyperpipes_example.rb
+++ b/examples/classifiers/hyperpipes_example.rb
@@ -3,15 +3,14 @@
 require_relative '../../lib/ai4r/classifiers/hyperpipes'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
+# Use fully qualified class names instead of including modules.
 
 # Load the training data
 file = "#{File.dirname(__FILE__)}/hyperpipes_data.csv"
-data = DataSet.new.parse_csv_with_labels(file)
+data = Ai4r::Data::DataSet.new.parse_csv_with_labels(file)
 
 # Build the classifier using custom parameters
-classifier = Hyperpipes.new.set_parameters(tie_break: :random).build(data)
+classifier = Ai4r::Classifiers::Hyperpipes.new.set_parameters(tie_break: :random).build(data)
 
 # Inspect the generated pipes
 pipes_summary = classifier.pipes

--- a/examples/classifiers/ib1_example.rb
+++ b/examples/classifiers/ib1_example.rb
@@ -3,13 +3,10 @@
 require_relative '../../lib/ai4r/classifiers/ib1'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 file = "#{File.dirname(__FILE__)}/hyperpipes_data.csv"
-data = DataSet.new.parse_csv_with_labels(file)
+data = Ai4r::Data::DataSet.new.parse_csv_with_labels(file)
 
-classifier = IB1.new.build(data)
+classifier = Ai4r::Classifiers::IB1.new.build(data)
 
 sample = ['Chicago', 55, 'M']
 puts "Prediction for #{sample.inspect}: #{classifier.eval(sample)}"

--- a/examples/classifiers/naive_bayes_attributes_example.rb
+++ b/examples/classifiers/naive_bayes_attributes_example.rb
@@ -3,13 +3,10 @@
 require_relative '../../lib/ai4r/classifiers/naive_bayes'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 file = "#{File.dirname(__FILE__)}/naive_bayes_data.csv"
-set = DataSet.new.load_csv_with_labels(file)
+set = Ai4r::Data::DataSet.new.load_csv_with_labels(file)
 
-bayes = NaiveBayes.new.set_parameters(m: 3).build(set)
+bayes = Ai4r::Classifiers::NaiveBayes.new.set_parameters(m: 3).build(set)
 
 puts bayes.class_prob.inspect
 puts bayes.pcc.inspect

--- a/examples/classifiers/naive_bayes_example.rb
+++ b/examples/classifiers/naive_bayes_example.rb
@@ -5,14 +5,11 @@ require_relative '../../lib/ai4r/data/data_set'
 require_relative '../../lib/ai4r/classifiers/id3'
 require 'benchmark'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
-data_set = DataSet.new
+data_set = Ai4r::Data::DataSet.new
 data_set.load_csv_with_labels "#{File.dirname(__FILE__)}/naive_bayes_data.csv"
 
-b = NaiveBayes.new
-              .set_parameters({ m: 3 })
-              .build data_set
+b = Ai4r::Classifiers::NaiveBayes.new
+                                 .set_parameters({ m: 3 })
+                                 .build data_set
 p b.eval(%w[Red SUV Domestic])
 p b.get_probability_map(%w[Red SUV Domestic])

--- a/examples/classifiers/one_r_example.rb
+++ b/examples/classifiers/one_r_example.rb
@@ -9,9 +9,6 @@
 require_relative '../../lib/ai4r/classifiers/one_r'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 items = [
   ['New York', 20, 'M', 'Y'],
   ['Chicago', 25, 'M', 'Y'],
@@ -23,8 +20,8 @@ items = [
 ]
 labels = %w[city age gender marketing_target]
 
-ds = DataSet.new(data_items: items, data_labels: labels)
+ds = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
 
-classifier = OneR.new.build(ds)
+classifier = Ai4r::Classifiers::OneR.new.build(ds)
 puts classifier.get_rules
 puts classifier.eval(['Chicago', 55, 'M'])

--- a/examples/classifiers/prism_nominal_example.rb
+++ b/examples/classifiers/prism_nominal_example.rb
@@ -3,13 +3,10 @@
 require_relative '../../lib/ai4r/classifiers/prism'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 data_file = "#{File.dirname(__FILE__)}/zero_one_r_data.csv"
-data = DataSet.new.load_csv_with_labels(data_file)
+data = Ai4r::Data::DataSet.new.load_csv_with_labels(data_file)
 
-classifier = Prism.new.build(data)
+classifier = Ai4r::Classifiers::Prism.new.build(data)
 
 puts 'Discovered rules:'
 puts classifier.get_rules

--- a/examples/classifiers/prism_numeric_example.rb
+++ b/examples/classifiers/prism_numeric_example.rb
@@ -3,9 +3,6 @@
 require_relative '../../lib/ai4r/classifiers/prism'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 items = [
   [20, 70, 'N'],
   [25, 80, 'N'],
@@ -14,9 +11,9 @@ items = [
 ]
 labels = %w[temperature humidity play]
 
-data = DataSet.new(data_items: items, data_labels: labels)
+data = Ai4r::Data::DataSet.new(data_items: items, data_labels: labels)
 
-classifier = Prism.new.build(data)
+classifier = Ai4r::Classifiers::Prism.new.build(data)
 
 puts 'Rules:'
 puts classifier.get_rules

--- a/examples/classifiers/simple_linear_regression_example.rb
+++ b/examples/classifiers/simple_linear_regression_example.rb
@@ -3,15 +3,12 @@
 require_relative '../../lib/ai4r/classifiers/simple_linear_regression'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 # Load training data
 file = "#{File.dirname(__FILE__)}/simple_linear_regression_example.csv"
-data_set = DataSet.new.parse_csv_with_labels file
+data_set = Ai4r::Data::DataSet.new.parse_csv_with_labels file
 
 # Build the regression model and inspect its coefficients
-r = SimpleLinearRegression.new.build data_set
+r = Ai4r::Classifiers::SimpleLinearRegression.new.build data_set
 puts "Selected attribute: #{r.attribute}"
 puts "Slope: #{r.slope}, Intercept: #{r.intercept}"
 

--- a/examples/classifiers/zero_and_one_r_example.rb
+++ b/examples/classifiers/zero_and_one_r_example.rb
@@ -4,33 +4,31 @@ require_relative '../../lib/ai4r/classifiers/zero_r'
 require_relative '../../lib/ai4r/classifiers/one_r'
 require_relative '../../lib/ai4r/data/data_set'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 # Load tutorial data
 data_file = "#{File.dirname(__FILE__)}/zero_one_r_data.csv"
-data = DataSet.new.load_csv_with_labels data_file
+data = Ai4r::Data::DataSet.new.load_csv_with_labels data_file
 
 puts "Data labels: #{data.data_labels.inspect}"
 puts
 
 # Build a default ZeroR classifier
-zero_default = ZeroR.new.build(data)
+zero_default = Ai4r::Classifiers::ZeroR.new.build(data)
 puts "ZeroR default prediction: #{zero_default.eval(data.data_items.first)}"
 puts "Generated rule: #{zero_default.get_rules}"
 
 # Build ZeroR with custom tie strategy
-zero_random = ZeroR.new.set_parameters(tie_break: :random).build(data)
+zero_random = Ai4r::Classifiers::ZeroR.new.set_parameters(tie_break: :random).build(data)
 puts "ZeroR random tie strategy prediction: #{zero_random.eval(data.data_items.first)}"
 
 puts
 
 # Build a default OneR classifier
-one_default = OneR.new.build(data)
+one_default = Ai4r::Classifiers::OneR.new.build(data)
 puts "OneR chose attribute index #{one_default.rule[:attr_index]}"
 puts "OneR rules:\n#{one_default.get_rules}"
 
 # Build OneR selecting the first attribute and using :last tie break
-one_custom = OneR.new.set_parameters(selected_attribute: 0, tie_break: :last).build(data)
+one_custom = Ai4r::Classifiers::OneR.new.set_parameters(selected_attribute: 0,
+                                                        tie_break: :last).build(data)
 puts "OneR forced attribute: #{one_custom.rule[:attr_index]}"
 puts "Custom rules:\n#{one_custom.get_rules}"

--- a/examples/clusterers/dbscan_example.rb
+++ b/examples/clusterers/dbscan_example.rb
@@ -2,17 +2,15 @@
 
 # Example showcasing DBSCAN clustering with custom parameters.
 require 'ai4r'
-include Ai4r::Clusterers
-include Ai4r::Data
 
 points = [
-  [1,1], [1,2], [1,3], [2,1], [2,2], [2,3],
-  [8,8], [8,9], [8,10], [9,8], [9,9], [9,10],
-  [5,5], [1,9], [10,0]
+  [1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3],
+  [8, 8], [8, 9], [8, 10], [9, 8], [9, 9], [9, 10],
+  [5, 5], [1, 9], [10, 0]
 ]
-set = DataSet.new(data_items: points)
+set = Ai4r::Data::DataSet.new(data_items: points)
 
-clusterer = DBSCAN.new
+clusterer = Ai4r::Clusterers::DBSCAN.new
 clusterer.set_parameters(epsilon: 10, min_points: 2).build(set)
 
 pp clusterer.labels

--- a/lib/ai4r/classifiers/simple_linear_regression.rb
+++ b/lib/ai4r/classifiers/simple_linear_regression.rb
@@ -61,7 +61,7 @@ module Ai4r
       # @param data [Object]
       # @return [Object]
       def build(data)
-        raise 'Error instance must be passed' unless data.is_a?(DataSet)
+        raise 'Error instance must be passed' unless data.is_a?(Ai4r::Data::DataSet)
         raise 'Data should not be empty' if data.data_items.empty?
 
         y_mean = data.get_mean_or_mode[data.num_attributes - 1]


### PR DESCRIPTION
## Summary
- use fully qualified constant names in example scripts
- update `SimpleLinearRegression` to check DataSet via namespace

## Testing
- `bundle exec rake test`
- `bundle exec rubocop -D --format offenses`

------
https://chatgpt.com/codex/tasks/task_e_687670ef0800832691f1de8ef6613ca6