### PR TITLE
Fix comment typo in Parameterizable

### DIFF
--- a/lib/ai4r/data/parameterizable.rb
+++ b/lib/ai4r/data/parameterizable.rb
@@ -37,7 +37,7 @@ module Ai4r
       end
 
       # Set parameter values on this algorithm instance.
-      # You must provide a hash with the folowing format:
+      # You must provide a hash with the following format:
       # { :param_name => parameter_value }
       # @param params [Object]
       # @return [Object]
@@ -49,7 +49,7 @@ module Ai4r
       end
 
       # Get parameter values on this algorithm instance.
-      # Returns a hash with the folowing format:
+      # Returns a hash with the following format:
       # { :param_name => parameter_value }
       # @return [Object]
       def get_parameters


### PR DESCRIPTION
## Summary
- fix typos in the comments for `set_parameters` and `get_parameters`

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68779daa24c0832b8359880a4b56230d