### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/lib/ai4r/clusterers/k_means.rb
+++ b/lib/ai4r/clusterers/k_means.rb
@@ -212,7 +212,7 @@ module Ai4r
           @cluster_indices[c] << data_index if @on_empty == 'outlier'
           @assignments[data_index] = c
         end
-        manage_empty_clusters if has_empty_cluster?
+        manage_empty_clusters if empty_cluster?
       end
 
       # @return [Object]
@@ -320,7 +320,7 @@ module Ai4r
       end
 
       # @return [Object]
-      def has_empty_cluster?
+      def empty_cluster?
         found_empty = false
         @number_of_clusters.times do |c|
           found_empty = true if @clusters[c].data_items.empty?

--- a/lib/ai4r/data/data_set.rb
+++ b/lib/ai4r/data/data_set.rb
@@ -106,7 +106,7 @@ module Ai4r
         items = []
         open_csv_file(filepath) do |row|
           items << row.collect do |x|
-            is_number?(x) ? Float(x, exception: false) : x
+            number?(x) ? Float(x, exception: false) : x
           end
         end
         set_data_items(items)
@@ -344,7 +344,7 @@ module Ai4r
 
       # @param x [Object]
       # @return [Object]
-      def is_number?(x)
+      def number?(x)
         !Float(x, exception: false).nil?
       end
 

--- a/test/classifiers/id3_test.rb
+++ b/test/classifiers/id3_test.rb
@@ -119,8 +119,6 @@ EXPECTED_RULES_STRING =
   "elsif age_range=='>80' then marketing_target='Y'\n" \
   "else raise 'There was not enough information during training to do a proper induction for this data element' end"
 
-
-
 class ID3Test < Minitest::Test
   include Ai4r::Classifiers
   include Ai4r::Data

--- a/test/classifiers/multilayer_perceptron_test.rb
+++ b/test/classifiers/multilayer_perceptron_test.rb
@@ -8,7 +8,7 @@ class MultilayerPerceptronTest < Minitest::Test
   include Ai4r::Classifiers
   include Ai4r::Data
 
-  @@data_set = DataSet.new(data_items: [
+  DATA_SET = DataSet.new(data_items: [
                              ['New York',  '<30', 'M', 'Y'],
                              ['Chicago',   '<30',     'M', 'Y'],
                              ['New York',  '<30',     'M', 'Y'],
@@ -16,7 +16,7 @@ class MultilayerPerceptronTest < Minitest::Test
                              ['Chicago',   '[30-50)', 'F', 'Y'],
                              ['New York',  '[30-50)', 'F', 'N'],
                              ['Chicago',   '[50-80]', 'M', 'N']
-                           ])
+                           ]).freeze
 
   def test_initialize
     classifier = MultilayerPerceptron.new
@@ -33,15 +33,15 @@ class MultilayerPerceptronTest < Minitest::Test
     assert_raises(ArgumentError) { MultilayerPerceptron.new.build(DataSet.new) }
     classifier = MultilayerPerceptron.new
     classifier.training_iterations = 1
-    classifier.build(@@data_set)
+    classifier.build(DATA_SET)
     assert_equal [7, 2], classifier.network.structure
     classifier.hidden_layers = [6, 4]
-    classifier.build(@@data_set)
+    classifier.build(DATA_SET)
     assert_equal [7, 6, 4, 2], classifier.network.structure
   end
 
   def test_eval
-    classifier = MultilayerPerceptron.new.build(@@data_set)
+    classifier = MultilayerPerceptron.new.build(DATA_SET)
     assert classifier
     assert_equal('N', classifier.eval(['Chicago', '[50-80]', 'M']))
     assert_equal('N', classifier.eval(['New York', '[30-50)', 'F']))

--- a/test/classifiers/simple_linear_regression_test.rb
+++ b/test/classifiers/simple_linear_regression_test.rb
@@ -7,11 +7,11 @@ require_relative '../test_helper'
 class SimpleLinearRegressionTest < Minitest::Test
   include Ai4r::Classifiers
   include Ai4r::Data
-  @@data_labels = %w[symboling normalized-losses wheel-base length width height curb-weight
-                     engine-size bore stroke compression-ratio horsepower peak-rpm city-mpg
-                     highway-mpg class]
+  DATA_LABELS = %w[symboling normalized-losses wheel-base length width height curb-weight
+                   engine-size bore stroke compression-ratio horsepower peak-rpm city-mpg
+                   highway-mpg class].freeze
 
-  @@data_items = [
+  DATA_ITEMS = [
     [2, 164, 99.8, 176.6, 66.2, 54.3, 2337, 109, 3.19, 3.4, 10, 102, 5500, 24, 30, 13_950],
     [2, 164, 99.4, 176.6, 66.4, 54.3, 2824, 136, 3.19, 3.4, 8, 115, 5500, 18, 22, 17_450],
     [1, 158, 105.8, 192.7, 71.4, 55.7, 2844, 136, 3.19, 3.4, 8.5, 110, 5500, 19, 25, 17_710],
@@ -21,11 +21,11 @@ class SimpleLinearRegressionTest < Minitest::Test
     [0, 188, 101.2, 176.8, 64.8, 54.3, 2710, 164, 3.31, 3.19, 9, 121, 4250, 21, 28, 20_970],
     [0, 188, 101.2, 176.8, 64.8, 54.3, 2765, 164, 3.31, 3.19, 9, 121, 4250, 21, 28, 21_105],
     [2, 121, 88.4, 141.1, 60.3, 53.2, 1488, 61, 2.91, 3.03, 9.5, 48, 5100, 47, 53, 5151]
-  ]
+  ].freeze
 
   def setup
     @data_set = DataSet.new
-    @data_set = DataSet.new(data_items: @@data_items, data_labels: @@data_labels)
+    @data_set = DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS)
     @c = SimpleLinearRegression.new.build @data_set
   end
 

--- a/test/classifiers/zero_r_test.rb
+++ b/test/classifiers/zero_r_test.rb
@@ -8,7 +8,7 @@ class ZeroRTest < Minitest::Test
   include Ai4r::Classifiers
   include Ai4r::Data
 
-  @@data_examples = [
+  DATA_EXAMPLES = [
     ['New York',  '[30-50)', 'F', 'N'],
     ['New York', '<30', 'M', 'Y'],
     ['Chicago', '<30', 'M', 'Y'],
@@ -16,33 +16,33 @@ class ZeroRTest < Minitest::Test
     ['Chicago', '[30-50)', 'F', 'Y'],
     ['New York', '[30-50)', 'F', 'N'],
     ['Chicago', '[50-80]', 'M', 'N']
-  ]
+  ].freeze
 
-  @@data_labels = %w[city age_range gender marketing_target]
+  DATA_LABELS = %w[city age_range gender marketing_target].freeze
 
   def test_build
     classifier = ZeroR.new.build(DataSet.new)
     assert_nil(classifier.class_value)
-    classifier = ZeroR.new.build(DataSet.new(data_items: @@data_examples))
+    classifier = ZeroR.new.build(DataSet.new(data_items: DATA_EXAMPLES))
     assert_equal('Y', classifier.class_value)
     assert_equal('attribute_1', classifier.data_set.data_labels.first)
     assert_equal('class_value', classifier.data_set.category_label)
-    classifier = ZeroR.new.build(DataSet.new(data_items: @@data_examples,
-                                             data_labels: @@data_labels))
+    classifier = ZeroR.new.build(DataSet.new(data_items: DATA_EXAMPLES,
+                                             data_labels: DATA_LABELS))
     assert_equal('Y', classifier.class_value)
     assert_equal('city', classifier.data_set.data_labels.first)
     assert_equal('marketing_target', classifier.data_set.category_label)
   end
 
   def test_eval
-    classifier = ZeroR.new.build(DataSet.new(data_items: @@data_examples))
-    assert_equal('Y', classifier.eval(@@data_examples.first))
-    assert_equal('Y', classifier.eval(@@data_examples.last))
+    classifier = ZeroR.new.build(DataSet.new(data_items: DATA_EXAMPLES))
+    assert_equal('Y', classifier.eval(DATA_EXAMPLES.first))
+    assert_equal('Y', classifier.eval(DATA_EXAMPLES.last))
   end
 
   def test_get_rules
-    classifier = ZeroR.new.build(DataSet.new(data_items: @@data_examples,
-                                             data_labels: @@data_labels))
+    classifier = ZeroR.new.build(DataSet.new(data_items: DATA_EXAMPLES,
+                                             data_labels: DATA_LABELS))
     marketing_target = nil
     eval(classifier.get_rules)
     assert_equal('Y', marketing_target)

--- a/test/clusterers/average_linkage_test.rb
+++ b/test/clusterers/average_linkage_test.rb
@@ -16,10 +16,10 @@ class AverageLinkageTest < Minitest::Test
   include Ai4r::Clusterers
   include Ai4r::Data
 
-  @@data = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
-            [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
+  DATA = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
+          [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]].freeze
 
-  @@expected_distance_matrix = [
+  EXPECTED_DISTANCE_MATRIX = [
     [98.0],
     [89.0, 5.0],
     [68.0, 26.0, 9.0],
@@ -31,13 +31,13 @@ class AverageLinkageTest < Minitest::Test
     [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
     [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
     [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]
-  ]
+  ].freeze
 
   def setup; end
 
   def test_linkage_distance
     clusterer = Ai4r::Clusterers::AverageLinkage.new
-    clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+    clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
     assert_equal 93.5, clusterer.send(:linkage_distance, 0, 1, 2)
     assert_equal 37.5, clusterer.send(:linkage_distance, 4, 2, 5)
   end

--- a/test/clusterers/bisecting_k_means_test.rb
+++ b/test/clusterers/bisecting_k_means_test.rb
@@ -16,8 +16,8 @@ class BisectingKMeansTest < Minitest::Test
   include Ai4r::Clusterers
   include Ai4r::Data
 
-  @@data = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
-            [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
+  DATA = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
+          [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]].freeze
 
   def test_build_without_refine
     build(false)
@@ -34,7 +34,7 @@ class BisectingKMeansTest < Minitest::Test
   protected
 
   def build(refine)
-    data_set = DataSet.new(data_items: @@data, data_labels: %w[X Y])
+    data_set = DataSet.new(data_items: DATA, data_labels: %w[X Y])
     clusterer = BisectingKMeans.new
     clusterer.set_parameters refine: refine
     clusterer.build(data_set, 4)
@@ -48,11 +48,11 @@ class BisectingKMeansTest < Minitest::Test
     clusterer.clusters.each do |cluster|
       total_length += cluster.data_items.length
     end
-    assert_equal @@data.length, total_length
+    assert_equal DATA.length, total_length
     # Data inside clusters must be the same as orifinal data
     clusterer.clusters.each do |cluster|
       cluster.data_items.each do |data_item|
-        assert @@data.include?(data_item)
+        assert DATA.include?(data_item)
       end
     end
   end

--- a/test/clusterers/centroid_linkage_test.rb
+++ b/test/clusterers/centroid_linkage_test.rb
@@ -18,10 +18,10 @@ module Ai4r
       include Ai4r::Clusterers
       include Ai4r::Data
 
-      @@data = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
-                [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
+      DATA = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
+              [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]].freeze
 
-      @@expected_distance_matrix = [
+      EXPECTED_DISTANCE_MATRIX = [
         [98.0],
         [89.0, 5.0],
         [68.0, 26.0, 9.0],
@@ -33,16 +33,16 @@ module Ai4r
         [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
         [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]
-      ]
+      ].freeze
 
       def setup; end
 
       def test_linkage_distance
         clusterer = Ai4r::Clusterers::CentroidLinkage.new
-        clusterer.instance_variable_set(:@data_set, DataSet.new(data_items: @@data))
+        clusterer.instance_variable_set(:@data_set, DataSet.new(data_items: DATA))
         clusterer.instance_variable_set(:@index_clusters,
                                         clusterer.send(:create_initial_index_clusters))
-        clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+        clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
         assert_equal 92.25, clusterer.send(:linkage_distance, 0, 1, 2)
         assert_equal 15.25, clusterer.send(:linkage_distance, 4, 2, 5)
       end

--- a/test/clusterers/complete_linkage_test.rb
+++ b/test/clusterers/complete_linkage_test.rb
@@ -16,10 +16,10 @@ class CompleteLinkageTest < Minitest::Test
   include Ai4r::Clusterers
   include Ai4r::Data
 
-  @@data = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
-            [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
+  DATA = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
+          [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]].freeze
 
-  @@expected_distance_matrix = [
+  EXPECTED_DISTANCE_MATRIX = [
     [98.0],
     [89.0, 5.0],
     [68.0, 26.0, 9.0],
@@ -31,20 +31,20 @@ class CompleteLinkageTest < Minitest::Test
     [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
     [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
     [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]
-  ]
+  ].freeze
 
   def setup; end
 
   def test_build_with_distance
     clusterer = Ai4r::Clusterers::CompleteLinkage.new
-    clusterer.build(DataSet.new(data_items: @@data), distance: 4.0)
+    clusterer.build(DataSet.new(data_items: DATA), distance: 4.0)
     # draw_map(clusterer)
     assert_equal 6, clusterer.clusters.length
   end
 
   def test_linkage_distance
     clusterer = Ai4r::Clusterers::CompleteLinkage.new
-    clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+    clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
     assert_equal 98, clusterer.send(:linkage_distance, 0, 1, 2)
     assert_equal 74, clusterer.send(:linkage_distance, 4, 2, 5)
   end

--- a/test/clusterers/median_linkage_test.rb
+++ b/test/clusterers/median_linkage_test.rb
@@ -18,10 +18,10 @@ module Ai4r
       include Ai4r::Clusterers
       include Ai4r::Data
 
-      @@data = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
-                [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
+      DATA = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
+              [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]].freeze
 
-      @@expected_distance_matrix = [
+      EXPECTED_DISTANCE_MATRIX = [
         [98.0],
         [89.0, 5.0],
         [68.0, 26.0, 9.0],
@@ -33,16 +33,16 @@ module Ai4r
         [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
         [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
         [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]
-      ]
+      ].freeze
 
       def setup; end
 
       def test_linkage_distance
         clusterer = Ai4r::Clusterers::MedianLinkage.new
-        clusterer.instance_variable_set(:@data_set, DataSet.new(data_items: @@data))
+        clusterer.instance_variable_set(:@data_set, DataSet.new(data_items: DATA))
         clusterer.instance_variable_set(:@index_clusters,
                                         clusterer.send(:create_initial_index_clusters))
-        clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+        clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
         assert_equal 92.25, clusterer.send(:linkage_distance, 0, 1, 2)
         assert_equal 15.25, clusterer.send(:linkage_distance, 4, 2, 5)
       end

--- a/test/clusterers/single_linkage_test.rb
+++ b/test/clusterers/single_linkage_test.rb
@@ -16,10 +16,10 @@ class SingleLinkageTest < Minitest::Test
   include Ai4r::Clusterers
   include Ai4r::Data
 
-  @@data = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
-            [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]]
+  DATA = [[10, 3], [3, 10], [2, 8], [2, 5], [3, 8], [10, 3],
+          [1, 3], [8, 1], [2, 9], [2, 5], [3, 3], [9, 4]].freeze
 
-  @@expected_distance_matrix = [
+  EXPECTED_DISTANCE_MATRIX = [
     [98.0],
     [89.0, 5.0],
     [68.0, 26.0, 9.0],
@@ -31,44 +31,44 @@ class SingleLinkageTest < Minitest::Test
     [68.0, 26.0, 9.0, 0.0, 10.0, 68.0, 5.0, 52.0, 16.0],
     [49.0, 49.0, 26.0, 5.0, 25.0, 49.0, 4.0, 29.0, 37.0, 5.0],
     [2.0, 72.0, 65.0, 50.0, 52.0, 2.0, 65.0, 10.0, 74.0, 50.0, 37.0]
-  ]
+  ].freeze
 
   def setup; end
 
   def test_build
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.build(DataSet.new(data_items: @@data), 4)
+    clusterer.build(DataSet.new(data_items: DATA), 4)
     # draw_map(clusterer)
     assert_equal 4, clusterer.clusters.length
   end
 
   def test_build_with_distance
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.build(DataSet.new(data_items: @@data), distance: 8.0)
+    clusterer.build(DataSet.new(data_items: DATA), distance: 8.0)
     # draw_map(clusterer)
     assert_equal 3, clusterer.clusters.length
   end
 
   def test_eval
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.build(DataSet.new(data_items: @@data), 4)
+    clusterer.build(DataSet.new(data_items: DATA), 4)
     assert_equal 2, clusterer.eval([0, 8])
     assert_equal 0, clusterer.eval([8, 0])
   end
 
   def test_create_distance_matrix
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.send(:create_distance_matrix, DataSet.new(data_items: @@data))
+    clusterer.send(:create_distance_matrix, DataSet.new(data_items: DATA))
     assert clusterer.instance_variable_get(:@distance_matrix)
     clusterer.instance_variable_get(:@distance_matrix).each_with_index do |row, row_index|
       assert_equal row_index + 1, row.length
     end
-    assert_equal @@expected_distance_matrix, clusterer.instance_variable_get(:@distance_matrix)
+    assert_equal EXPECTED_DISTANCE_MATRIX, clusterer.instance_variable_get(:@distance_matrix)
   end
 
   def test_read_distance_matrix
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+    clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
     assert_equal 9.0, clusterer.send(:read_distance_matrix, 3, 2)
     assert_equal 9.0, clusterer.send(:read_distance_matrix, 2, 3)
     assert_equal 0, clusterer.send(:read_distance_matrix, 5, 5)
@@ -76,25 +76,25 @@ class SingleLinkageTest < Minitest::Test
 
   def test_linkage_distance
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+    clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
     assert_equal 89, clusterer.send(:linkage_distance, 0, 1, 2)
     assert_equal 1, clusterer.send(:linkage_distance, 4, 2, 5)
   end
 
   def test_get_closest_clusters
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.instance_variable_set(:@distance_matrix, @@expected_distance_matrix)
+    clusterer.instance_variable_set(:@distance_matrix, EXPECTED_DISTANCE_MATRIX)
     assert_equal [1, 0], clusterer.send(:get_closest_clusters, [[0, 1], [3, 4]])
     assert_equal [2, 1], clusterer.send(:get_closest_clusters, [[3, 4], [0, 1], [5, 6]])
   end
 
   def test_create_initial_index_clusters
     clusterer = Ai4r::Clusterers::SingleLinkage.new
-    clusterer.instance_variable_set(:@data_set, DataSet.new(data_items: @@data))
+    clusterer.instance_variable_set(:@data_set, DataSet.new(data_items: DATA))
     index_clusters = clusterer.send(:create_initial_index_clusters)
-    assert_equal @@data.length, index_clusters.length
+    assert_equal DATA.length, index_clusters.length
     assert_equal 0, index_clusters.first.first
-    assert_equal @@data.length - 1, index_clusters.last.first
+    assert_equal DATA.length - 1, index_clusters.last.first
   end
 
   def test_merge_clusters

--- a/test/data/proximity_test.rb
+++ b/test/data/proximity_test.rb
@@ -15,73 +15,73 @@ require 'ai4r/data/proximity'
 module Ai4r
   module Data
     class ProximityTest < Minitest::Test
-      @@delta = 0.0000001
-      @@data1 = [rand * 10, rand * 10, rand * -10]
-      @@data2 = [rand * 10, rand * -10, rand * 10]
+      DELTA = 0.0000001
+      DATA1 = [rand * 10, rand * 10, rand * -10].freeze
+      DATA2 = [rand * 10, rand * -10, rand * 10].freeze
 
       def test_squared_euclidean_distance
-        assert_equal 0, Proximity.squared_euclidean_distance(@@data1, @@data1)
-        assert_equal  Proximity.squared_euclidean_distance(@@data1, @@data2),
-                      Proximity.squared_euclidean_distance(@@data2, @@data1)
-        assert Proximity.squared_euclidean_distance(@@data1, @@data1) >= 0
+        assert_equal 0, Proximity.squared_euclidean_distance(DATA1, DATA1)
+        assert_equal  Proximity.squared_euclidean_distance(DATA1, DATA2),
+                      Proximity.squared_euclidean_distance(DATA2, DATA1)
+        assert Proximity.squared_euclidean_distance(DATA1, DATA1) >= 0
         assert_equal 2, Proximity.squared_euclidean_distance([1, 1], [2, 2])
         assert_equal 9, Proximity.squared_euclidean_distance([3], [0])
       end
 
       def test_euclidean_distance
-        assert_equal 0, Proximity.euclidean_distance(@@data1, @@data1)
-        assert_equal  Proximity.euclidean_distance(@@data1, @@data2),
-                      Proximity.euclidean_distance(@@data2, @@data1)
-        assert Proximity.euclidean_distance(@@data1, @@data1) >= 0
+        assert_equal 0, Proximity.euclidean_distance(DATA1, DATA1)
+        assert_equal  Proximity.euclidean_distance(DATA1, DATA2),
+                      Proximity.euclidean_distance(DATA2, DATA1)
+        assert Proximity.euclidean_distance(DATA1, DATA1) >= 0
         assert_equal Math.sqrt(2), Proximity.euclidean_distance([1, 1], [2, 2])
         assert_equal 3, Proximity.euclidean_distance([3], [0])
       end
 
       def test_manhattan_distance
-        assert_equal 0, Proximity.manhattan_distance(@@data1, @@data1)
-        assert_equal  Proximity.manhattan_distance(@@data1, @@data2),
-                      Proximity.manhattan_distance(@@data2, @@data1)
-        assert Proximity.manhattan_distance(@@data1, @@data1) >= 0
+        assert_equal 0, Proximity.manhattan_distance(DATA1, DATA1)
+        assert_equal  Proximity.manhattan_distance(DATA1, DATA2),
+                      Proximity.manhattan_distance(DATA2, DATA1)
+        assert Proximity.manhattan_distance(DATA1, DATA1) >= 0
         assert_equal 2, Proximity.manhattan_distance([1, 1], [2, 2])
         assert_equal 9, Proximity.manhattan_distance([1, 10], [2, 2])
         assert_equal 3, Proximity.manhattan_distance([3], [0])
       end
 
       def test_sup_distance
-        assert_equal 0, Proximity.sup_distance(@@data1, @@data1)
-        assert_equal  Proximity.sup_distance(@@data1, @@data2),
-                      Proximity.sup_distance(@@data2, @@data1)
-        assert Proximity.sup_distance(@@data1, @@data1) >= 0
+        assert_equal 0, Proximity.sup_distance(DATA1, DATA1)
+        assert_equal  Proximity.sup_distance(DATA1, DATA2),
+                      Proximity.sup_distance(DATA2, DATA1)
+        assert Proximity.sup_distance(DATA1, DATA1) >= 0
         assert_equal 1, Proximity.sup_distance([1, 1], [2, 2])
         assert_equal 8, Proximity.sup_distance([1, 10], [2, 2])
         assert_equal 3, Proximity.sup_distance([3], [0])
       end
 
       def test_hamming_distance
-        assert_equal 0, Proximity.hamming_distance(@@data1, @@data1)
-        assert_equal  Proximity.hamming_distance(@@data1, @@data2),
-                      Proximity.hamming_distance(@@data2, @@data1)
-        assert Proximity.hamming_distance(@@data1, @@data1) >= 0
+        assert_equal 0, Proximity.hamming_distance(DATA1, DATA1)
+        assert_equal  Proximity.hamming_distance(DATA1, DATA2),
+                      Proximity.hamming_distance(DATA2, DATA1)
+        assert Proximity.hamming_distance(DATA1, DATA1) >= 0
         assert_equal 1, Proximity.hamming_distance([1, 1], [0, 1])
         assert_equal 2, Proximity.hamming_distance([1, 10], [2, 2])
         assert_equal 1, Proximity.hamming_distance([3], [0])
       end
 
       def test_simple_matching_distance
-        assert_equal 0, Proximity.simple_matching_distance(@@data1, @@data1)
-        assert_equal  Proximity.simple_matching_distance(@@data1, @@data2),
-                      Proximity.simple_matching_distance(@@data2, @@data1)
-        assert Proximity.simple_matching_distance(@@data1, @@data1) >= 0
+        assert_equal 0, Proximity.simple_matching_distance(DATA1, DATA1)
+        assert_equal  Proximity.simple_matching_distance(DATA1, DATA2),
+                      Proximity.simple_matching_distance(DATA2, DATA1)
+        assert Proximity.simple_matching_distance(DATA1, DATA1) >= 0
         assert_equal 1, Proximity.simple_matching_distance([1, 2], [0, 1])
         assert_equal 1.0 / 0, Proximity.simple_matching_distance([1, 10], [2, 2])
         assert_equal 1.0 / 0, Proximity.simple_matching_distance([3], [0])
       end
 
       def test_cosine_distance
-        assert_in_delta 0.0, Proximity.cosine_distance(@@data1, @@data1), @@delta
-        assert_equal  Proximity.cosine_distance(@@data1, @@data2),
-                      Proximity.cosine_distance(@@data2, @@data1)
-        assert_in_delta 0.0, Proximity.cosine_distance(@@data1, @@data1), @@delta
+        assert_in_delta 0.0, Proximity.cosine_distance(DATA1, DATA1), DELTA
+        assert_equal  Proximity.cosine_distance(DATA1, DATA2),
+                      Proximity.cosine_distance(DATA2, DATA1)
+        assert_in_delta 0.0, Proximity.cosine_distance(DATA1, DATA1), DELTA
       end
     end
   end

--- a/test/e2e/ga_function_opt_test.rb
+++ b/test/e2e/ga_function_opt_test.rb
@@ -17,8 +17,8 @@ class GaFunctionOptTest < Minitest::Test
       new(RANGE.to_a.sample)
     end
 
-    def self.reproduce(a, b, _rate = 0.7)
-      new(rand < _rate ? b.data : a.data)
+    def self.reproduce(a, b, rate = 0.7)
+      new(rand < rate ? b.data : a.data)
     end
 
     def self.mutate(chrom, rate = 0.1)


### PR DESCRIPTION
## Summary
- convert many test class variables to constants
- rename helper methods and variables flagged by RuboCop
- update KMeans empty cluster predicate
- clean whitespace issues

## Testing
- `bundle exec rubocop --display-cop-names`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6877a87431c4832bbabf303559cd029c