### PR TITLE
Add examples to bench docs

### DIFF
--- a/bench/classifier/README.md
+++ b/bench/classifier/README.md
@@ -14,6 +14,19 @@ ruby bench/classifier/classifier_bench.rb \
     --export out/results_classifier.csv
 ```
 
+### Example: iris flowers
+
+Compare four algorithms on the classic iris dataset:
+
+```bash
+ruby bench/classifier/classifier_bench.rb \
+    --dataset bench/classifier/datasets/iris.csv \
+    --split 0.3 \
+    --algos id3,naive_bayes,ib1,hyperpipes
+```
+
+You'll see accuracy, F1 score and timing for each model. For a full walkthrough visit [../../docs/classifier_bench.md](../../docs/classifier_bench.md).
+
 ## Dataset format
 
 CSV files require a header row. The last column is treated as the label and all

--- a/bench/clusterer/README.md
+++ b/bench/clusterer/README.md
@@ -14,6 +14,19 @@ $ ruby -Ilib bench/clusterer/cluster_bench.rb \
     --export out/cluster_results.csv
 ```
 
+### Example: blob clustering
+
+Try KMeans and DBSCAN on a small set of points:
+
+```bash
+ruby -Ilib bench/clusterer/cluster_bench.rb \
+    --dataset bench/clusterer/datasets/blobs.csv \
+    --k 3 \
+    --algos kmeans,dbscan
+```
+
+The console shows silhouette scores and SSE for each run. See [../../docs/clusterer_bench.md](../../docs/clusterer_bench.md) for a detailed demo.
+
 When running directly from the git repository you must include `-Ilib` so Ruby
 can find the library without installing the gem.
 

--- a/bench/search/README.md
+++ b/bench/search/README.md
@@ -20,6 +20,18 @@ Console output shows a table of metrics and the CSV can be loaded into a
 spreadsheet. Swap the problem or algorithm names to try DFS, IDDFS or the
 classic eight puzzle.
 
+### Example: grid path finding
+
+Run the bench on a tiny maze to see BFS and A* in action:
+
+```bash
+ruby -Ilib bench/search/search_bench.rb \
+    --problem grid --map bench/search/maps/small.txt \
+    --algos bfs,a_star
+```
+
+You'll get a short table with depth, nodes expanded and runtime. For a step-by-step walkthrough see [../../docs/search_bench.md](../../docs/search_bench.md).
+
 ## Metrics
 
 * `solution_depth` – length of the returned path minus one

--- a/docs/benches_overview.md
+++ b/docs/benches_overview.md
@@ -6,9 +6,9 @@ problems. Shared helpers such as the CLI, metrics and table reporter reside in
 `bench/common`.
 
 Labs exist for search algorithms, clustering algorithms and classifiers:
-- [`bench/search`](../bench/search) – see [search_bench.md](search_bench.md)
-- [`bench/clusterer`](../bench/clusterer) – see [clusterer_bench.md](clusterer_bench.md)
-- [`bench/classifier`](../bench/classifier) – see [classifier_bench.md](classifier_bench.md)
+- [`bench/search`](../bench/search) – run BFS against A* in the [grid example](search_bench.md)
+- [`bench/clusterer`](../bench/clusterer) – cluster blobs in the [demo](clusterer_bench.md)
+- [`bench/classifier`](../bench/classifier) – predict iris species in the [classification tour](classifier_bench.md)
 
 ## Adding a new lab
 


### PR DESCRIPTION
## Summary
- add quick examples to each bench README
- link examples with taglines from benches overview

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68790b076700832bbd76c5dcebf63566