### PR TITLE
Reduce Rubocop violations

### DIFF
--- a/lib/ai4r/classifiers/id3.rb
+++ b/lib/ai4r/classifiers/id3.rb
@@ -196,8 +196,6 @@ module Ai4r
         self
       end
 
-      private
-
       # @param data_examples [Object]
       # @return [Object]
       def preprocess_data(data_examples)
@@ -295,6 +293,8 @@ module Ai4r
 
         Math.log(z) / LOG2
       end
+
+      private
 
 
       # @param examples [Object]

--- a/lib/ai4r/classifiers/simple_linear_regression.rb
+++ b/lib/ai4r/classifiers/simple_linear_regression.rb
@@ -67,11 +67,11 @@ module Ai4r
 
         y_mean = data.get_mean_or_mode[data.num_attributes - 1]
         result = if @selected_attribute
-                    evaluate_attribute(data, @selected_attribute, y_mean)
-                  else
-                    evaluate_all_attributes(data, y_mean)
-                  end
-        assign_result(data, result, y_mean)
+                   evaluate_attribute(data, @selected_attribute, y_mean)
+                 else
+                   evaluate_all_attributes(data, y_mean)
+                 end
+        assign_result(data, result)
       end
 
       def validate_data(data)
@@ -105,7 +105,7 @@ module Ai4r
         result
       end
 
-      def assign_result(data, result, y_mean)
+      def assign_result(data, result)
         raise 'no useful attribute found' if result[:chosen] == -1
 
         @attribute = data.data_labels[result[:chosen]]

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -14,17 +14,16 @@ require_relative '../test_helper'
 require 'set'
 require 'yaml'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 class HyperpipesTest < Minitest::Test
+  include Ai4r::Classifiers
+  include Ai4r::Data
   fixture = YAML.load_file(File.expand_path('../fixtures/marketing_target_numeric.yml', __dir__))
 
-  @@data_labels = fixture['data_labels']
-  @@data_items  = fixture['data_items']
+  DATA_LABELS = fixture['data_labels']
+  DATA_ITEMS  = fixture['data_items']
 
   def setup
-    @data_set = DataSet.new(data_items: @@data_items, data_labels: @@data_labels)
+    @data_set = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
   end
 
   def test_build_pipe
@@ -54,11 +53,11 @@ class HyperpipesTest < Minitest::Test
     age = 28 # rubocop:disable Lint/UselessAssignment
     gender = 'M' # rubocop:disable Lint/UselessAssignment
     marketing_target = nil
-    eval classifier.get_rules
+    instance_eval classifier.get_rules
     assert_equal 'Y', marketing_target
     age = 44 # rubocop:disable Lint/UselessAssignment
     city = 'New York' # rubocop:disable Lint/UselessAssignment
-    eval classifier.get_rules
+    instance_eval classifier.get_rules
     assert_equal 'N', marketing_target
   end
 

--- a/test/classifiers/ib1_test.rb
+++ b/test/classifiers/ib1_test.rb
@@ -12,28 +12,27 @@
 require 'ai4r/classifiers/ib1'
 require_relative '../test_helper'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 class IB1Test < Minitest::Test
-  @@data_labels = %w[city age gender marketing_target]
+  include Ai4r::Classifiers
+  include Ai4r::Data
+  DATA_LABELS = %w[city age gender marketing_target].freeze
 
-  @@data_items = [['New York',  25, 'M', 'Y'],
-                  ['New York',  23, 'M', 'Y'],
-                  ['New York',  18, 'M', 'Y'],
-                  ['Chicago',   43, 'M', 'Y'],
-                  ['New York',  34, 'F', 'N'],
-                  ['Chicago',   33, 'F', 'Y'],
-                  ['New York',  31, 'F', 'N'],
-                  ['Chicago',   55, 'M', 'N'],
-                  ['New York',  58, 'F', 'N'],
-                  ['New York',  59, 'M', 'N'],
-                  ['Chicago',   71, 'M', 'N'],
-                  ['New York',  60, 'F', 'N'],
-                  ['Chicago',   85, 'F', 'Y']]
+  DATA_ITEMS = [['New York', 25, 'M', 'Y'],
+                ['New York',  23, 'M', 'Y'],
+                ['New York',  18, 'M', 'Y'],
+                ['Chicago',   43, 'M', 'Y'],
+                ['New York',  34, 'F', 'N'],
+                ['Chicago',   33, 'F', 'Y'],
+                ['New York',  31, 'F', 'N'],
+                ['Chicago',   55, 'M', 'N'],
+                ['New York',  58, 'F', 'N'],
+                ['New York',  59, 'M', 'N'],
+                ['Chicago',   71, 'M', 'N'],
+                ['New York',  60, 'F', 'N'],
+                ['Chicago',   85, 'F', 'Y']].freeze
 
   def setup
-    @data_set = DataSet.new(data_items: @@data_items, data_labels: @@data_labels)
+    @data_set = DataSet.new(data_items: DATA_ITEMS.map(&:dup), data_labels: DATA_LABELS)
     @classifier = IB1.new.build(@data_set)
   end
 
@@ -102,8 +101,8 @@ class IB1Test < Minitest::Test
   end
 
   def test_add_instance
-    items = @@data_items[0...7]
-    data_set = DataSet.new(data_items: items, data_labels: @@data_labels)
+    items = DATA_ITEMS[0...7].map(&:dup)
+    data_set = DataSet.new(data_items: items, data_labels: DATA_LABELS)
     classifier = IB1.new.build(data_set)
     assert_equal('Y', classifier.eval(['Chicago', 55, 'M']))
     classifier.add_instance(['Chicago', 55, 'M', 'N'])

--- a/test/classifiers/naive_bayes_test.rb
+++ b/test/classifiers/naive_bayes_test.rb
@@ -4,13 +4,12 @@ require 'ai4r/classifiers/naive_bayes'
 require 'ai4r/data/data_set'
 require_relative '../test_helper'
 
-include Ai4r::Classifiers
-include Ai4r::Data
-
 class NaiveBayesTest < Minitest::Test
-  @@data_labels = %w[Color Type Origin Stolen?]
+  include Ai4r::Classifiers
+  include Ai4r::Data
+  DATA_LABELS = %w[Color Type Origin Stolen?].freeze
 
-  @@data_items = [
+  DATA_ITEMS = [
     %w[Red Sports Domestic Yes],
     %w[Red Sports Domestic No],
     %w[Red Sports Domestic Yes],
@@ -21,11 +20,11 @@ class NaiveBayesTest < Minitest::Test
     %w[Yellow Sports Domestic No],
     %w[Red SUV Imported No],
     %w[Red Sports Imported Yes]
-  ]
+  ].freeze
 
   def setup
     @data_set = DataSet.new
-    @data_set = DataSet.new(data_items: @@data_items, data_labels: @@data_labels)
+    @data_set = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
     @b = NaiveBayes.new.set_parameters({ m: 3 }).build @data_set
   end
 

--- a/test/classifiers/one_r_test.rb
+++ b/test/classifiers/one_r_test.rb
@@ -7,25 +7,25 @@ class OneRTest < Minitest::Test
   include Ai4r::Classifiers
   include Ai4r::Data
 
-  @@data_examples = [['New York', 20, 'M', 'Y'],
-                     ['Chicago', 25, 'M', 'Y'],
-                     ['New York',  28, 'M', 'Y'],
-                     ['New York',  35, 'F', 'N'],
-                     ['Chicago', 40, 'F', 'Y'],
-                     ['New York', 45, 'F', 'N'],
-                     ['Chicago', 55, 'M', 'N']]
+  DATA_EXAMPLES = [['New York', 20, 'M', 'Y'],
+                   ['Chicago', 25, 'M', 'Y'],
+                   ['New York',  28, 'M', 'Y'],
+                   ['New York',  35, 'F', 'N'],
+                   ['Chicago', 40, 'F', 'Y'],
+                   ['New York', 45, 'F', 'N'],
+                   ['Chicago', 55, 'M', 'N']].freeze
 
-  @@data_labels = %w[city age gender marketing_target]
+  DATA_LABELS = %w[city age gender marketing_target].freeze
 
   def test_build
     assert_raises(ArgumentError) { OneR.new.build(DataSet.new) }
-    classifier = OneR.new.build(DataSet.new(data_items: @@data_examples))
+    classifier = OneR.new.build(DataSet.new(data_items: DATA_EXAMPLES))
     refute_nil(classifier.data_set.data_labels)
     refute_nil(classifier.rule)
     assert_equal('attribute_1', classifier.data_set.data_labels.first)
     assert_equal('class_value', classifier.data_set.category_label)
-    classifier = OneR.new.build(DataSet.new(data_items: @@data_examples,
-                                            data_labels: @@data_labels))
+    classifier = OneR.new.build(DataSet.new(data_items: DATA_EXAMPLES,
+                                            data_labels: DATA_LABELS))
     refute_nil(classifier.data_set.data_labels)
     refute_nil(classifier.rule)
     assert_equal('city', classifier.data_set.data_labels.first)
@@ -34,33 +34,33 @@ class OneRTest < Minitest::Test
   end
 
   def test_eval
-    classifier = OneR.new.build(DataSet.new(data_items: @@data_examples))
+    classifier = OneR.new.build(DataSet.new(data_items: DATA_EXAMPLES))
     assert_equal('Y', classifier.eval(['New York',  20,      'M']))
     assert_equal('N', classifier.eval(['New York',  35,      'M']))
     assert_equal('N', classifier.eval(['Chicago', 55, 'M']))
   end
 
   def test_get_rules
-    classifier = OneR.new.build(DataSet.new(data_items: @@data_examples,
-                                            data_labels: @@data_labels))
+    classifier = OneR.new.build(DataSet.new(data_items: DATA_EXAMPLES,
+                                            data_labels: DATA_LABELS))
     marketing_target = nil
     age = nil # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_nil(marketing_target)
     age = 20 # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
     age = 35 # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('N', marketing_target)
     age = 55 # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('N', marketing_target)
   end
 
   def test_selected_attribute
     classifier = OneR.new.set_parameters({ selected_attribute: 0 }).build(
-      DataSet.new(data_items: @@data_examples, data_labels: @@data_labels)
+      DataSet.new(data_items: DATA_EXAMPLES, data_labels: DATA_LABELS)
     )
     assert_equal(0, classifier.rule[:attr_index])
   end

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -10,24 +10,24 @@ class PrismTest < Minitest::Test
 
   fixture = YAML.load_file(File.expand_path('../fixtures/marketing_target_age_range.yml', __dir__))
 
-  @@data_examples = fixture['data_items']
-  @@data_labels   = fixture['data_labels']
+  DATA_EXAMPLES = fixture['data_items']
+  DATA_LABELS   = fixture['data_labels']
 
   numeric_fixture = YAML.load_file(File.expand_path('../fixtures/prism_numeric_examples.yml',
                                                     __dir__))
 
-  @@numeric_examples = numeric_fixture['data_items']
-  @@numeric_labels   = numeric_fixture['data_labels']
+  NUMERIC_EXAMPLES = numeric_fixture['data_items']
+  NUMERIC_LABELS   = numeric_fixture['data_labels']
 
   def test_build
     assert_raises(ArgumentError) { Ai4r::Classifiers::Prism.new.build(DataSet.new) }
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: @@data_examples))
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: DATA_EXAMPLES))
     refute_nil(classifier.data_set.data_labels)
     refute_nil(classifier.rules)
     assert_equal('attribute_1', classifier.data_set.data_labels.first)
     assert_equal('class_value', classifier.data_set.category_label)
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: @@data_examples,
-                                                                data_labels: @@data_labels))
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: DATA_EXAMPLES,
+                                                                data_labels: DATA_LABELS))
     refute_nil(classifier.data_set.data_labels)
     refute_nil(classifier.rules)
     assert_equal('city', classifier.data_set.data_labels.first)
@@ -36,38 +36,38 @@ class PrismTest < Minitest::Test
   end
 
   def test_eval
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: @@data_examples))
-    @@data_examples.each do |data|
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: DATA_EXAMPLES))
+    DATA_EXAMPLES.each do |data|
       assert_equal(data.last, classifier.eval(data[0...-1]))
     end
   end
 
   def test_get_rules
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: @@data_examples,
-                                                                data_labels: @@data_labels))
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: DATA_EXAMPLES,
+                                                                data_labels: DATA_LABELS))
     marketing_target = nil
     age_range = nil # rubocop:disable Lint/UselessAssignment
     city = 'Chicago' # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     age_range = '<30' # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('Y', marketing_target)
     age_range = '[30-50)' # rubocop:disable Lint/UselessAssignment
     city = 'New York' # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('N', marketing_target)
     age_range = '[50-80]' # rubocop:disable Lint/UselessAssignment
-    eval(classifier.get_rules)
+    instance_eval(classifier.get_rules)
     assert_equal('N', marketing_target)
   end
 
   def test_matches_conditions
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_labels: @@data_labels,
-                                                                data_items: @@data_examples))
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_labels: DATA_LABELS,
+                                                                data_items: DATA_EXAMPLES))
 
     assert classifier.send(:matches_conditions,
                            ['New York', '<30', 'M', 'Y'], { 'age_range' => '<30' })
@@ -77,7 +77,7 @@ class PrismTest < Minitest::Test
 
   def test_default_class
     classifier = Ai4r::Classifiers::Prism.new.set_parameters(default_class: 'Z').build(
-      DataSet.new(data_items: @@data_examples, data_labels: @@data_labels)
+      DataSet.new(data_items: DATA_EXAMPLES, data_labels: DATA_LABELS)
     )
     classifier.instance_variable_set(:@rules, [])
     assert_equal('Z', classifier.eval(['Paris', '<30', 'M']))
@@ -99,21 +99,21 @@ class PrismTest < Minitest::Test
   end
 
   def test_fallback_class
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: @@data_examples))
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: DATA_EXAMPLES))
     classifier.rules.pop
     assert_equal(classifier.majority_class,
                  classifier.eval(['New York', '[50-80]', 'M']))
 
     classifier = Ai4r::Classifiers::Prism.new.set_parameters(fallback_class: 'Z').build(
-      DataSet.new(data_items: @@data_examples)
+      DataSet.new(data_items: DATA_EXAMPLES)
     )
     classifier.rules.pop
     assert_equal('Z', classifier.eval(['New York', '[50-80]', 'M']))
   end
 
   def test_rules_have_unique_attributes
-    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_labels: @@data_labels,
-                                                                data_items: @@data_examples))
+    classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_labels: DATA_LABELS,
+                                                                data_items: DATA_EXAMPLES))
     classifier.rules.each do |rule|
       keys = rule[:conditions].keys
       assert_equal keys.uniq, keys
@@ -138,8 +138,8 @@ class PrismTest < Minitest::Test
 
   def test_numeric_data
     classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(
-                                                      data_items: @@numeric_examples,
-                                                      data_labels: @@numeric_labels
+                                                      data_items: NUMERIC_EXAMPLES,
+                                                      data_labels: NUMERIC_LABELS
                                                     ))
     assert(classifier.rules.any? { |r| r[:conditions].values.any? { |v| v.is_a?(Range) } })
     assert_equal('Y', classifier.eval(['New York', 20, 'M']))


### PR DESCRIPTION
## Summary
- update tests to use constants instead of class variables
- tidy up SimpleLinearRegression indentation
- move ID3 `private` section
- replace eval with instance_eval in tests

## Testing
- `bundle exec rubocop --format json`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68779b38fec0832b97069d708d4f120a