### PR TITLE
Fix LogisticRegression input dimension handling

### DIFF
--- a/lib/ai4r/classifiers/logistic_regression.rb
+++ b/lib/ai4r/classifiers/logistic_regression.rb
@@ -71,7 +71,16 @@ module Ai4r
       def eval(data)
         raise 'Model not trained' unless @weights
 
-        z = data.each_with_index.inject(@weights.last) { |s, (v, j)| s + (v.to_f * @weights[j]) }
+        expected_size = @weights.length - 1
+        if data.length != expected_size
+          raise ArgumentError,
+                "Wrong number of inputs. Expected: #{expected_size}, " \
+                "received: #{data.length}."
+        end
+
+        z = data.each_with_index.inject(@weights.last) do |s, (v, j)|
+          s + (v.to_f * @weights[j])
+        end
         prob = 1.0 / (1.0 + Math.exp(-z))
         prob >= 0.5 ? 1 : 0
       end

--- a/test/classifiers/logistic_regression_test.rb
+++ b/test/classifiers/logistic_regression_test.rb
@@ -30,6 +30,10 @@ class LogisticRegressionTest < Minitest::Test
     assert_equal 1, @classifier.eval([1, 1])
   end
 
+  def test_eval_dimension_mismatch
+    assert_raises(ArgumentError) { @classifier.eval([0, 0, 1]) }
+  end
+
   def test_weights_present
     assert_equal 3, @classifier.weights.length
   end


### PR DESCRIPTION
## Summary
- validate input length when evaluating LogisticRegression models
- test dimension mismatch behavior

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68779afa26d8832b9dbfe1fd98aa4759