### PR TITLE
Reduce RuboCop offenses

### DIFF
--- a/lib/ai4r/clusterers/average_linkage.rb
+++ b/lib/ai4r/clusterers/average_linkage.rb
@@ -69,9 +69,9 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        (read_distance_matrix(cx, ci) +
-          read_distance_matrix(cx, cj)) / 2
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        (read_distance_matrix(cluster_x, cluster_i) +
+          read_distance_matrix(cluster_x, cluster_j)) / 2
       end
     end
   end

--- a/lib/ai4r/clusterers/centroid_linkage.rb
+++ b/lib/ai4r/clusterers/centroid_linkage.rb
@@ -70,12 +70,12 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        ni = @index_clusters[ci].length
-        nj = @index_clusters[cj].length
-        ((ni * read_distance_matrix(cx, ci)) +
-          (nj * read_distance_matrix(cx, cj)) -
-         (1.0 * ni * nj * read_distance_matrix(ci, cj) / (ni + nj))) / (ni + nj)
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        ni = @index_clusters[cluster_i].length
+        nj = @index_clusters[cluster_j].length
+        ((ni * read_distance_matrix(cluster_x, cluster_i)) +
+          (nj * read_distance_matrix(cluster_x, cluster_j)) -
+         (1.0 * ni * nj * read_distance_matrix(cluster_i, cluster_j) / (ni + nj))) / (ni + nj)
       end
     end
   end

--- a/lib/ai4r/clusterers/complete_linkage.rb
+++ b/lib/ai4r/clusterers/complete_linkage.rb
@@ -57,9 +57,9 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        [read_distance_matrix(cx, ci),
-         read_distance_matrix(cx, cj)].max
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        [read_distance_matrix(cluster_x, cluster_i),
+         read_distance_matrix(cluster_x, cluster_j)].max
       end
 
       # @param data_item [Object]

--- a/lib/ai4r/clusterers/median_linkage.rb
+++ b/lib/ai4r/clusterers/median_linkage.rb
@@ -67,10 +67,10 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        ((0.5 * read_distance_matrix(cx, ci)) +
-          (0.5  * read_distance_matrix(cx, cj)) -
-          (0.25 * read_distance_matrix(ci, cj)))
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        ((0.5 * read_distance_matrix(cluster_x, cluster_i)) +
+          (0.5  * read_distance_matrix(cluster_x, cluster_j)) -
+          (0.25 * read_distance_matrix(cluster_i, cluster_j)))
       end
     end
   end

--- a/lib/ai4r/clusterers/single_linkage.rb
+++ b/lib/ai4r/clusterers/single_linkage.rb
@@ -230,9 +230,9 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        [read_distance_matrix(cx, ci),
-         read_distance_matrix(cx, cj)].min
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        [read_distance_matrix(cluster_x, cluster_i),
+         read_distance_matrix(cluster_x, cluster_j)].min
       end
 
       # cluster_a and cluster_b are removed from index_cluster,

--- a/lib/ai4r/clusterers/ward_linkage.rb
+++ b/lib/ai4r/clusterers/ward_linkage.rb
@@ -67,13 +67,13 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        ni = @index_clusters[ci].length
-        nj = @index_clusters[cj].length
-        nx = @index_clusters[cx].length
-        ((((1.0 * (ni + nx) * read_distance_matrix(cx, ci)) +
-            (1.0 * (nj + nx) * read_distance_matrix(cx, cj))) / (ni + nj + nx)) -
-            (1.0 * nx * read_distance_matrix(ci, cj) / ((ni + nj)**2)))
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        ni = @index_clusters[cluster_i].length
+        nj = @index_clusters[cluster_j].length
+        nx = @index_clusters[cluster_x].length
+        ((((1.0 * (ni + nx) * read_distance_matrix(cluster_x, cluster_i)) +
+            (1.0 * (nj + nx) * read_distance_matrix(cluster_x, cluster_j))) / (ni + nj + nx)) -
+            (1.0 * nx * read_distance_matrix(cluster_i, cluster_j) / ((ni + nj)**2)))
       end
     end
   end

--- a/lib/ai4r/clusterers/weighted_average_linkage.rb
+++ b/lib/ai4r/clusterers/weighted_average_linkage.rb
@@ -66,11 +66,11 @@ module Ai4r
       # @param ci [Object]
       # @param cj [Object]
       # @return [Object]
-      def linkage_distance(cx, ci, cj)
-        ni = @index_clusters[ci].length
-        nj = @index_clusters[cj].length
-        ((1.0 * ni * read_distance_matrix(cx, ci)) +
-          (nj * read_distance_matrix(cx, cj))) / (ni + nj)
+      def linkage_distance(cluster_x, cluster_i, cluster_j)
+        ni = @index_clusters[cluster_i].length
+        nj = @index_clusters[cluster_j].length
+        ((1.0 * ni * read_distance_matrix(cluster_x, cluster_i)) +
+          (nj * read_distance_matrix(cluster_x, cluster_j))) / (ni + nj)
       end
     end
   end

--- a/lib/ai4r/data/proximity.rb
+++ b/lib/ai4r/data/proximity.rb
@@ -15,10 +15,10 @@ module Ai4r
     module Proximity
       # This is a faster computational replacement for eclidean distance.
       # Parameters a and b are vectors with continuous attributes.
-      def squared_euclidean_distance(a, b)
+      def squared_euclidean_distance(vec_a, vec_b)
         sum = 0.0
-        a.each_with_index do |item_a, i|
-          item_b = b[i]
+        vec_a.each_with_index do |item_a, i|
+          item_b = vec_b[i]
           sum += (item_a - item_b)**2
         end
         sum
@@ -33,16 +33,16 @@ module Ai4r
       # If attributes are measured with different units,
       # attributes with larger values and variance will
       # dominate the metric.
-      def euclidean_distance(a, b)
-        Math.sqrt(squared_euclidean_distance(a, b))
+      def euclidean_distance(vec_a, vec_b)
+        Math.sqrt(squared_euclidean_distance(vec_a, vec_b))
       end
 
       # city block, Manhattan distance, or L1 norm.
       # Parameters a and b are vectors with continuous attributes.
-      def manhattan_distance(a, b)
+      def manhattan_distance(vec_a, vec_b)
         sum = 0.0
-        a.each_with_index do |item_a, i|
-          item_b = b[i]
+        vec_a.each_with_index do |item_a, i|
+          item_b = vec_b[i]
           sum += (item_a - item_b).abs
         end
         sum
@@ -50,10 +50,10 @@ module Ai4r
 
       # Sup distance, or L-intinity norm
       # Parameters a and b are vectors with continuous attributes.
-      def sup_distance(a, b)
+      def sup_distance(vec_a, vec_b)
         distance = 0.0
-        a.each_with_index do |item_a, i|
-          item_b = b[i]
+        vec_a.each_with_index do |item_a, i|
+          item_b = vec_b[i]
           diff = (item_a - item_b).abs
           distance = diff if diff > distance
         end
@@ -65,10 +65,10 @@ module Ai4r
       # vectors are different
       # This distance function is frequently used with binary attributes,
       # though it can be used with other discrete attributes.
-      def hamming_distance(a, b)
+      def hamming_distance(vec_a, vec_b)
         count = 0
-        a.each_index do |i|
-          count += 1 if a[i] != b[i]
+        vec_a.each_index do |i|
+          count += 1 if vec_a[i] != vec_b[i]
         end
         count
       end
@@ -84,10 +84,10 @@ module Ai4r
       # * a and b must not include repeated items
       # * all attributes are treated equally
       # * all attributes are treated equally
-      def simple_matching_distance(a, b)
+      def simple_matching_distance(vec_a, vec_b)
         similarity = 0.0
-        a.each { |item| similarity += 2 if b.include?(item) }
-        similarity /= (a.length + b.length)
+        vec_a.each { |item| similarity += 2 if vec_b.include?(item) }
+        similarity /= (vec_a.length + vec_b.length)
         (1.0 / similarity) - 1
       end
 
@@ -98,15 +98,15 @@ module Ai4r
       # Parameters a and b are vectors with continuous attributes.
       #
       # D = sum(a[i] * b[i]) / sqrt(sum(a[i]**2)) * sqrt(sum(b[i]**2))
-      def cosine_distance(a, b)
+      def cosine_distance(vec_a, vec_b)
         dot_product = 0.0
         norm_a = 0.0
         norm_b = 0.0
 
-        a.each_index do |i|
-          dot_product += a[i] * b[i]
-          norm_a += a[i]**2
-          norm_b += b[i]**2
+        vec_a.each_index do |i|
+          dot_product += vec_a[i] * vec_b[i]
+          norm_a += vec_a[i]**2
+          norm_b += vec_b[i]**2
         end
 
         magnitude = Math.sqrt(norm_a) * Math.sqrt(norm_b)

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -51,13 +51,13 @@ class HyperpipesTest < Minitest::Test
 
   def test_get_rules
     classifier = Hyperpipes.new.build(@data_set)
-    age = 28
-    gender = 'M'
+    age = 28 # rubocop:disable Lint/UselessAssignment
+    gender = 'M' # rubocop:disable Lint/UselessAssignment
     marketing_target = nil
     eval classifier.get_rules
     assert_equal 'Y', marketing_target
-    age = 44
-    city = 'New York'
+    age = 44 # rubocop:disable Lint/UselessAssignment
+    city = 'New York' # rubocop:disable Lint/UselessAssignment
     eval classifier.get_rules
     assert_equal 'N', marketing_target
   end

--- a/test/classifiers/id3_test.rb
+++ b/test/classifiers/id3_test.rb
@@ -239,12 +239,12 @@ class ID3Test < Minitest::Test
     id3 = ID3.new.build(DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS))
     # if age_range='<30' then marketing_target='Y'
     marketing_target = nil
-    age_range = '<30'
+    age_range = '<30' # rubocop:disable Lint/UselessAssignment
     eval id3.get_rules
     assert_equal 'Y', marketing_target
     # if age_range='[30-50)' and city='New York' then marketing_target='N'
-    age_range = '[30-50)'
-    city = 'New York'
+    age_range = '[30-50)' # rubocop:disable Lint/UselessAssignment
+    city = 'New York' # rubocop:disable Lint/UselessAssignment
     eval id3.get_rules
     assert_equal 'N', marketing_target
   end

--- a/test/classifiers/one_r_test.rb
+++ b/test/classifiers/one_r_test.rb
@@ -44,16 +44,16 @@ class OneRTest < Minitest::Test
     classifier = OneR.new.build(DataSet.new(data_items: @@data_examples,
                                             data_labels: @@data_labels))
     marketing_target = nil
-    age = nil
+    age = nil # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_nil(marketing_target)
-    age = 20
+    age = 20 # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
-    age = 35
+    age = 35 # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_equal('N', marketing_target)
-    age = 55
+    age = 55 # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_equal('N', marketing_target)
   end

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -46,21 +46,21 @@ class PrismTest < Minitest::Test
     classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: @@data_examples,
                                                                 data_labels: @@data_labels))
     marketing_target = nil
-    age_range = nil
-    city = 'Chicago'
+    age_range = nil # rubocop:disable Lint/UselessAssignment
+    city = 'Chicago' # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
-    age_range = '<30'
-    eval(classifier.get_rules)
-    assert_equal('Y', marketing_target)
+    age_range = '<30' # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
     eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
-    age_range = '[30-50)'
-    city = 'New York'
+    eval(classifier.get_rules)
+    assert_equal('Y', marketing_target)
+    age_range = '[30-50)' # rubocop:disable Lint/UselessAssignment
+    city = 'New York' # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_equal('N', marketing_target)
-    age_range = '[50-80]'
+    age_range = '[50-80]' # rubocop:disable Lint/UselessAssignment
     eval(classifier.get_rules)
     assert_equal('N', marketing_target)
   end


### PR DESCRIPTION
## Summary
- run `rubocop -A` and manually update parameter names in clusterer classes
- rename vector arguments in `Proximity` helpers
- silence unused variable warnings in several tests

## Testing
- `bundle exec rubocop`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6876b8bd78208326b6f8578e5d1c428c