### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/lib/ai4r.rb
+++ b/lib/ai4r.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "ai4r/version"
+require_relative 'ai4r/version'
 
 # Data
 require_relative 'ai4r/data/data_set'

--- a/lib/ai4r/data/parameterizable.rb
+++ b/lib/ai4r/data/parameterizable.rb
@@ -31,9 +31,7 @@ module Ai4r
         def parameters_info(params_info)
           @_params_info_ = get_parameters_info.merge(params_info)
           params_info.each_key do |param|
-            unless method_defined?(param) || method_defined?("#{param}=")
-              attr_accessor param
-            end
+            attr_accessor param unless method_defined?(param) || method_defined?("#{param}=")
           end
         end
       end

--- a/lib/ai4r/neural_network/backpropagation.rb
+++ b/lib/ai4r/neural_network/backpropagation.rb
@@ -90,7 +90,6 @@ module Ai4r
     class Backpropagation
       include Ai4r::Data::Parameterizable
 
-
       attr_accessor :structure, :weights, :activation_nodes, :last_changes
 
       # When the activation parameter changes, update internal lambdas for each

--- a/lib/ai4r/neural_network/transformer.rb
+++ b/lib/ai4r/neural_network/transformer.rb
@@ -27,7 +27,6 @@ module Ai4r
                       architecture: 'Architecture (:encoder, :decoder or :seq2seq).',
                       seed: 'Deterministic random seed for initialization.'
 
-
       # Initialize the Transformer with given hyperparameters.
       def initialize(vocab_size:, max_len:, embed_dim: 8, num_heads: 2, ff_dim: 32,
                      architecture: :encoder, seed: nil)

--- a/lib/ai4r/version.rb
+++ b/lib/ai4r/version.rb
@@ -1,3 +1,3 @@
 module Ai4r
-  VERSION = '2.0'
+  VERSION = '2.0'.freeze
 end


### PR DESCRIPTION
## Summary
- correct quoting style in `ai4r.rb`
- replace multi-line `unless` in `parameterizable.rb`
- trim blank lines in Transformer and Backpropagation
- freeze mutable constant in version file

## Testing
- `bundle exec rubocop -f simple`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6877d4fd14cc832b888aaa5cf592609b