### PR TITLE
Remove test warnings

### DIFF
--- a/lib/ai4r/data/parameterizable.rb
+++ b/lib/ai4r/data/parameterizable.rb
@@ -31,7 +31,9 @@ module Ai4r
         def parameters_info(params_info)
           @_params_info_ = get_parameters_info.merge(params_info)
           params_info.each_key do |param|
-            attr_accessor param
+            unless method_defined?(param) || method_defined?("#{param}=")
+              attr_accessor param
+            end
           end
         end
       end

--- a/lib/ai4r/hmm/hidden_markov_model.rb
+++ b/lib/ai4r/hmm/hidden_markov_model.rb
@@ -41,9 +41,6 @@ module Ai4r
     class HiddenMarkovModel
       include Ai4r::Data::Parameterizable
 
-      attr_accessor :states, :observations, :start_prob,
-                    :transition_prob, :emission_prob
-
       parameters_info states: 'Array of hidden states',
                       observations: 'Array of observation symbols',
                       start_prob: 'Initial state probabilities',

--- a/lib/ai4r/neural_network/backpropagation.rb
+++ b/lib/ai4r/neural_network/backpropagation.rb
@@ -90,23 +90,6 @@ module Ai4r
     class Backpropagation
       include Ai4r::Data::Parameterizable
 
-      parameters_info disable_bias: 'If true, the algorithm will not use ' \
-                                    'bias nodes. False by default.',
-                      initial_weight_function: 'f(n, i, j) must return the initial ' \
-                                               'weight for the conection between the node i in layer n, and ' \
-                                               'node j in layer n+1. By default a random number in [-1, 1) range.',
-                      weight_init: 'Built-in weight initialization strategy (:uniform, :xavier or :he). Default: :uniform',
-                      propagation_function: 'By default: ' \
-                                            'lambda { |x| 1/(1+Math.exp(-1*(x))) }',
-                      derivative_propagation_function: 'Derivative of the propagation ' \
-                                                       'function, based on propagation function output. By default: ' \
-                                                       'lambda { |y| y*(1-y) }, where y=propagation_function(x)',
-                      activation: 'Activation function per layer. Provide a symbol or an array of symbols (:sigmoid, :tanh, :relu or :softmax). Default: :sigmoid',
-                      learning_rate: 'By default 0.25',
-                      momentum: 'By default 0.1. Set this parameter to 0 to disable ' \
-                                'momentum.',
-                      loss_function: 'Loss function used when training (:mse or ' \
-                                     ':cross_entropy). Default: :mse'
 
       attr_accessor :structure, :weights, :activation_nodes, :last_changes
 
@@ -597,6 +580,24 @@ module Ai4r
                              "Expected: #{@structure.last}, " \
                              "received: #{outputs}."
       end
+
+      parameters_info disable_bias: 'If true, the algorithm will not use ' \
+                                   'bias nodes. False by default.',
+                      initial_weight_function: 'f(n, i, j) must return the initial ' \
+                                               'weight for the conection between the node i in layer n, and ' \
+                                               'node j in layer n+1. By default a random number in [-1, 1) range.',
+                      weight_init: 'Built-in weight initialization strategy (:uniform, :xavier or :he). Default: :uniform',
+                      propagation_function: 'By default: ' \
+                                            'lambda { |x| 1/(1+Math.exp(-1*(x))) }',
+                      derivative_propagation_function: 'Derivative of the propagation ' \
+                                                       'function, based on propagation function output. By default: ' \
+                                                       'lambda { |y| y*(1-y) }, where y=propagation_function(x)',
+                      activation: 'Activation function per layer. Provide a symbol or an array of symbols (:sigmoid, :tanh, :relu or :softmax). Default: :sigmoid',
+                      learning_rate: 'By default 0.25',
+                      momentum: 'By default 0.1. Set this parameter to 0 to disable ' \
+                                'momentum.',
+                      loss_function: 'Loss function used when training (:mse or ' \
+                                     ':cross_entropy). Default: :mse'
     end
   end
 end

--- a/lib/ai4r/neural_network/transformer.rb
+++ b/lib/ai4r/neural_network/transformer.rb
@@ -27,8 +27,6 @@ module Ai4r
                       architecture: 'Architecture (:encoder, :decoder or :seq2seq).',
                       seed: 'Deterministic random seed for initialization.'
 
-      attr_accessor :embed_dim, :num_heads, :ff_dim, :vocab_size, :max_len,
-                    :architecture, :seed
 
       # Initialize the Transformer with given hyperparameters.
       def initialize(vocab_size:, max_len:, embed_dim: 8, num_heads: 2, ff_dim: 32,

--- a/test/classifiers/hyperpipes_test.rb
+++ b/test/classifiers/hyperpipes_test.rb
@@ -50,15 +50,17 @@ class HyperpipesTest < Minitest::Test
 
   def test_get_rules
     classifier = Hyperpipes.new.build(@data_set)
-    age = 28 # rubocop:disable Lint/UselessAssignment
-    gender = 'M' # rubocop:disable Lint/UselessAssignment
-    marketing_target = nil
-    instance_eval classifier.get_rules
-    assert_equal 'Y', marketing_target
-    age = 44 # rubocop:disable Lint/UselessAssignment
-    city = 'New York' # rubocop:disable Lint/UselessAssignment
-    instance_eval classifier.get_rules
-    assert_equal 'N', marketing_target
+    ctx = binding
+    ctx.local_variable_set(:city, 'New York')
+    ctx.local_variable_set(:age, 28)
+    ctx.local_variable_set(:gender, 'M')
+    ctx.local_variable_set(:marketing_target, nil)
+    ctx.eval classifier.get_rules
+    assert_equal 'Y', ctx.local_variable_get(:marketing_target)
+    ctx.local_variable_set(:age, 44)
+    ctx.local_variable_set(:city, 'New York')
+    ctx.eval classifier.get_rules
+    assert_equal 'N', ctx.local_variable_get(:marketing_target)
   end
 
   def test_pipes_summary

--- a/test/classifiers/id3_test.rb
+++ b/test/classifiers/id3_test.rb
@@ -236,16 +236,15 @@ class ID3Test < Minitest::Test
 
   def test_rules_eval
     id3 = ID3.new.build(DataSet.new(data_items: DATA_ITEMS, data_labels: DATA_LABELS))
-    # if age_range='<30' then marketing_target='Y'
-    marketing_target = nil
-    age_range = '<30' # rubocop:disable Lint/UselessAssignment
-    eval id3.get_rules
-    assert_equal 'Y', marketing_target
-    # if age_range='[30-50)' and city='New York' then marketing_target='N'
-    age_range = '[30-50)' # rubocop:disable Lint/UselessAssignment
-    city = 'New York' # rubocop:disable Lint/UselessAssignment
-    eval id3.get_rules
-    assert_equal 'N', marketing_target
+    ctx = binding
+    ctx.local_variable_set(:marketing_target, nil)
+    ctx.local_variable_set(:age_range, '<30')
+    ctx.eval id3.get_rules
+    assert_equal 'Y', ctx.local_variable_get(:marketing_target)
+    ctx.local_variable_set(:age_range, '[30-50)')
+    ctx.local_variable_set(:city, 'New York')
+    ctx.eval id3.get_rules
+    assert_equal 'N', ctx.local_variable_get(:marketing_target)
   end
 
   def test_numeric_attribute

--- a/test/classifiers/one_r_test.rb
+++ b/test/classifiers/one_r_test.rb
@@ -43,19 +43,20 @@ class OneRTest < Minitest::Test
   def test_get_rules
     classifier = OneR.new.build(DataSet.new(data_items: DATA_EXAMPLES,
                                             data_labels: DATA_LABELS))
-    marketing_target = nil
-    age = nil # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_nil(marketing_target)
-    age = 20 # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_equal('Y', marketing_target)
-    age = 35 # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_equal('N', marketing_target)
-    age = 55 # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_equal('N', marketing_target)
+    ctx = binding
+    ctx.local_variable_set(:marketing_target, nil)
+    ctx.local_variable_set(:age, nil)
+    ctx.eval(classifier.get_rules)
+    assert_nil(ctx.local_variable_get(:marketing_target))
+    ctx.local_variable_set(:age, 20)
+    ctx.eval(classifier.get_rules)
+    assert_equal('Y', ctx.local_variable_get(:marketing_target))
+    ctx.local_variable_set(:age, 35)
+    ctx.eval(classifier.get_rules)
+    assert_equal('N', ctx.local_variable_get(:marketing_target))
+    ctx.local_variable_set(:age, 55)
+    ctx.eval(classifier.get_rules)
+    assert_equal('N', ctx.local_variable_get(:marketing_target))
   end
 
   def test_selected_attribute

--- a/test/classifiers/prism_test.rb
+++ b/test/classifiers/prism_test.rb
@@ -45,24 +45,25 @@ class PrismTest < Minitest::Test
   def test_get_rules
     classifier = Ai4r::Classifiers::Prism.new.build(DataSet.new(data_items: DATA_EXAMPLES,
                                                                 data_labels: DATA_LABELS))
-    marketing_target = nil
-    age_range = nil # rubocop:disable Lint/UselessAssignment
-    city = 'Chicago' # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    age_range = '<30' # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_equal('Y', marketing_target)
-    instance_eval(classifier.get_rules)
-    assert_equal('Y', marketing_target)
-    instance_eval(classifier.get_rules)
-    assert_equal('Y', marketing_target)
-    age_range = '[30-50)' # rubocop:disable Lint/UselessAssignment
-    city = 'New York' # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_equal('N', marketing_target)
-    age_range = '[50-80]' # rubocop:disable Lint/UselessAssignment
-    instance_eval(classifier.get_rules)
-    assert_equal('N', marketing_target)
+    ctx = binding
+    ctx.local_variable_set(:marketing_target, nil)
+    ctx.local_variable_set(:age_range, nil)
+    ctx.local_variable_set(:city, 'Chicago')
+    ctx.eval(classifier.get_rules)
+    ctx.local_variable_set(:age_range, '<30')
+    ctx.eval(classifier.get_rules)
+    assert_equal('Y', ctx.local_variable_get(:marketing_target))
+    ctx.eval(classifier.get_rules)
+    assert_equal('Y', ctx.local_variable_get(:marketing_target))
+    ctx.eval(classifier.get_rules)
+    assert_equal('Y', ctx.local_variable_get(:marketing_target))
+    ctx.local_variable_set(:age_range, '[30-50)')
+    ctx.local_variable_set(:city, 'New York')
+    ctx.eval(classifier.get_rules)
+    assert_equal('N', ctx.local_variable_get(:marketing_target))
+    ctx.local_variable_set(:age_range, '[50-80]')
+    ctx.eval(classifier.get_rules)
+    assert_equal('N', ctx.local_variable_get(:marketing_target))
   end
 
   def test_matches_conditions


### PR DESCRIPTION
## Summary
- avoid attr_accessor duplication
- update Parameterizable to not clobber custom accessors
- move parameter metadata setup for backpropagation
- evaluate classifier rules using binding in tests

## Testing
- `bundle install`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6877cb21221c832baf75fda9ca038287