### PR TITLE
Fix top Rubocop violations

### DIFF
--- a/lib/ai4r/classifiers/naive_bayes.rb
+++ b/lib/ai4r/classifiers/naive_bayes.rb
@@ -66,6 +66,7 @@ module Ai4r
 
       # @return [Object]
       def initialize
+        super()
         @m = 0
         @unknown_value_strategy = :ignore
         @class_counts = []

--- a/lib/ai4r/classifiers/prism.rb
+++ b/lib/ai4r/classifiers/prism.rb
@@ -36,6 +36,7 @@ module Ai4r
       )
 
       def initialize
+        super()
         @fallback_class = nil
         @bin_count = 10
         @attr_bins = {}
@@ -71,7 +72,7 @@ module Ai4r
         instances = @data_set.data_items.collect { |data| data }
         @rules = []
         domains.last.each do |class_value|
-          while has_class_value(instances, class_value)
+          while class_value?(instances, class_value)
             rule = build_rule(class_value, instances)
             @rules << rule
             instances = instances.reject { |data| matches_conditions(data, rule[:conditions]) }
@@ -131,15 +132,14 @@ module Ai4r
       # @param instances [Object]
       # @param class_value [Object]
       # @return [Object]
-      def has_class_value(instances, class_value)
-        instances.each { |data| return true if data.last == class_value }
-        false
+      def class_value?(instances, class_value)
+        instances.any? { |data| data.last == class_value }
       end
 
       # @param instances [Object]
       # @param rule [Object]
       # @return [Object]
-      def is_perfect(instances, rule)
+      def perfect?(instances, rule)
         class_value = rule[:class_value]
         instances.each do |data|
           return false if (data.last != class_value) && matches_conditions(data, rule[:conditions])
@@ -169,7 +169,7 @@ module Ai4r
         rule = { class_value: class_value, conditions: {} }
         rule_instances = instances.collect { |data| data }
         attributes = @data_set.data_labels[0...-1].collect { |label| label }
-        until is_perfect(instances, rule) || attributes.empty?
+        until perfect?(instances, rule) || attributes.empty?
           freq_table = build_freq_table(rule_instances, attributes, class_value)
           condition = get_condition(freq_table)
           rule[:conditions].merge!(condition)

--- a/lib/ai4r/classifiers/random_forest.rb
+++ b/lib/ai4r/classifiers/random_forest.rb
@@ -13,15 +13,18 @@ require_relative 'votes'
 
 module Ai4r
   module Classifiers
+    # RandomForest ensemble classifier built from decision trees.
     class RandomForest < Classifier
       parameters_info n_trees: 'Number of trees to build. Default 10.',
                       sample_size: 'Number of data items for each tree (with replacement). Default: data set size.',
-                      feature_fraction: 'Fraction of attributes sampled for each tree. Default: sqrt(num_attributes)/num_attributes.',
+                      feature_fraction:
+                        'Fraction of attributes sampled for each tree. Default: sqrt(num_attributes)/num_attributes.',
                       random_seed: 'Seed for reproducible randomness.'
 
       attr_reader :trees, :features
 
       def initialize
+        super()
         @n_trees = 10
         @sample_size = nil
         @feature_fraction = nil

--- a/lib/ai4r/classifiers/support_vector_machine.rb
+++ b/lib/ai4r/classifiers/support_vector_machine.rb
@@ -26,6 +26,7 @@ module Ai4r
                       c: 'Regularization strength.'
 
       def initialize
+        super()
         @learning_rate = 0.01
         @iterations = 1000
         @c = 1.0


### PR DESCRIPTION
## Summary
- shorten a long string in id3 rules
- add initialization super calls
- document and refactor random forest and simple linear regression
- refactor OneR rule builder to reduce length
- rename predicate methods in prism
- adjust SVM initializer

## Testing
- `bundle exec rake test`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_687786e9a700832685f80008ba31aad6