### PR TITLE
Add BFS start node test

### DIFF
--- a/test/unit/search/bfs_test.rb
+++ b/test/unit/search/bfs_test.rb
@@ -29,6 +29,12 @@ class BFSTest < Minitest::Test
     assert_equal %i[a b d], path
   end
 
+  def test_search_uses_initialized_start
+    bfs = BFS.new(method(:goal_test), method(:neighbor_fn), :a)
+    path = bfs.search
+    assert_equal %i[a b d], path
+  end
+
   def goal_test_unreach(node)
     node == :x
   end


### PR DESCRIPTION
## Summary
- ensure BFS#search uses start node from initialization

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68779db3cf38832bad586ca59e3ddda8