### PR TITLE
Improve bench documentation

### DIFF
--- a/docs/benches_overview.md
+++ b/docs/benches_overview.md
@@ -6,9 +6,9 @@ problems. Shared helpers such as the CLI, metrics and table reporter reside in
 `bench/common`.
 
 Labs exist for search algorithms, clustering algorithms and classifiers:
-- [`bench/search`](../bench/search)
-- [`bench/clusterer`](../bench/clusterer)
-- [`bench/classifier`](../bench/classifier)
+- [`bench/search`](../bench/search) – see [search_bench.md](search_bench.md)
+- [`bench/clusterer`](../bench/clusterer) – see [clusterer_bench.md](clusterer_bench.md)
+- [`bench/classifier`](../bench/classifier) – see [classifier_bench.md](classifier_bench.md)
 
 ## Adding a new lab
 

--- a/docs/classifier_bench.md
+++ b/docs/classifier_bench.md
@@ -19,3 +19,22 @@ speed.
 The bench is a quick way to compare [ID3](machine_learning.md),
 [Naive Bayes](naive_bayes.md), [IB1](ib1.md) and
 [Hyperpipes](hyperpipes.md) on the same dataset.
+
+## Walk through the iris example
+
+1. Navigate to the project root and run the command above. Add `-Ilib` if you haven't installed the gem locally.
+2. The script loads `bench/classifier/datasets/iris.csv` which holds 150 flower measurements with a `species` label.
+3. Records are shuffled and split 70/30 into training and test sets.
+4. Each selected algorithm builds a model from the training data and predicts the holdout set.
+5. The console prints a table of metrics for every classifier. An extra table marks which algorithms are accurate, fast or interpretable.
+6. The `--export` option writes the same information to a CSV file for later review.
+
+Example output:
+
+```text
+algorithm  | accuracy | f1   | training_ms | predict_ms | model_size_kb
+-----------------------------------------------------------------------
+id3        | 0.93     | 0.94 | 8.54        | 0.07       | 3.4
+ib1        | 0.96     | 0.96 | 0.14        | 41.02      | 3.12
+hyperpipes | 0.91     | 0.92 | 0.34        | 2.3        | 3.31
+```

--- a/docs/clusterer_bench.md
+++ b/docs/clusterer_bench.md
@@ -14,3 +14,21 @@ ruby bench/clusterer/cluster_bench.rb \
 
 `--epsilon` and `--min-points` only apply to DBSCAN. Results are shown in an
 ASCII table and can be exported to CSV.
+
+## Walk through the blobs example
+
+1. Execute the command above from the project root. Use `-Ilib` if the gem isn't installed.
+2. `bench/clusterer/datasets/blobs.csv` contains 300 two‑dimensional points plus a label column used only for evaluation.
+3. The bench builds three clusters with each selected algorithm.
+4. Metrics such as silhouette coefficient and SSE are printed to the terminal.
+5. A second table highlights algorithms that are fast or memory intensive.
+6. Passing `--export` writes all metrics to a CSV file.
+
+Example output:
+
+```text
+algorithm | silhouette         | sse               | duration_ms | notes
+--------------------------------------------------------------------------
+kmeans    | 0.9120608842715905 | 607.6781788299999 | 15.41       | iter=5
+dbscan    | 0.9120608842715913 |                   | 161.88      | eps=4.0
+```

--- a/docs/search_bench.md
+++ b/docs/search_bench.md
@@ -1,0 +1,26 @@
+# Search Bench
+
+Benchmark BFS, DFS, IDDFS and A* on small search problems. The bench shares the common CLI with other labs.
+
+```bash
+ruby -Ilib bench/search/search_bench.rb \
+    --problem grid --map bench/search/maps/small.txt \
+    --algos bfs,a_star
+```
+
+## Walk through the grid example
+
+1. The map file `bench/search/maps/small.txt` defines a 5x4 maze where `S` is the start and `G` the goal.
+2. Running the command loads the grid problem and searches for a path using BFS and A*.
+3. Metrics such as solution depth, nodes expanded and runtime are printed as a table.
+4. A second table marks algorithms that are compact or fast.
+5. Use `--export FILE` to save the metrics as CSV for later analysis.
+
+Example output:
+
+```text
+algorithm | solution_depth | nodes_expanded | max_frontier_size | duration_ms | completed
+-----------------------------------------------------------------------------------------
+bfs       | 3              | 4              | 2                 | 0.04        | true
+astar     | 3              | 4              | 2                 | 0.06        | true
+```


### PR DESCRIPTION
## Summary
- document how to walk through the classifier bench example
- document how to walk through the clusterer bench example
- add a new walkthrough for the search bench
- cross-reference bench docs in benches overview

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687782fde86483268fb4b0adf2ffaefc