### PR TITLE
Increase bench CLI coverage

### DIFF
--- a/test/clusterers/cluster_tree_test.rb
+++ b/test/clusterers/cluster_tree_test.rb
@@ -13,9 +13,7 @@ class ClusterTreeTest < Minitest::Test
       @data_set = data_set
       @distance_matrix = []
       index_clusters = data_set.data_items.each_index.map { |i| [i] }
-      while index_clusters.length > number_of_clusters
-        merge_clusters(index_clusters.length - 1, 0, index_clusters)
-      end
+      merge_clusters(index_clusters.length - 1, 0, index_clusters) while index_clusters.length > number_of_clusters
       @clusters = build_clusters_from_index_clusters(index_clusters)
       self
     end

--- a/test/integration/classifier_cli_run_test.rb
+++ b/test/integration/classifier_cli_run_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../bench/classifier/classifier_bench'
+
+class ClassifierCliRunTest < Minitest::Test
+  StubRunner = Class.new do
+    attr_reader :train, :test
+
+    @@instances = []
+
+    def self.instances
+      @@instances
+    end
+
+    def initialize(train, test)
+      @train = train
+      @test = test
+      @@instances << self
+    end
+
+    def call
+      Bench::Common::Metrics.new('stub', {})
+    end
+  end
+
+  def with_const(mod, const, val)
+    old = mod.const_get(const)
+    mod.send(:remove_const, const)
+    mod.const_set(const, val)
+    yield
+  ensure
+    mod.send(:remove_const, const)
+    mod.const_set(const, old)
+  end
+
+  def test_run_splits_data_and_reports
+    StubRunner.instances.clear
+
+    options = { algos: %w[foo], dataset: 'ignore.csv', split: 0.25, export: nil }
+    cli = Minitest::Mock.new
+    cli.expect(:parse, options, [Array])
+    captured = nil
+    cli.expect(:report, nil) { |results, _| captured = results }
+
+    train_set = 'train'
+    test_set = 'test'
+    dataset = Object.new
+    dataset.define_singleton_method(:shuffle!) { dataset }
+    dataset.define_singleton_method(:split) do |ratio:|
+      raise 'ratio mismatch' unless (ratio - 0.75).abs < 0.0001
+
+      [train_set, test_set]
+    end
+
+    stub_new = lambda do |_name, _algos, _metrics, &block|
+      block&.call(Object.new.tap { |o| def o.on(*); end }, {})
+      cli
+    end
+
+    Bench::Common::CLI.stub(:new, stub_new) do
+      Bench::Classifier.stub(:load_dataset, dataset) do
+        with_const(Bench::Classifier, :RUNNERS, { 'foo' => StubRunner }) do
+          Bench::Classifier.run([])
+        end
+      end
+    end
+
+    cli.verify
+
+    assert_equal 1, StubRunner.instances.size
+    assert_equal train_set, StubRunner.instances.first.train
+    assert_equal test_set, StubRunner.instances.first.test
+
+    assert_equal 1, captured.size
+    assert_kind_of Bench::Common::Metrics, captured.first
+  end
+end

--- a/test/integration/classifier_load_dataset_test.rb
+++ b/test/integration/classifier_load_dataset_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../bench/classifier/classifier_bench'
+
+class ClassifierLoadDatasetTest < Minitest::Test
+  DATA_PATH = File.expand_path('../../bench/classifier/datasets/play_tennis.csv', __dir__)
+
+  def test_load_dataset
+    ds = Bench::Classifier.load_dataset(DATA_PATH)
+    refute_empty ds.data_items
+    assert_equal %w[Outlook Temperature Humidity Wind Play], ds.data_labels
+  end
+end

--- a/test/integration/clusterer_cli_run_test.rb
+++ b/test/integration/clusterer_cli_run_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../bench/clusterer/cluster_bench'
+
+class ClustererCliRunTest < Minitest::Test
+  StubRunner = Class.new do
+    attr_reader :data_set, :k
+
+    @instances = []
+    class << self
+      attr_reader :instances
+    end
+
+    def initialize(data_set, k)
+      @data_set = data_set
+      @k = k
+      self.class.instances << self
+    end
+
+    def call
+      Bench::Common::Metrics.new('stub', {})
+    end
+  end
+
+  StubDbscan = Class.new do
+    attr_reader :data_set, :epsilon, :min_points
+
+    @instances = []
+    class << self
+      attr_reader :instances
+    end
+
+    def initialize(data_set, epsilon, min_points)
+      @data_set = data_set
+      @epsilon = epsilon
+      @min_points = min_points
+      self.class.instances << self
+    end
+
+    def call
+      Bench::Common::Metrics.new('dbscan', {})
+    end
+  end
+
+  def with_const(mod, const, val)
+    old = mod.const_get(const)
+    mod.send(:remove_const, const)
+    mod.const_set(const, val)
+    yield
+  ensure
+    mod.send(:remove_const, const)
+    mod.const_set(const, old)
+  end
+
+  def test_run_invokes_runners_and_reports_results
+    StubRunner.instances.clear
+    StubDbscan.instances.clear
+
+    options = {
+      algos: %w[foo dbscan],
+      dataset: 'dummy.csv',
+      k: 3,
+      epsilon: 0.4,
+      min_points: 2,
+      with_gt: false,
+      export: nil
+    }
+    cli = Minitest::Mock.new
+    cli.expect(:parse, options, [Array])
+    captured = nil
+    cli.expect(:report, nil) { |results, _| captured = results }
+
+    data_set = Ai4r::Data::DataSet.new(data_items: [[1, 2]])
+
+    stub_new = lambda do |_name, _algos, _metrics, &block|
+      block&.call(Object.new.tap { |o| def o.on(*); end }, {})
+      cli
+    end
+
+    Bench::Common::CLI.stub(:new, stub_new) do
+      Bench::Clusterer.stub(:load_dataset, data_set) do
+        with_const(Bench::Clusterer, :RUNNERS, { 'foo' => StubRunner, 'dbscan' => StubDbscan }) do
+          Bench::Clusterer.run([])
+        end
+      end
+    end
+
+    cli.verify
+
+    assert_equal 1, StubRunner.instances.size
+    assert_equal data_set, StubRunner.instances.first.data_set
+    assert_equal 3, StubRunner.instances.first.k
+
+    assert_equal 1, StubDbscan.instances.size
+    assert_equal data_set, StubDbscan.instances.first.data_set
+    assert_equal 0.4, StubDbscan.instances.first.epsilon
+    assert_equal 2, StubDbscan.instances.first.min_points
+
+    assert_equal 2, captured.size
+    assert_kind_of Bench::Common::Metrics, captured.first
+  end
+end

--- a/test/integration/clusterer_load_dataset_test.rb
+++ b/test/integration/clusterer_load_dataset_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../bench/clusterer/cluster_bench'
+
+class ClustererLoadDatasetTest < Minitest::Test
+  def test_load_dataset_with_and_without_labels
+    Tempfile.create(['data', '.csv']) do |f|
+      f.write("1,2,3\n4,5,6\n")
+      f.close
+      ds_with = Bench::Clusterer.load_dataset(f.path, true)
+      ds_without = Bench::Clusterer.load_dataset(f.path, false)
+
+      assert_equal [[1.0, 2.0], [4.0, 5.0]], ds_with.data_items
+      assert_equal [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], ds_without.data_items
+    end
+  end
+end

--- a/test/integration/dbscan_runner_test.rb
+++ b/test/integration/dbscan_runner_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../bench/clusterer/runners/dbscan_runner'
+
+class DbscanRunnerTest < Minitest::Test
+  def test_call_returns_metrics
+    ds = Ai4r::Data::DataSet.new(data_items: [[0, 0], [0, 0.1], [3, 3], [3.1, 3.1]])
+    runner = Bench::Clusterer::Runners::DbscanRunner.new(ds, 0.05, 1)
+    metrics = runner.call
+
+    assert_equal 'dbscan', metrics.algorithm
+    assert_equal [[0, 1], [2, 3]], metrics[:clusters]
+    assert metrics[:silhouette] <= 1 && metrics[:silhouette] >= -1
+    assert_equal 'eps=0.05', metrics[:notes]
+  end
+end


### PR DESCRIPTION
## Summary
- add integration tests for bench CLI runners
- add load dataset tests for classifier and clusterer benches
- exercise DBSCAN runner
- fix rubocop offense in existing test

## Testing
- `bundle exec rubocop`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6878dd4aaf3c832ba6f9f9e1bf75d1c2