### PR TITLE
Add tests for bench common utilities

### DIFF
--- a/test/unit/bench/base_runner_test.rb
+++ b/test/unit/bench/base_runner_test.rb
@@ -1,0 +1,29 @@
+require_relative '../../test_helper'
+require_relative '../../../bench/common/base_runner'
+
+class DummyRunner < Bench::Common::BaseRunner
+  def initialize(problem, path)
+    super(problem)
+    @path = path
+  end
+
+  def run
+    expand
+    frontier_size(2)
+    @path
+  end
+end
+
+class BenchBaseRunnerTest < Minitest::Test
+  def test_metrics_collection
+    runner = DummyRunner.new(:prob, %w[a b c])
+    result = runner.call
+    assert_equal 'dummy', result.algorithm
+    data = result.to_h
+    assert data[:duration_ms] >= 0
+    assert_equal 2, data[:solution_depth]
+    assert_equal true, data[:completed]
+    assert_equal 1, data[:nodes_expanded]
+    assert_equal 2, data[:max_frontier_size]
+  end
+end

--- a/test/unit/bench/cli_test.rb
+++ b/test/unit/bench/cli_test.rb
@@ -1,0 +1,14 @@
+require_relative '../../test_helper'
+require_relative '../../../bench/common/cli'
+
+class BenchCliTest < Minitest::Test
+  def test_parse_with_custom_option
+    cli = Bench::Common::CLI.new('foo', %w[a b], [:m]) do |opts, options|
+      opts.on('--flag VALUE', String) { |v| options[:flag] = v }
+    end
+    opts = cli.parse(%w[--algos a,b --export res.csv --flag bar])
+    assert_equal %w[a b], opts[:algos]
+    assert_equal 'res.csv', opts[:export]
+    assert_equal 'bar', opts[:flag]
+  end
+end

--- a/test/unit/bench/metrics_test.rb
+++ b/test/unit/bench/metrics_test.rb
@@ -1,0 +1,23 @@
+require_relative '../../test_helper'
+require_relative '../../../bench/common/metrics'
+
+class BenchMetricsTest < Minitest::Test
+  include Bench::Common
+
+  def test_sse_and_silhouette
+    data = [[0,0],[1,1],[10,10],[11,11]]
+    clusters = [[0,1],[2,3]]
+    assert_in_delta 2.0, sse(data, clusters), 0.0001
+    sil = silhouette(data, clusters)
+    assert sil <= 1 && sil > 0.9
+  end
+
+  def test_classification_metrics
+    truth = [1,0,1,1,0]
+    preds = [1,0,0,1,0]
+    assert_in_delta 0.8, accuracy(truth, preds), 0.0001
+    assert_in_delta 0.8333, precision(truth, preds), 0.0001
+    assert_in_delta 0.8333, recall(truth, preds), 0.0001
+    assert_in_delta 0.8333, f1(truth, preds), 0.0001
+  end
+end

--- a/test/unit/bench/reporter_test.rb
+++ b/test/unit/bench/reporter_test.rb
@@ -1,0 +1,27 @@
+require_relative '../../test_helper'
+require_relative '../../../bench/common/reporter'
+require 'tempfile'
+
+class BenchReporterTest < Minitest::Test
+  def setup
+    @results = [
+      { algorithm: 'a', accuracy: 0.9, training_ms: 1, predict_ms: 1, model_size_kb: 10 },
+      { algorithm: 'b', accuracy: 1.0, training_ms: 2, predict_ms: 2, model_size_kb: 20 }
+    ]
+    @metrics = %i[accuracy training_ms predict_ms model_size_kb]
+  end
+
+  def test_print_table_and_export
+    reporter = Bench::Common::Reporter.new(@results, @metrics)
+    out, = capture_io { reporter.print_table }
+    assert_includes out, 'algorithm'
+    assert_includes out, 'accuracy'
+    Tempfile.create('report') do |f|
+      reporter.export_csv(f.path)
+      f.rewind
+      csv = f.read
+      assert_includes csv, 'algorithm,accuracy,training_ms,predict_ms,model_size_kb'
+      assert_includes csv, 'a,0.9,1,1,10'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add unit tests for the bench common metrics, CLI, Reporter and BaseRunner
- ensure metrics like SSE, silhouette and classification measures are covered
- verify CLI option parsing and Reporter CSV export

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687830914974832ba17fc9dcf45bd2fc