### PR TITLE
Add tests for clustering and GA base classes

### DIFF
--- a/test/clusterers/cluster_tree_test.rb
+++ b/test/clusterers/cluster_tree_test.rb
@@ -1,0 +1,56 @@
+require_relative '../test_helper'
+require 'ai4r/clusterers/cluster_tree'
+
+class ClusterTreeTest < Minitest::Test
+  include Ai4r::Clusterers
+  include Ai4r::Data
+
+  class DummyClusterer < Clusterer
+    prepend Ai4r::Clusterers::ClusterTree
+    attr_reader :clusters
+
+    def build(data_set, number_of_clusters = 1, **_options)
+      @data_set = data_set
+      @distance_matrix = []
+      index_clusters = data_set.data_items.each_index.map { |i| [i] }
+      while index_clusters.length > number_of_clusters
+        merge_clusters(index_clusters.length - 1, 0, index_clusters)
+      end
+      @clusters = build_clusters_from_index_clusters(index_clusters)
+      self
+    end
+
+    protected
+
+    def merge_clusters(index_a, index_b, index_clusters)
+      index_clusters[index_b] += index_clusters[index_a]
+      index_clusters.delete_at(index_a)
+      index_clusters
+    end
+
+    def build_clusters_from_index_clusters(index_clusters)
+      index_clusters.map do |indices|
+        Ai4r::Data::DataSet.new(data_items: indices.map { |i| @data_set.data_items[i] })
+      end
+    end
+  end
+
+  DATA = [[0, 0], [0, 1], [1, 0], [1, 1]].freeze
+
+  def setup
+    @data_set = DataSet.new(data_items: DATA)
+  end
+
+  def test_records_all_merges_by_default
+    clusterer = DummyClusterer.new.build(@data_set, 1)
+    assert_equal 4, clusterer.cluster_tree.length
+    final_items = clusterer.clusters.map(&:data_items)
+    assert_equal final_items, clusterer.cluster_tree.first.map(&:data_items)
+  end
+
+  def test_depth_limits_history
+    clusterer = DummyClusterer.new(2).build(@data_set, 1)
+    assert_equal 2, clusterer.cluster_tree.length
+    assert_equal 1, clusterer.cluster_tree.first.length
+  end
+end

--- a/test/clusterers/clusterer_test.rb
+++ b/test/clusterers/clusterer_test.rb
@@ -1,0 +1,19 @@
+require_relative '../test_helper'
+require 'ai4r/clusterers/clusterer'
+
+class ClustererBaseTest < Minitest::Test
+  include Ai4r::Clusterers
+
+  def test_base_methods_raise_and_support_eval
+    clusterer = Clusterer.new
+    assert clusterer.supports_eval?
+    assert_raises(NotImplementedError) { clusterer.build(nil, 1) }
+    assert_raises(NotImplementedError) { clusterer.eval(nil) }
+  end
+
+  def test_get_min_index
+    clusterer = Clusterer.new
+    assert_equal 1, clusterer.send(:get_min_index, [5, 2, 3])
+    assert_equal 0, clusterer.send(:get_min_index, [-1, 0, 1])
+  end
+end

--- a/test/genetic_algorithm/chromosome_base_test.rb
+++ b/test/genetic_algorithm/chromosome_base_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_helper'
+require 'ai4r/genetic_algorithm/chromosome_base'
+
+class ChromosomeBaseTest < Minitest::Test
+  include Ai4r::GeneticAlgorithm
+
+  def test_base_methods_raise_errors
+    chromosome = ChromosomeBase.new([1, 2])
+    assert_raises(NotImplementedError) { chromosome.fitness }
+    assert_raises(NotImplementedError) { ChromosomeBase.seed }
+    assert_raises(NotImplementedError) { ChromosomeBase.reproduce(chromosome, chromosome) }
+    assert_raises(NotImplementedError) { ChromosomeBase.mutate(chromosome) }
+  end
+
+  def test_attribute_accessors
+    chromosome = ChromosomeBase.new([1, 2])
+    chromosome.normalized_fitness = 0.5
+    assert_equal [1, 2], chromosome.data
+    assert_equal 0.5, chromosome.normalized_fitness
+  end
+end


### PR DESCRIPTION
## Summary
- add `chromosome_base_test` exercising raise conditions and attribute access
- cover clusterer base functionality
- implement `cluster_tree_test` with a simple dummy clusterer to verify history tracking

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68783168284c832ba688e4384478021f