### PR TITLE
Disable while/until modifier cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,3 +49,6 @@ Security/Eval:
 
 Security/MarshalLoad:
   Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false


### PR DESCRIPTION
## Summary
- disable `Style/WhileUntilModifier` in RuboCop config

## Testing
- `bundle exec rake test`
- `bundle exec rubocop`


------
https://chatgpt.com/codex/tasks/task_e_6878f07425e0832ba52eeed3becb4b16