### PR TITLE
Fix IB1 each_value bug

### DIFF
--- a/lib/ai4r/classifiers/ib1.rb
+++ b/lib/ai4r/classifiers/ib1.rb
@@ -97,7 +97,7 @@ module Ai4r
         end
 
         counts = Hash.new(0)
-        k_neighbors.each_value { |klass| counts[klass] += 1 }
+        k_neighbors.each { |_, klass| counts[klass] += 1 }
         max_votes = counts.values.max
         tied = counts.select { |_, v| v == max_votes }.keys
 
@@ -109,7 +109,7 @@ module Ai4r
         when :random
           tied.sample(random: rng)
         else
-          k_neighbors.each_value { |klass| return klass if tied.include?(klass) }
+          k_neighbors.each { |_, klass| return klass if tied.include?(klass) }
         end
       end
 


### PR DESCRIPTION
## Summary
- fix `IB1#eval` neighbor iteration to avoid each_value on arrays

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68769e37fc84832698a35c950739c5d1